### PR TITLE
Add execution layer for trading engine with order executor

### DIFF
--- a/KryptoLowca/core/order_executor.py
+++ b/KryptoLowca/core/order_executor.py
@@ -1,0 +1,553 @@
+# core/order_executor.py
+# -*- coding: utf-8 -*-
+"""Order execution helper used by :mod:`core.trading_engine`."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from managers.exchange_core import Mode, OrderStatus
+
+try:  # pragma: no cover - opcjonalne
+    import ccxt  # type: ignore
+except Exception:  # pragma: no cover
+    ccxt = None  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter('[%(asctime)s] %(name)s - %(levelname)s - %(message)s'))
+    logger.addHandler(_handler)
+logger.setLevel(logging.INFO)
+
+
+@dataclass
+class ExecutionResult:
+    """Represents the outcome of a single order submission."""
+
+    status: str
+    order_id: Any
+    client_order_id: str
+    quantity: float
+    price: float
+    notional: float
+    mode: str
+    raw: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable dictionary."""
+        payload = {
+            "status": self.status,
+            "order_id": self.order_id,
+            "client_order_id": self.client_order_id,
+            "quantity": self.quantity,
+            "price": self.price,
+            "notional": self.notional,
+            "mode": self.mode,
+            "raw": self.raw,
+        }
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+@dataclass
+class PreparedOrder:
+    """Internal structure holding validated order parameters."""
+
+    symbol: str
+    side: str
+    order_type: str
+    quantity: float
+    price: Optional[float]
+    client_order_id: str
+    mode: str
+    notional: float
+    plan: Dict[str, Any]
+    position_size: float
+    allow_short: bool
+    db_order_id: Optional[int] = None
+
+
+class OrderExecutor:
+    """Responsible for translating trading plans into exchange orders."""
+
+    def __init__(
+        self,
+        exchange_manager: Any,
+        db_manager: Optional[Any] = None,
+        *,
+        max_fraction: float = 0.2,
+        fee_buffer: float = 0.0015,
+        max_retries: int = 2,
+        retry_delay: float = 1.0,
+    ) -> None:
+        self.exchange_manager = exchange_manager
+        self.db_manager = db_manager
+        self.max_fraction = max(0.0, float(max_fraction))
+        self.fee_buffer = max(0.0, float(fee_buffer))
+        self.max_retries = max(0, int(max_retries))
+        self.retry_delay = max(0.0, float(retry_delay))
+        self._lock = asyncio.Lock()
+        self._user_id: Optional[int] = None
+
+    def set_user(self, user_id: Optional[int]) -> None:
+        """Store user identifier for structured logging."""
+        self._user_id = user_id
+
+    async def execute_plan(self, plan: Dict[str, Any]) -> ExecutionResult:
+        """Validate, submit and record an order based on *plan*."""
+        async with self._lock:
+            prepared: Optional[PreparedOrder] = None
+            try:
+                prepared = await self._prepare_order(plan)
+                result = await self._place_order(prepared)
+                return result
+            except Exception as exc:  # pragma: no cover - awaryjna ścieżka
+                error_msg = str(exc)
+                logger.exception("Order execution failed for %s: %s", plan.get("symbol"), error_msg)
+                if prepared:
+                    await self._mark_failure(prepared, error_msg)
+                    return ExecutionResult(
+                        status="FAILED",
+                        order_id=None,
+                        client_order_id=prepared.client_order_id,
+                        quantity=prepared.quantity,
+                        price=float(prepared.price or plan.get("price_ref") or 0.0),
+                        notional=0.0,
+                        mode=prepared.mode,
+                        raw={"error": error_msg},
+                        error=error_msg,
+                    )
+                return ExecutionResult(
+                    status="FAILED",
+                    order_id=None,
+                    client_order_id=str(plan.get("client_order_id", "")),
+                    quantity=0.0,
+                    price=float(plan.get("price_ref") or 0.0),
+                    notional=0.0,
+                    mode=self._mode_string(),
+                    raw={"error": error_msg},
+                    error=error_msg,
+                )
+
+    async def _prepare_order(self, plan: Dict[str, Any]) -> PreparedOrder:
+        symbol = str(plan.get("symbol") or "").strip()
+        if not symbol:
+            raise ValueError("Trading plan missing symbol")
+
+        side = str(plan.get("side") or "").lower()
+        if side not in {"buy", "sell"}:
+            raise ValueError("Trading plan side must be 'buy' or 'sell'")
+
+        order_type = str(plan.get("order_type", "market")).lower()
+        if order_type not in {"market", "limit"}:
+            raise ValueError("Unsupported order type")
+
+        price_ref = float(plan.get("price_ref") or 0.0)
+        if price_ref <= 0:
+            raise ValueError("Trading plan missing reference price")
+
+        qty_hint = float(plan.get("qty_hint") or 0.0)
+        if qty_hint <= 0:
+            raise ValueError("Trading plan recommends zero size")
+
+        allow_short = bool(plan.get("allow_short"))
+        capital = plan.get("capital")
+        capital_val = float(capital) if capital is not None else None
+        if capital_val is None or capital_val <= 0:
+            capital_val = await self._fetch_capital(symbol)
+
+        position_qty, _ = self._extract_position(symbol, plan.get("portfolio"))
+
+        quantity, notional = self._determine_quantity(
+            symbol=symbol,
+            side=side,
+            qty_hint=qty_hint,
+            price_ref=price_ref,
+            capital=capital_val,
+            position_qty=position_qty,
+            allow_short=allow_short,
+        )
+
+        limit_price = None
+        if order_type == "limit":
+            limit_price = float(plan.get("limit_price") or price_ref)
+            limit_price = self._quantize_price(symbol, limit_price)
+
+        quantity = self._quantize_amount(symbol, quantity)
+        if quantity <= 0:
+            raise ValueError("Order quantity collapsed to zero after quantization")
+        notional = quantity * price_ref
+
+        min_notional = self._min_notional(symbol)
+        if min_notional and notional + 1e-12 < min_notional:
+            raise ValueError("Order notional below exchange minimum")
+
+        client_order_id = plan.get("client_order_id") or self._generate_client_order_id(symbol)
+        plan["client_order_id"] = client_order_id
+
+        prepared = PreparedOrder(
+            symbol=symbol,
+            side=side,
+            order_type=order_type,
+            quantity=quantity,
+            price=limit_price,
+            client_order_id=client_order_id,
+            mode=self._mode_string(),
+            notional=notional,
+            plan=plan,
+            position_size=position_qty,
+            allow_short=allow_short,
+        )
+
+        prepared.db_order_id = await self._record_initial_order(prepared)
+        await self._log(
+            "INFO",
+            f"Prepared order {symbol} {side} qty={quantity:.8f} notional={notional:.2f}",
+            context={
+                "client_order_id": client_order_id,
+                "order_type": order_type,
+                "stop_loss": plan.get("stop_loss"),
+                "take_profit": plan.get("take_profit"),
+            },
+        )
+        return prepared
+
+    async def _place_order(self, prepared: PreparedOrder) -> ExecutionResult:
+        last_error: Optional[Exception] = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = self.exchange_manager.create_order(
+                    prepared.symbol,
+                    prepared.side.upper(),
+                    prepared.order_type.upper(),
+                    prepared.quantity,
+                    prepared.price,
+                    prepared.client_order_id,
+                )
+                if inspect.isawaitable(response):
+                    response = await response
+                if response is None:
+                    raise RuntimeError("Exchange returned empty response")
+                result = self._build_execution_result(prepared, response)
+                await self._finalise_success(prepared, result)
+                return result
+            except Exception as exc:  # pragma: no cover - retry branch ciężki do pokrycia
+                last_error = exc
+                if not self._should_retry(exc) or attempt >= self.max_retries:
+                    break
+                delay = self.retry_delay * (2 ** attempt)
+                logger.warning(
+                    "Order attempt %s/%s failed (%s). Retrying in %.2fs",
+                    attempt + 1,
+                    self.max_retries + 1,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        error_msg = str(last_error) if last_error else "Unknown order execution error"
+        await self._mark_failure(prepared, error_msg)
+        return ExecutionResult(
+            status="FAILED",
+            order_id=None,
+            client_order_id=prepared.client_order_id,
+            quantity=prepared.quantity,
+            price=float(prepared.price or prepared.plan.get("price_ref") or 0.0),
+            notional=0.0,
+            mode=prepared.mode,
+            raw={"error": error_msg},
+            error=error_msg,
+        )
+
+    def _build_execution_result(self, prepared: PreparedOrder, response: Any) -> ExecutionResult:
+        raw = self._normalise_response(response)
+        status = str(raw.get("status") or OrderStatus.FILLED.value).upper()
+        price = float(raw.get("price") or prepared.plan.get("price_ref") or 0.0)
+        quantity = float(raw.get("quantity") or prepared.quantity)
+        order_id = raw.get("id") or raw.get("order_id") or raw.get("orderId")
+        notional = quantity * price if price else prepared.notional
+        return ExecutionResult(
+            status=status,
+            order_id=order_id,
+            client_order_id=prepared.client_order_id,
+            quantity=quantity,
+            price=price,
+            notional=notional,
+            mode=prepared.mode,
+            raw=raw,
+        )
+
+    async def _finalise_success(self, prepared: PreparedOrder, result: ExecutionResult) -> None:
+        if self.db_manager and (prepared.db_order_id or prepared.client_order_id):
+            try:
+                await self.db_manager.update_order_status(
+                    order_id=prepared.db_order_id,
+                    client_order_id=prepared.client_order_id,
+                    status=result.status,
+                    price=result.price,
+                    exchange_order_id=str(result.order_id) if result.order_id is not None else None,
+                    extra={
+                        "execution": result.raw,
+                        "notional": result.notional,
+                        "mode": result.mode,
+                    },
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Failed to update order status: %s", exc)
+        await self._log(
+            "INFO",
+            f"Order executed {prepared.symbol} {prepared.side} qty={result.quantity:.8f} status={result.status}",
+            context={
+                "client_order_id": prepared.client_order_id,
+                "mode": result.mode,
+                "price": result.price,
+                "notional": result.notional,
+            },
+        )
+
+    async def _mark_failure(self, prepared: PreparedOrder, error_msg: str) -> None:
+        if self.db_manager and (prepared.db_order_id or prepared.client_order_id):
+            try:
+                await self.db_manager.update_order_status(
+                    order_id=prepared.db_order_id,
+                    client_order_id=prepared.client_order_id,
+                    status=OrderStatus.REJECTED.value,
+                    extra={
+                        "error": error_msg,
+                        "plan": self._safe_json(prepared.plan),
+                    },
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Failed to mark order failure: %s", exc)
+        await self._log(
+            "ERROR",
+            f"Order execution failed {prepared.symbol} {prepared.side}: {error_msg}",
+            context={
+                "client_order_id": prepared.client_order_id,
+                "mode": prepared.mode,
+            },
+        )
+
+    async def _record_initial_order(self, prepared: PreparedOrder) -> Optional[int]:
+        if not self.db_manager:
+            return None
+        try:
+            payload = {
+                "symbol": prepared.symbol,
+                "side": prepared.side.upper(),
+                "type": prepared.order_type.upper(),
+                "quantity": prepared.quantity,
+                "price": prepared.price,
+                "status": "NEW",
+                "client_order_id": prepared.client_order_id,
+                "mode": prepared.mode,
+                "extra": {
+                    "strength": prepared.plan.get("strength"),
+                    "stop_loss": prepared.plan.get("stop_loss"),
+                    "take_profit": prepared.plan.get("take_profit"),
+                },
+            }
+            order_id = await self.db_manager.record_order(payload)
+            return order_id
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Failed to record initial order: %s", exc)
+            return None
+
+    async def _fetch_capital(self, symbol: str) -> float:
+        balance = self.exchange_manager.fetch_balance()
+        if inspect.isawaitable(balance):
+            balance = await balance
+        quote = self._quote_asset(symbol)
+        return self._extract_balance_amount(balance, quote)
+
+    def _determine_quantity(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty_hint: float,
+        price_ref: float,
+        capital: float,
+        position_qty: float,
+        allow_short: bool,
+    ) -> Tuple[float, float]:
+        min_notional = self._min_notional(symbol)
+        fraction: Optional[float] = None
+        if qty_hint <= 1.0:
+            fraction = max(0.0, qty_hint)
+            if self.max_fraction > 0:
+                fraction = min(fraction, self.max_fraction)
+        quantity: float
+        notional: float
+
+        if fraction is not None:
+            if side == "buy":
+                spendable = capital / (1.0 + self.fee_buffer) if capital > 0 else 0.0
+                notional = spendable * fraction
+                if min_notional and notional < min_notional:
+                    notional = min_notional
+                if notional * (1.0 + self.fee_buffer) > capital + 1e-9:
+                    if capital < min_notional:
+                        raise ValueError("Insufficient capital for minimum order size")
+                    notional = capital / (1.0 + self.fee_buffer)
+                quantity = notional / price_ref
+            else:
+                if position_qty > 0 and not allow_short:
+                    quantity = position_qty * min(fraction, 1.0)
+                    notional = quantity * price_ref
+                else:
+                    if not allow_short and position_qty <= 0:
+                        raise ValueError("No position available to sell and shorting disabled")
+                    notional = capital * fraction
+                    if min_notional and notional < min_notional:
+                        notional = min_notional
+                    quantity = notional / price_ref
+        else:
+            quantity = qty_hint
+            notional = quantity * price_ref
+
+        if side == "sell" and not allow_short and quantity > position_qty + 1e-9:
+            quantity = position_qty
+            notional = quantity * price_ref
+
+        if quantity <= 0 or notional <= 0:
+            raise ValueError("Calculated order size is zero")
+        return quantity, notional
+
+    def _quantize_amount(self, symbol: str, amount: float) -> float:
+        quantizer = getattr(self.exchange_manager, "quantize_amount", None)
+        if callable(quantizer):
+            return float(quantizer(symbol, amount))
+        return float(f"{amount:.8f}")
+
+    def _quantize_price(self, symbol: str, price: float) -> float:
+        quantizer = getattr(self.exchange_manager, "quantize_price", None)
+        if callable(quantizer):
+            return float(quantizer(symbol, price))
+        return float(f"{price:.8f}")
+
+    def _min_notional(self, symbol: str) -> float:
+        getter = getattr(self.exchange_manager, "min_notional", None)
+        if callable(getter):
+            try:
+                return float(getter(symbol))
+            except Exception:  # pragma: no cover
+                return 0.0
+        return 0.0
+
+    def _extract_position(self, symbol: str, portfolio: Any) -> Tuple[float, str]:
+        positions: List[Dict[str, Any]] = []
+        if isinstance(portfolio, dict):
+            maybe_positions = portfolio.get("positions")
+            if isinstance(maybe_positions, list):
+                positions = [p for p in maybe_positions if isinstance(p, dict)]
+        elif isinstance(portfolio, list):
+            positions = [p for p in portfolio if isinstance(p, dict)]
+
+        for pos in positions:
+            if str(pos.get("symbol")) == symbol:
+                qty = float(pos.get("qty") or pos.get("quantity") or 0.0)
+                side = str(pos.get("side") or "").upper()
+                return qty, side
+        return 0.0, ""
+
+    def _mode_string(self) -> str:
+        mode = getattr(self.exchange_manager, "mode", None)
+        if hasattr(mode, "value"):
+            return str(getattr(mode, "value"))
+        if isinstance(mode, Mode):
+            return mode.value
+        if isinstance(mode, str):
+            return mode
+        return Mode.PAPER.value
+
+    def _quote_asset(self, symbol: str) -> str:
+        if "/" in symbol:
+            return symbol.split("/")[-1].upper()
+        if "-" in symbol:
+            return symbol.split("-")[-1].upper()
+        return "USDT"
+
+    @staticmethod
+    def _extract_balance_amount(balance: Any, currency: str) -> float:
+        if isinstance(balance, dict):
+            if currency in balance and isinstance(balance[currency], (int, float)):
+                return float(balance[currency])
+            for key in ("free", "total", "balance"):
+                section = balance.get(key)
+                if isinstance(section, dict) and currency in section:
+                    amount = section[currency]
+                    if isinstance(amount, (int, float)):
+                        return float(amount)
+        try:
+            return float(balance or 0.0)
+        except Exception:  # pragma: no cover
+            return 0.0
+
+    def _normalise_response(self, response: Any) -> Dict[str, Any]:
+        if hasattr(response, "model_dump"):
+            raw = response.model_dump()
+        elif isinstance(response, dict):
+            raw = dict(response)
+        else:
+            raw = {"response": str(response)}
+        serialised: Dict[str, Any] = {}
+        for key, value in raw.items():
+            if hasattr(value, "value"):
+                serialised[key] = getattr(value, "value")
+            elif isinstance(value, (str, int, float, bool)) or value is None:
+                serialised[key] = value
+            else:
+                serialised[key] = str(value)
+        if "status" in serialised:
+            serialised["status"] = str(serialised["status"]).upper()
+        return serialised
+
+    def _should_retry(self, exc: Exception) -> bool:
+        retryable = (ConnectionError, asyncio.TimeoutError, TimeoutError)
+        if isinstance(exc, retryable):
+            return True
+        if ccxt:
+            network_errors = (
+                getattr(ccxt, "NetworkError", Exception),
+                getattr(ccxt, "DDoSProtection", Exception),
+                getattr(ccxt, "RateLimitExceeded", Exception),
+            )
+            if isinstance(exc, network_errors):
+                return True
+        return False
+
+    async def _log(self, level: str, message: str, *, context: Optional[Dict[str, Any]] = None) -> None:
+        if not self.db_manager:
+            return
+        try:
+            await self.db_manager.log(
+                self._user_id,
+                level,
+                message,
+                category="trade",
+                context=self._safe_json(context or {}),
+            )
+        except Exception:  # pragma: no cover
+            logger.debug("Structured log failed", exc_info=True)
+
+    def _generate_client_order_id(self, symbol: str) -> str:
+        prefix = symbol.replace("/", "").replace("-", "")[:6].upper()
+        return f"BOT-{prefix}-{uuid.uuid4().hex[:12]}"
+
+    def _safe_json(self, data: Any) -> Any:
+        if isinstance(data, (str, int, float, bool)) or data is None:
+            return data
+        if isinstance(data, dict):
+            return {str(k): self._safe_json(v) for k, v in data.items()}
+        if isinstance(data, list):
+            return [self._safe_json(v) for v in data]
+        return str(data)

--- a/KryptoLowca/core/trading_engine.py
+++ b/KryptoLowca/core/trading_engine.py
@@ -15,16 +15,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import pandas as pd
-from typing import Dict, Optional, Callable, Any
-from dataclasses import dataclass
-import numpy as np
+from typing import Any, Callable, Dict, Optional
 
-from managers.exchange_manager import ExchangeManager
+import pandas as pd
+
+from core.order_executor import ExecutionResult, OrderExecutor
 from managers.ai_manager import AIManager
-from managers.risk_manager_adapter import RiskManager
 from managers.database_manager import DatabaseManager
-from trading_strategies import TradingStrategies, TradingParameters, EngineConfig
+from managers.exchange_manager import ExchangeManager
+from managers.risk_manager_adapter import RiskManager
+from trading_strategies import EngineConfig, TradingParameters, TradingStrategies
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
@@ -33,10 +33,11 @@ if not logger.handlers:
     logger.addHandler(_h)
 logger.setLevel(logging.INFO)
 
+
 # --- Custom exceptions ---
 class TradingError(Exception):
     """Raised when trading operations fail."""
-    pass
+
 
 class TradingEngine:
     """
@@ -45,6 +46,7 @@ class TradingEngine:
     Args:
         db_manager: DatabaseManager for logging and position tracking.
     """
+
     def __init__(self, db_manager: Optional[DatabaseManager] = None):
         self.ex_mgr: Optional[ExchangeManager] = None
         self.ai_mgr: Optional[AIManager] = None
@@ -53,11 +55,12 @@ class TradingEngine:
         self.strategies = TradingStrategies()
         self.tp = TradingParameters()
         self.ec = EngineConfig()
-        self._event_callback: Optional[Callable] = None
+        self._event_callback: Optional[Callable[[Dict[str, Any]], None]] = None
         self._lock = asyncio.Lock()
         self._user_id: Optional[int] = None
+        self._order_executor: Optional[OrderExecutor] = None
 
-    async def configure(self, ex_mgr: ExchangeManager, ai_mgr: AIManager, risk_mgr: RiskManager):
+    async def configure(self, ex_mgr: ExchangeManager, ai_mgr: AIManager, risk_mgr: RiskManager) -> None:
         """Configure the engine with dependencies."""
         async with self._lock:
             self.ex_mgr = ex_mgr
@@ -71,6 +74,8 @@ class TradingEngine:
                     setattr(self.ai_mgr, "ai_threshold_bps", float(self.tp.signal_threshold * 10_000))
                 except Exception:
                     setattr(self.ai_mgr, "ai_threshold_bps", 5.0)
+            self._order_executor = OrderExecutor(ex_mgr, self.db_manager)
+            self._order_executor.set_user(self._user_id)
 
     @staticmethod
     def _extract_balance_amount(balance: Any, currency: str) -> float:
@@ -88,35 +93,62 @@ class TradingEngine:
         except Exception:
             return 0.0
 
-    def set_parameters(self, tp: TradingParameters, ec: EngineConfig):
+    @staticmethod
+    def _derive_quote_currency(symbol: str) -> str:
+        if "/" in symbol:
+            return symbol.split("/")[-1].upper()
+        if "-" in symbol:
+            return symbol.split("-")[-1].upper()
+        return "USDT"
+
+    def set_parameters(self, tp: TradingParameters, ec: EngineConfig) -> None:
         """Set trading parameters and configuration."""
         try:
             if hasattr(tp, "validate"):
                 tp.validate()
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - walidacja
             raise ValueError(f"Invalid trading parameters: {exc}") from exc
         try:
             if hasattr(ec, "validate"):
                 ec.validate()
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - walidacja
             raise ValueError(f"Invalid engine config: {exc}") from exc
         self.tp = tp
         self.ec = ec
         if self.db_manager:
-            asyncio.create_task(self.db_manager.log(self._user_id, "INFO", f"Parameters set: {tp.__dict__}, {ec.__dict__}", category="engine"))
+            asyncio.create_task(
+                self.db_manager.log(
+                    self._user_id,
+                    "INFO",
+                    f"Parameters set: {tp.__dict__}, {ec.__dict__}",
+                    category="engine",
+                )
+            )
+        if self._order_executor:
+            self._order_executor.set_user(self._user_id)
 
-    def on_event(self, callback: Callable):
+    def on_event(self, callback: Callable[[Dict[str, Any]], None]) -> None:
         """Register event callback for GUI updates."""
         self._event_callback = callback
 
-    async def _emit_event(self, event: Dict[str, Any]):
+    async def _emit_event(self, event: Dict[str, Any]) -> None:
         """Emit an event to the callback."""
         if self._event_callback:
             self._event_callback(event)
         if self.db_manager:
-            await self.db_manager.log(self._user_id, "INFO", f"Event emitted: {event}", category="engine")
+            await self.db_manager.log(
+                self._user_id,
+                "INFO",
+                f"Event emitted: {event}",
+                category="engine",
+            )
 
-    async def execute_live_tick(self, symbol: str, df: pd.DataFrame, preds: pd.Series) -> Optional[Dict[str, Any]]:
+    async def execute_live_tick(
+        self,
+        symbol: str,
+        df: pd.DataFrame,
+        preds: pd.Series,
+    ) -> Optional[Dict[str, Any]]:
         """
         Execute trading logic for a single tick.
 
@@ -126,18 +158,21 @@ class TradingEngine:
             preds: Series with AI predictions (in basis points).
 
         Returns:
-            Trading plan or None if no action is taken.
+            Trading plan (possibly with execution details) or ``None`` if no action is taken.
         """
         async with self._lock:
             try:
                 if not symbol or not isinstance(symbol, str):
                     raise ValueError("Invalid symbol")
                 if df.empty or len(df) < self.ec.min_data_points:
-                    raise ValueError(f"Insufficient data: {len(df)} bars, required {self.ec.min_data_points}")
+                    raise ValueError(
+                        f"Insufficient data: {len(df)} bars, required {self.ec.min_data_points}"
+                    )
                 if len(preds) != len(df):
                     raise ValueError("Predictions length does not match data length")
+                if not self.ex_mgr or not self.ai_mgr or not self.risk_mgr:
+                    raise TradingError("Trading engine is not fully configured")
 
-                # Check current positions
                 positions = await self.db_manager.get_positions(self._user_id) if self.db_manager else []
                 max_positions = getattr(self.tp, "max_position_size", getattr(self.tp, "max_positions", 5))
                 try:
@@ -145,60 +180,132 @@ class TradingEngine:
                 except Exception:
                     max_positions = 5
                 if len(positions) >= max_positions:
-                    await self._emit_event({"type": "max_positions_reached", "symbol": symbol, "positions": len(positions)})
+                    await self._emit_event(
+                        {"type": "max_positions_reached", "symbol": symbol, "positions": len(positions)}
+                    )
                     return None
 
                 if hasattr(self.strategies, "run_strategy"):
                     try:
                         self.strategies.run_strategy(df, self.tp)
-                    except Exception as exc:
+                    except Exception as exc:  # pragma: no cover - ostrzeżenie
                         logger.warning("Strategy execution skipped: %s", exc)
 
-                # Get latest prediction and price
-                latest_pred = preds.iloc[-1]
-                latest_price = df["close"].iloc[-1]
+                latest_pred = float(preds.iloc[-1])
+                latest_price = float(df["close"].iloc[-1])
+                if latest_price <= 0:
+                    raise ValueError("Latest price must be positive")
 
-                # Determine trade side
-                side = "buy" if latest_pred > 0 else "sell" if self.ec.enable_shorting else None
-                if side is None:
-                    await self._emit_event({"type": "shorting_disabled", "symbol": symbol})
+                shorting_enabled = bool(getattr(self.ec, "enable_shorting", False))
+                if latest_pred > 0:
+                    side = "buy"
+                elif latest_pred < 0 and shorting_enabled:
+                    side = "sell"
+                else:
+                    await self._emit_event({"type": "no_trade_signal", "symbol": symbol})
                     return None
 
-                # Calculate position size
-                balance_data = self.ex_mgr.fetch_balance() if self.ex_mgr else {}
+                balance_data = self.ex_mgr.fetch_balance()
                 if asyncio.iscoroutine(balance_data):
                     balance_data = await balance_data
-                capital = self._extract_balance_amount(balance_data, currency="USDT")
+                quote_currency = self._derive_quote_currency(symbol)
+                capital = self._extract_balance_amount(balance_data, currency=quote_currency)
                 if capital <= 0:
                     raise TradingError("Insufficient balance")
-                portfolio = {"capital": capital, "positions": positions}
-                qty = self.risk_mgr.calculate_position_size(symbol, latest_pred, df, portfolio)
 
-                # Create trading plan
-                plan = {
+                portfolio_ctx = {"positions": positions, "capital": capital}
+                qty_hint = self.risk_mgr.calculate_position_size(symbol, latest_pred, df, portfolio_ctx)
+                try:
+                    qty_hint = float(qty_hint)
+                except Exception:
+                    qty_hint = 0.0
+                if qty_hint <= 0:
+                    await self._emit_event({"type": "no_position_size", "symbol": symbol})
+                    return None
+
+                atr_window = max(1, int(getattr(self.tp, "atr_period", 14)))
+                tr = (df["high"] - df["low"]).abs()
+                atr = float(tr.tail(atr_window).mean()) if not tr.empty else 0.0
+                if atr <= 0:
+                    atr = latest_price * 0.01
+
+                threshold_bps = float(getattr(self.ai_mgr, "ai_threshold_bps", 1.0) or 1.0)
+                plan: Dict[str, Any] = {
                     "symbol": symbol,
                     "side": side,
-                    "qty_hint": qty,
+                    "qty_hint": qty_hint,
                     "price_ref": latest_price,
-                    "strength": abs(latest_pred) / self.ai_mgr.ai_threshold_bps,
-                    "stop_loss": latest_price * (1 - self.tp.stop_loss_atr_mult if side == "buy" else 1 + self.tp.stop_loss_atr_mult),
-                    "take_profit": latest_price * (1 + self.tp.take_profit_atr_mult if side == "buy" else 1 - self.tp.take_profit_atr_mult)
+                    "strength": abs(latest_pred) / threshold_bps,
+                    "stop_loss": latest_price - atr * self.tp.stop_loss_atr_mult
+                    if side == "buy"
+                    else latest_price + atr * self.tp.stop_loss_atr_mult,
+                    "take_profit": latest_price + atr * self.tp.take_profit_atr_mult
+                    if side == "buy"
+                    else latest_price - atr * self.tp.take_profit_atr_mult,
+                    "order_type": "market",
+                    "capital": capital,
+                    "portfolio": {"positions": positions},
+                    "allow_short": shorting_enabled,
+                    "quote_currency": quote_currency,
+                    "user_id": self._user_id,
                 }
 
                 await self._emit_event({"type": "plan_created", "symbol": symbol, "plan": plan})
                 if self.db_manager:
-                    await self.db_manager.log(self._user_id, "INFO", f"Trading plan created for {symbol}: {plan}", category="trade")
+                    await self.db_manager.log(
+                        self._user_id,
+                        "INFO",
+                        f"Trading plan created for {symbol}: {plan}",
+                        category="trade",
+                    )
+
+                auto_execute = bool(getattr(self.ec, "auto_execute", True))
+                if auto_execute and self._order_executor:
+                    await self._emit_event(
+                        {"type": "order_submitting", "symbol": symbol, "plan": plan}
+                    )
+                    execution: ExecutionResult = await self._order_executor.execute_plan(plan)
+                    plan["execution"] = execution.to_dict()
+                    event_payload = {
+                        "symbol": symbol,
+                        "execution": plan["execution"],
+                        "type": "order_filled"
+                        if execution.status.upper() == "FILLED"
+                        else "order_submitted",
+                    }
+                    if execution.error:
+                        event_payload["type"] = "order_failed"
+                        event_payload["error"] = execution.error
+                    await self._emit_event(event_payload)
+                    if self.db_manager:
+                        await self.db_manager.log(
+                            self._user_id,
+                            "ERROR" if execution.error else "INFO",
+                            f"Order execution result for {symbol}: {plan['execution']}",
+                            category="trade",
+                        )
+
                 return plan
 
-            except ValueError as e:
-                logger.error(f"Trading tick failed for {symbol}: {e}")
+            except ValueError as exc:
+                logger.error("Trading tick failed for %s: %s", symbol, exc)
                 if self.db_manager:
-                    await self.db_manager.log(self._user_id, "ERROR", f"Trading tick failed for {symbol}: {e}", category="trade")
-                await self._emit_event({"type": "error", "symbol": symbol, "error": str(e)})
+                    await self.db_manager.log(
+                        self._user_id,
+                        "ERROR",
+                        f"Trading tick failed for {symbol}: {exc}",
+                        category="trade",
+                    )
+                await self._emit_event({"type": "error", "symbol": symbol, "error": str(exc)})
                 raise
-            except Exception as e:
-                logger.error(f"Trading tick failed for {symbol}: {e}")
+            except Exception as exc:
+                logger.error("Trading tick failed for %s: %s", symbol, exc, exc_info=True)
                 if self.db_manager:
-                    await self.db_manager.log(self._user_id, "ERROR", f"Trading tick failed for {symbol}: {e}", category="trade")
-                await self._emit_event({"type": "error", "symbol": symbol, "error": str(e)})
-                return None
+                    await self.db_manager.log(
+                        self._user_id,
+                        "ERROR",
+                        f"Trading tick failed for {symbol}: {exc}",
+                        category="trade",
+                    )
+                await self._emit_event({"type": "error", "symbol": symbol, "error": str(exc)})
+                raise TradingError(str(exc)) from exc

--- a/KryptoLowca/tests/test_trading_engine.py
+++ b/KryptoLowca/tests/test_trading_engine.py
@@ -1,109 +1,194 @@
 # tests/test_trading_engine.py
 # -*- coding: utf-8 -*-
-"""
-Unit tests for trading_engine.py.
-"""
-import pytest
+"""Unit tests for :mod:`core.trading_engine`."""
+
+from __future__ import annotations
+
 import asyncio
-import pandas as pd
+import sys
+from pathlib import Path
+
 import numpy as np
+import pandas as pd
+import pytest
 from unittest.mock import AsyncMock
-from core.trading_engine import TradingEngine, TradingError
-from trading_strategies import TradingParameters, EngineConfig, TradingStrategies
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.trading_engine import TradingEngine
+from managers.exchange_core import Mode, OrderDTO, OrderSide, OrderStatus, OrderType
+from trading_strategies import EngineConfig, TradingParameters
+
 
 class MockExchange:
+    def __init__(self) -> None:
+        self.mode = Mode.PAPER
+        self.created_orders = []
+
     async def fetch_balance(self):
-        return {"USDT": 10000.0}
+        return {"USDT": 10_000.0, "free": {"USDT": 10_000.0}}
+
+    def quantize_amount(self, symbol: str, amount: float) -> float:
+        return round(float(amount), 6)
+
+    def quantize_price(self, symbol: str, price: float) -> float:
+        return round(float(price), 2)
+
+    def min_notional(self, symbol: str) -> float:
+        return 10.0
+
+    def create_order(
+        self,
+        symbol: str,
+        side: str,
+        type: str,
+        quantity: float,
+        price: float | None = None,
+        client_order_id: str | None = None,
+    ) -> OrderDTO:
+        self.created_orders.append(
+            {
+                "symbol": symbol,
+                "side": side,
+                "type": type,
+                "quantity": quantity,
+                "price": price,
+                "client_order_id": client_order_id,
+            }
+        )
+        return OrderDTO(
+            id=123,
+            client_order_id=client_order_id,
+            symbol=symbol,
+            side=OrderSide.BUY if side.upper() == "BUY" else OrderSide.SELL,
+            type=OrderType.MARKET if type.upper() == "MARKET" else OrderType.LIMIT,
+            quantity=quantity,
+            price=price or 100.5,
+            status=OrderStatus.FILLED,
+            mode=self.mode,
+        )
+
 
 class MockAI:
-    async def predict_series(self, symbol, df):
-        return pd.Series(np.full(len(df), 10.0), index=df.index)
     ai_threshold_bps = 5.0
+
 
 class MockRisk:
     def calculate_position_size(self, symbol, signal, market_data, portfolio):
         return 0.1
 
+
 class MockDB:
-    async def ensure_user(self, email):
+    def __init__(self) -> None:
+        self.orders = []
+        self.order_updates = []
+        self.logs = []
+        self.positions = []
+
+    async def ensure_user(self, email: str) -> int:
         return 1
-    async def log(self, user_id, level, msg, category="general", context=None):
-        pass
+
+    async def log(self, user_id, level, message, category="general", context=None):
+        self.logs.append((level, message, category, context))
+
     async def get_positions(self, user_id):
-        return []
+        return list(self.positions)
+
+    async def record_order(self, order):
+        self.orders.append(order)
+        return len(self.orders)
+
+    async def update_order_status(
+        self,
+        *,
+        order_id=None,
+        client_order_id=None,
+        status=None,
+        price=None,
+        exchange_order_id=None,
+        extra=None,
+    ):
+        self.order_updates.append(
+            {
+                "order_id": order_id,
+                "client_order_id": client_order_id,
+                "status": status,
+                "price": price,
+                "exchange_order_id": exchange_order_id,
+                "extra": extra,
+            }
+        )
+
 
 @pytest.fixture
-async def engine(monkeypatch):
-    monkeypatch.setattr("core.trading_engine.ExchangeManager", MockExchange)
-    monkeypatch.setattr("core.trading_engine.AIManager", MockAI)
-    monkeypatch.setattr("core.trading_engine.RiskManager", MockRisk)
-    monkeypatch.setattr("core.trading_engine.DatabaseManager", MockDB)
-    engine = TradingEngine(db_manager=MockDB())
-    await engine.configure(MockExchange(), MockAI(), MockRisk())
-    engine.set_parameters(TradingParameters(), EngineConfig())
+def engine():
+    exchange = MockExchange()
+    db = MockDB()
+    engine = TradingEngine(db_manager=db)
+
+    async def _setup():
+        await engine.configure(exchange, MockAI(), MockRisk())
+        engine.set_parameters(TradingParameters(), EngineConfig())
+
+    asyncio.run(_setup())
     return engine
 
-@pytest.mark.asyncio
-async def test_execute_live_tick(engine):
-    df = pd.DataFrame({
-        "timestamp": pd.date_range("2025-08-21", periods=252, freq="T"),
-        "open": np.full(252, 100.0),
-        "high": np.full(252, 101.0),
-        "low": np.full(252, 99.0),
-        "close": np.full(252, 100.5),
-        "volume": np.full(252, 10.0)
-    })
-    preds = pd.Series(np.full(252, 10.0), index=df.index)
-    plan = await engine.execute_live_tick("BTC/USDT", df, preds)
+
+def _sample_df(size: int = 252) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-08-21", periods=size, freq="T"),
+            "open": np.full(size, 100.0),
+            "high": np.full(size, 101.0),
+            "low": np.full(size, 99.0),
+            "close": np.full(size, 100.5),
+            "volume": np.full(size, 10.0),
+        }
+    )
+
+
+def test_execute_live_tick(engine):
+    df = _sample_df()
+    preds = pd.Series(np.full(len(df), 10.0), index=df.index)
+
+    plan = asyncio.run(engine.execute_live_tick("BTC/USDT", df, preds))
+
     assert plan is not None
     assert plan["symbol"] == "BTC/USDT"
     assert plan["side"] == "buy"
-    assert plan["qty_hint"] == 0.1
-    assert plan["price_ref"] == 100.5
+    assert "execution" in plan
+    assert plan["execution"]["status"] == "FILLED"
+    assert engine.ex_mgr.created_orders  # type: ignore[attr-defined]
+    assert engine.db_manager.orders  # type: ignore[attr-defined]
 
-@pytest.mark.asyncio
-async def test_no_signal(engine, monkeypatch):
-    monkeypatch.setattr(engine.strategies, "run_strategy", lambda *args: ({}, [], pd.Series()))
-    df = pd.DataFrame({
-        "timestamp": pd.date_range("2025-08-21", periods=252, freq="T"),
-        "open": np.full(252, 100.0),
-        "high": np.full(252, 101.0),
-        "low": np.full(252, 99.0),
-        "close": np.full(252, 100.5),
-        "volume": np.full(252, 10.0)
-    })
-    preds = pd.Series(np.full(252, 0.0), index=df.index)
-    plan = await engine.execute_live_tick("BTC/USDT", df, preds)
+
+def test_no_signal(engine):
+    df = _sample_df()
+    preds = pd.Series(np.zeros(len(df)), index=df.index)
+
+    plan = asyncio.run(engine.execute_live_tick("BTC/USDT", df, preds))
+
     assert plan is None
 
-@pytest.mark.asyncio
-async def test_max_positions(engine, monkeypatch):
-    monkeypatch.setattr(engine.db_manager, "get_positions", AsyncMock(return_value=[{}]*1))
+
+def test_max_positions(engine, monkeypatch):
+    monkeypatch.setattr(engine.db_manager, "positions", [{"symbol": "BTC/USDT"}])
+    monkeypatch.setattr(engine.db_manager, "get_positions", AsyncMock(return_value=[{"symbol": "BTC/USDT"}]))
     engine.tp = TradingParameters(max_position_size=1)
-    df = pd.DataFrame({
-        "timestamp": pd.date_range("2025-08-21", periods=252, freq="T"),
-        "open": np.full(252, 100.0),
-        "high": np.full(252, 101.0),
-        "low": np.full(252, 99.0),
-        "close": np.full(252, 100.5),
-        "volume": np.full(252, 10.0)
-    })
-    preds = pd.Series(np.full(252, 10.0), index=df.index)
-    plan = await engine.execute_live_tick("BTC/USDT", df, preds)
+
+    df = _sample_df()
+    preds = pd.Series(np.full(len(df), 10.0), index=df.index)
+
+    plan = asyncio.run(engine.execute_live_tick("BTC/USDT", df, preds))
+
     assert plan is None
 
-@pytest.mark.asyncio
-async def test_invalid_input(engine):
-    df = pd.DataFrame({
-        "timestamp": pd.date_range("2025-08-21", periods=10, freq="T"),
-        "open": np.full(10, 100.0),
-        "high": np.full(10, 101.0),
-        "low": np.full(10, 99.0),
-        "close": np.full(10, 100.5),
-        "volume": np.full(10, 10.0)
-    })
-    preds = pd.Series(np.full(10, 10.0), index=df.index)
+
+def test_invalid_input(engine):
+    df_short = _sample_df(size=10)
+    preds_short = pd.Series(np.full(len(df_short), 10.0), index=df_short.index)
+
     with pytest.raises(ValueError):
-        await engine.execute_live_tick("", df, preds)
+        asyncio.run(engine.execute_live_tick("", df_short, preds_short))
     with pytest.raises(ValueError):
-        await engine.execute_live_tick("BTC/USDT", df, preds)
+        asyncio.run(engine.execute_live_tick("BTC/USDT", df_short, preds_short))


### PR DESCRIPTION
## Summary
- add a dedicated `OrderExecutor` helper that validates trading plans, submits orders with retries and records outcomes in the database
- enhance `TradingEngine` to generate richer plans, trigger automatic execution, and emit detailed events and logs
- refresh trading engine unit tests to cover the new execution flow using synchronous helpers

## Testing
- pytest tests/test_trading_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d42171bb64832a86f846b12cc6fb0d