### PR TITLE
Improve risk sizing metadata and fraction caps

### DIFF
--- a/KryptoLowca/core/order_executor.py
+++ b/KryptoLowca/core/order_executor.py
@@ -1,0 +1,573 @@
+# core/order_executor.py
+# -*- coding: utf-8 -*-
+"""Order execution helper used by :mod:`core.trading_engine`."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from managers.exchange_core import Mode, OrderStatus
+
+try:  # pragma: no cover - opcjonalne
+    import ccxt  # type: ignore
+except Exception:  # pragma: no cover
+    ccxt = None  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter('[%(asctime)s] %(name)s - %(levelname)s - %(message)s'))
+    logger.addHandler(_handler)
+logger.setLevel(logging.INFO)
+
+
+@dataclass
+class ExecutionResult:
+    """Represents the outcome of a single order submission."""
+
+    status: str
+    order_id: Any
+    client_order_id: str
+    quantity: float
+    price: float
+    notional: float
+    mode: str
+    raw: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable dictionary."""
+        payload = {
+            "status": self.status,
+            "order_id": self.order_id,
+            "client_order_id": self.client_order_id,
+            "quantity": self.quantity,
+            "price": self.price,
+            "notional": self.notional,
+            "mode": self.mode,
+            "raw": self.raw,
+        }
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+@dataclass
+class PreparedOrder:
+    """Internal structure holding validated order parameters."""
+
+    symbol: str
+    side: str
+    order_type: str
+    quantity: float
+    price: Optional[float]
+    client_order_id: str
+    mode: str
+    notional: float
+    plan: Dict[str, Any]
+    position_size: float
+    allow_short: bool
+    applied_fraction: Optional[float] = None
+    db_order_id: Optional[int] = None
+
+
+class OrderExecutor:
+    """Responsible for translating trading plans into exchange orders."""
+
+    def __init__(
+        self,
+        exchange_manager: Any,
+        db_manager: Optional[Any] = None,
+        *,
+        max_fraction: float = 0.2,
+        fee_buffer: float = 0.0015,
+        max_retries: int = 2,
+        retry_delay: float = 1.0,
+    ) -> None:
+        self.exchange_manager = exchange_manager
+        self.db_manager = db_manager
+        self.max_fraction = max(0.0, float(max_fraction))
+        self.fee_buffer = max(0.0, float(fee_buffer))
+        self.max_retries = max(0, int(max_retries))
+        self.retry_delay = max(0.0, float(retry_delay))
+        self._lock = asyncio.Lock()
+        self._user_id: Optional[int] = None
+
+    def set_user(self, user_id: Optional[int]) -> None:
+        """Store user identifier for structured logging."""
+        self._user_id = user_id
+
+    async def execute_plan(self, plan: Dict[str, Any]) -> ExecutionResult:
+        """Validate, submit and record an order based on *plan*."""
+        async with self._lock:
+            prepared: Optional[PreparedOrder] = None
+            try:
+                prepared = await self._prepare_order(plan)
+                result = await self._place_order(prepared)
+                return result
+            except Exception as exc:  # pragma: no cover - awaryjna ścieżka
+                error_msg = str(exc)
+                logger.exception("Order execution failed for %s: %s", plan.get("symbol"), error_msg)
+                if prepared:
+                    await self._mark_failure(prepared, error_msg)
+                    return ExecutionResult(
+                        status="FAILED",
+                        order_id=None,
+                        client_order_id=prepared.client_order_id,
+                        quantity=prepared.quantity,
+                        price=float(prepared.price or plan.get("price_ref") or 0.0),
+                        notional=0.0,
+                        mode=prepared.mode,
+                        raw={"error": error_msg},
+                        error=error_msg,
+                    )
+                return ExecutionResult(
+                    status="FAILED",
+                    order_id=None,
+                    client_order_id=str(plan.get("client_order_id", "")),
+                    quantity=0.0,
+                    price=float(plan.get("price_ref") or 0.0),
+                    notional=0.0,
+                    mode=self._mode_string(),
+                    raw={"error": error_msg},
+                    error=error_msg,
+                )
+
+    async def _prepare_order(self, plan: Dict[str, Any]) -> PreparedOrder:
+        symbol = str(plan.get("symbol") or "").strip()
+        if not symbol:
+            raise ValueError("Trading plan missing symbol")
+
+        side = str(plan.get("side") or "").lower()
+        if side not in {"buy", "sell"}:
+            raise ValueError("Trading plan side must be 'buy' or 'sell'")
+
+        order_type = str(plan.get("order_type", "market")).lower()
+        if order_type not in {"market", "limit"}:
+            raise ValueError("Unsupported order type")
+
+        price_ref = float(plan.get("price_ref") or 0.0)
+        if price_ref <= 0:
+            raise ValueError("Trading plan missing reference price")
+
+        qty_hint = float(plan.get("qty_hint") or 0.0)
+        if qty_hint <= 0:
+            raise ValueError("Trading plan recommends zero size")
+
+        allow_short = bool(plan.get("allow_short"))
+        capital = plan.get("capital")
+        capital_val = float(capital) if capital is not None else None
+        if capital_val is None or capital_val <= 0:
+            capital_val = await self._fetch_capital(symbol)
+
+        position_qty, _ = self._extract_position(symbol, plan.get("portfolio"))
+
+        quantity, notional, used_fraction = self._determine_quantity(
+            symbol=symbol,
+            side=side,
+            qty_hint=qty_hint,
+            price_ref=price_ref,
+            capital=capital_val,
+            position_qty=position_qty,
+            allow_short=allow_short,
+            fraction_limit=plan.get("max_fraction"),
+        )
+
+        limit_price = None
+        if order_type == "limit":
+            limit_price = float(plan.get("limit_price") or price_ref)
+            limit_price = self._quantize_price(symbol, limit_price)
+
+        quantity = self._quantize_amount(symbol, quantity)
+        if quantity <= 0:
+            raise ValueError("Order quantity collapsed to zero after quantization")
+        notional = quantity * price_ref
+
+        if used_fraction is not None:
+            plan["applied_fraction"] = used_fraction
+
+        min_notional = self._min_notional(symbol)
+        if min_notional and notional + 1e-12 < min_notional:
+            raise ValueError("Order notional below exchange minimum")
+
+        client_order_id = plan.get("client_order_id") or self._generate_client_order_id(symbol)
+        plan["client_order_id"] = client_order_id
+
+        prepared = PreparedOrder(
+            symbol=symbol,
+            side=side,
+            order_type=order_type,
+            quantity=quantity,
+            price=limit_price,
+            client_order_id=client_order_id,
+            mode=self._mode_string(),
+            notional=notional,
+            plan=plan,
+            position_size=position_qty,
+            allow_short=allow_short,
+            applied_fraction=used_fraction,
+        )
+
+        prepared.db_order_id = await self._record_initial_order(prepared)
+        await self._log(
+            "INFO",
+            f"Prepared order {symbol} {side} qty={quantity:.8f} notional={notional:.2f}",
+            context={
+                "client_order_id": client_order_id,
+                "order_type": order_type,
+                "stop_loss": plan.get("stop_loss"),
+                "take_profit": plan.get("take_profit"),
+            },
+        )
+        return prepared
+
+    async def _place_order(self, prepared: PreparedOrder) -> ExecutionResult:
+        last_error: Optional[Exception] = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = self.exchange_manager.create_order(
+                    prepared.symbol,
+                    prepared.side.upper(),
+                    prepared.order_type.upper(),
+                    prepared.quantity,
+                    prepared.price,
+                    prepared.client_order_id,
+                )
+                if inspect.isawaitable(response):
+                    response = await response
+                if response is None:
+                    raise RuntimeError("Exchange returned empty response")
+                result = self._build_execution_result(prepared, response)
+                await self._finalise_success(prepared, result)
+                return result
+            except Exception as exc:  # pragma: no cover - retry branch ciężki do pokrycia
+                last_error = exc
+                if not self._should_retry(exc) or attempt >= self.max_retries:
+                    break
+                delay = self.retry_delay * (2 ** attempt)
+                logger.warning(
+                    "Order attempt %s/%s failed (%s). Retrying in %.2fs",
+                    attempt + 1,
+                    self.max_retries + 1,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        error_msg = str(last_error) if last_error else "Unknown order execution error"
+        await self._mark_failure(prepared, error_msg)
+        return ExecutionResult(
+            status="FAILED",
+            order_id=None,
+            client_order_id=prepared.client_order_id,
+            quantity=prepared.quantity,
+            price=float(prepared.price or prepared.plan.get("price_ref") or 0.0),
+            notional=0.0,
+            mode=prepared.mode,
+            raw={"error": error_msg},
+            error=error_msg,
+        )
+
+    def _build_execution_result(self, prepared: PreparedOrder, response: Any) -> ExecutionResult:
+        raw = self._normalise_response(response)
+        status = str(raw.get("status") or OrderStatus.FILLED.value).upper()
+        price = float(raw.get("price") or prepared.plan.get("price_ref") or 0.0)
+        quantity = float(raw.get("quantity") or prepared.quantity)
+        order_id = raw.get("id") or raw.get("order_id") or raw.get("orderId")
+        notional = quantity * price if price else prepared.notional
+        return ExecutionResult(
+            status=status,
+            order_id=order_id,
+            client_order_id=prepared.client_order_id,
+            quantity=quantity,
+            price=price,
+            notional=notional,
+            mode=prepared.mode,
+            raw=raw,
+        )
+
+    async def _finalise_success(self, prepared: PreparedOrder, result: ExecutionResult) -> None:
+        if self.db_manager and (prepared.db_order_id or prepared.client_order_id):
+            try:
+                await self.db_manager.update_order_status(
+                    order_id=prepared.db_order_id,
+                    client_order_id=prepared.client_order_id,
+                    status=result.status,
+                    price=result.price,
+                    exchange_order_id=str(result.order_id) if result.order_id is not None else None,
+                    extra={
+                        "execution": result.raw,
+                        "notional": result.notional,
+                        "mode": result.mode,
+                    },
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Failed to update order status: %s", exc)
+        await self._log(
+            "INFO",
+            f"Order executed {prepared.symbol} {prepared.side} qty={result.quantity:.8f} status={result.status}",
+            context={
+                "client_order_id": prepared.client_order_id,
+                "mode": result.mode,
+                "price": result.price,
+                "notional": result.notional,
+            },
+        )
+
+    async def _mark_failure(self, prepared: PreparedOrder, error_msg: str) -> None:
+        if self.db_manager and (prepared.db_order_id or prepared.client_order_id):
+            try:
+                await self.db_manager.update_order_status(
+                    order_id=prepared.db_order_id,
+                    client_order_id=prepared.client_order_id,
+                    status=OrderStatus.REJECTED.value,
+                    extra={
+                        "error": error_msg,
+                        "plan": self._safe_json(prepared.plan),
+                    },
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Failed to mark order failure: %s", exc)
+        await self._log(
+            "ERROR",
+            f"Order execution failed {prepared.symbol} {prepared.side}: {error_msg}",
+            context={
+                "client_order_id": prepared.client_order_id,
+                "mode": prepared.mode,
+            },
+        )
+
+    async def _record_initial_order(self, prepared: PreparedOrder) -> Optional[int]:
+        if not self.db_manager:
+            return None
+        try:
+            payload = {
+                "symbol": prepared.symbol,
+                "side": prepared.side.upper(),
+                "type": prepared.order_type.upper(),
+                "quantity": prepared.quantity,
+                "price": prepared.price,
+                "status": "NEW",
+                "client_order_id": prepared.client_order_id,
+                "mode": prepared.mode,
+                "extra": {
+                    "strength": prepared.plan.get("strength"),
+                    "stop_loss": prepared.plan.get("stop_loss"),
+                    "take_profit": prepared.plan.get("take_profit"),
+                    "applied_fraction": prepared.applied_fraction,
+                    "max_fraction": prepared.plan.get("max_fraction"),
+                    "risk": prepared.plan.get("risk"),
+                },
+            }
+            order_id = await self.db_manager.record_order(payload)
+            return order_id
+        except Exception as exc:  # pragma: no cover
+            logger.warning("Failed to record initial order: %s", exc)
+            return None
+
+    async def _fetch_capital(self, symbol: str) -> float:
+        balance = self.exchange_manager.fetch_balance()
+        if inspect.isawaitable(balance):
+            balance = await balance
+        quote = self._quote_asset(symbol)
+        return self._extract_balance_amount(balance, quote)
+
+    def _determine_quantity(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        qty_hint: float,
+        price_ref: float,
+        capital: float,
+        position_qty: float,
+        allow_short: bool,
+        fraction_limit: Optional[float],
+    ) -> Tuple[float, float, Optional[float]]:
+        min_notional = self._min_notional(symbol)
+        fraction: Optional[float] = None
+        if qty_hint <= 1.0:
+            fraction = max(0.0, qty_hint)
+            if self.max_fraction > 0:
+                fraction = min(fraction, self.max_fraction)
+            if fraction_limit is not None:
+                try:
+                    cap = float(fraction_limit)
+                    fraction = min(fraction, max(0.0, min(1.0, cap)))
+                except Exception:
+                    pass
+        quantity: float
+        notional: float
+        used_fraction: Optional[float] = None
+
+        if fraction is not None:
+            if side == "buy":
+                spendable = capital / (1.0 + self.fee_buffer) if capital > 0 else 0.0
+                notional = spendable * fraction
+                if min_notional and notional < min_notional:
+                    notional = min_notional
+                if notional * (1.0 + self.fee_buffer) > capital + 1e-9:
+                    if capital < min_notional:
+                        raise ValueError("Insufficient capital for minimum order size")
+                    notional = capital / (1.0 + self.fee_buffer)
+                quantity = notional / price_ref
+                used_fraction = min(1.0, notional / capital) if capital > 0 else fraction
+            else:
+                if position_qty > 0 and not allow_short:
+                    quantity = position_qty * min(fraction, 1.0)
+                    notional = quantity * price_ref
+                    used_fraction = min(1.0, notional / capital) if capital > 0 else fraction
+                else:
+                    if not allow_short and position_qty <= 0:
+                        raise ValueError("No position available to sell and shorting disabled")
+                    notional = capital * fraction
+                    if min_notional and notional < min_notional:
+                        notional = min_notional
+                    quantity = notional / price_ref
+                    used_fraction = min(1.0, notional / capital) if capital > 0 else fraction
+        else:
+            quantity = qty_hint
+            notional = quantity * price_ref
+
+        if side == "sell" and not allow_short and quantity > position_qty + 1e-9:
+            quantity = position_qty
+            notional = quantity * price_ref
+
+        if quantity <= 0 or notional <= 0:
+            raise ValueError("Calculated order size is zero")
+        return quantity, notional, used_fraction
+
+    def _quantize_amount(self, symbol: str, amount: float) -> float:
+        quantizer = getattr(self.exchange_manager, "quantize_amount", None)
+        if callable(quantizer):
+            return float(quantizer(symbol, amount))
+        return float(f"{amount:.8f}")
+
+    def _quantize_price(self, symbol: str, price: float) -> float:
+        quantizer = getattr(self.exchange_manager, "quantize_price", None)
+        if callable(quantizer):
+            return float(quantizer(symbol, price))
+        return float(f"{price:.8f}")
+
+    def _min_notional(self, symbol: str) -> float:
+        getter = getattr(self.exchange_manager, "min_notional", None)
+        if callable(getter):
+            try:
+                return float(getter(symbol))
+            except Exception:  # pragma: no cover
+                return 0.0
+        return 0.0
+
+    def _extract_position(self, symbol: str, portfolio: Any) -> Tuple[float, str]:
+        positions: List[Dict[str, Any]] = []
+        if isinstance(portfolio, dict):
+            maybe_positions = portfolio.get("positions")
+            if isinstance(maybe_positions, list):
+                positions = [p for p in maybe_positions if isinstance(p, dict)]
+        elif isinstance(portfolio, list):
+            positions = [p for p in portfolio if isinstance(p, dict)]
+
+        for pos in positions:
+            if str(pos.get("symbol")) == symbol:
+                qty = float(pos.get("qty") or pos.get("quantity") or 0.0)
+                side = str(pos.get("side") or "").upper()
+                return qty, side
+        return 0.0, ""
+
+    def _mode_string(self) -> str:
+        mode = getattr(self.exchange_manager, "mode", None)
+        if hasattr(mode, "value"):
+            return str(getattr(mode, "value"))
+        if isinstance(mode, Mode):
+            return mode.value
+        if isinstance(mode, str):
+            return mode
+        return Mode.PAPER.value
+
+    def _quote_asset(self, symbol: str) -> str:
+        if "/" in symbol:
+            return symbol.split("/")[-1].upper()
+        if "-" in symbol:
+            return symbol.split("-")[-1].upper()
+        return "USDT"
+
+    @staticmethod
+    def _extract_balance_amount(balance: Any, currency: str) -> float:
+        if isinstance(balance, dict):
+            if currency in balance and isinstance(balance[currency], (int, float)):
+                return float(balance[currency])
+            for key in ("free", "total", "balance"):
+                section = balance.get(key)
+                if isinstance(section, dict) and currency in section:
+                    amount = section[currency]
+                    if isinstance(amount, (int, float)):
+                        return float(amount)
+        try:
+            return float(balance or 0.0)
+        except Exception:  # pragma: no cover
+            return 0.0
+
+    def _normalise_response(self, response: Any) -> Dict[str, Any]:
+        if hasattr(response, "model_dump"):
+            raw = response.model_dump()
+        elif isinstance(response, dict):
+            raw = dict(response)
+        else:
+            raw = {"response": str(response)}
+        serialised: Dict[str, Any] = {}
+        for key, value in raw.items():
+            if hasattr(value, "value"):
+                serialised[key] = getattr(value, "value")
+            elif isinstance(value, (str, int, float, bool)) or value is None:
+                serialised[key] = value
+            else:
+                serialised[key] = str(value)
+        if "status" in serialised:
+            serialised["status"] = str(serialised["status"]).upper()
+        return serialised
+
+    def _should_retry(self, exc: Exception) -> bool:
+        retryable = (ConnectionError, asyncio.TimeoutError, TimeoutError)
+        if isinstance(exc, retryable):
+            return True
+        if ccxt:
+            network_errors = (
+                getattr(ccxt, "NetworkError", Exception),
+                getattr(ccxt, "DDoSProtection", Exception),
+                getattr(ccxt, "RateLimitExceeded", Exception),
+            )
+            if isinstance(exc, network_errors):
+                return True
+        return False
+
+    async def _log(self, level: str, message: str, *, context: Optional[Dict[str, Any]] = None) -> None:
+        if not self.db_manager:
+            return
+        try:
+            await self.db_manager.log(
+                self._user_id,
+                level,
+                message,
+                category="trade",
+                context=self._safe_json(context or {}),
+            )
+        except Exception:  # pragma: no cover
+            logger.debug("Structured log failed", exc_info=True)
+
+    def _generate_client_order_id(self, symbol: str) -> str:
+        prefix = symbol.replace("/", "").replace("-", "")[:6].upper()
+        return f"BOT-{prefix}-{uuid.uuid4().hex[:12]}"
+
+    def _safe_json(self, data: Any) -> Any:
+        if isinstance(data, (str, int, float, bool)) or data is None:
+            return data
+        if isinstance(data, dict):
+            return {str(k): self._safe_json(v) for k, v in data.items()}
+        if isinstance(data, list):
+            return [self._safe_json(v) for v in data]
+        return str(data)

--- a/KryptoLowca/core/trading_engine.py
+++ b/KryptoLowca/core/trading_engine.py
@@ -15,16 +15,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import pandas as pd
-from typing import Dict, Optional, Callable, Any
-from dataclasses import dataclass
-import numpy as np
+from typing import Any, Callable, Dict, Optional
 
-from managers.exchange_manager import ExchangeManager
+import pandas as pd
+
+from core.order_executor import ExecutionResult, OrderExecutor
 from managers.ai_manager import AIManager
-from managers.risk_manager_adapter import RiskManager
 from managers.database_manager import DatabaseManager
-from trading_strategies import TradingStrategies, TradingParameters, EngineConfig
+from managers.exchange_manager import ExchangeManager
+from managers.risk_manager_adapter import RiskManager
+from trading_strategies import EngineConfig, TradingParameters, TradingStrategies
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
@@ -33,10 +33,11 @@ if not logger.handlers:
     logger.addHandler(_h)
 logger.setLevel(logging.INFO)
 
+
 # --- Custom exceptions ---
 class TradingError(Exception):
     """Raised when trading operations fail."""
-    pass
+
 
 class TradingEngine:
     """
@@ -45,6 +46,7 @@ class TradingEngine:
     Args:
         db_manager: DatabaseManager for logging and position tracking.
     """
+
     def __init__(self, db_manager: Optional[DatabaseManager] = None):
         self.ex_mgr: Optional[ExchangeManager] = None
         self.ai_mgr: Optional[AIManager] = None
@@ -53,11 +55,12 @@ class TradingEngine:
         self.strategies = TradingStrategies()
         self.tp = TradingParameters()
         self.ec = EngineConfig()
-        self._event_callback: Optional[Callable] = None
+        self._event_callback: Optional[Callable[[Dict[str, Any]], None]] = None
         self._lock = asyncio.Lock()
         self._user_id: Optional[int] = None
+        self._order_executor: Optional[OrderExecutor] = None
 
-    async def configure(self, ex_mgr: ExchangeManager, ai_mgr: AIManager, risk_mgr: RiskManager):
+    async def configure(self, ex_mgr: ExchangeManager, ai_mgr: AIManager, risk_mgr: RiskManager) -> None:
         """Configure the engine with dependencies."""
         async with self._lock:
             self.ex_mgr = ex_mgr
@@ -71,6 +74,12 @@ class TradingEngine:
                     setattr(self.ai_mgr, "ai_threshold_bps", float(self.tp.signal_threshold * 10_000))
                 except Exception:
                     setattr(self.ai_mgr, "ai_threshold_bps", 5.0)
+            self._order_executor = OrderExecutor(
+                ex_mgr,
+                self.db_manager,
+                max_fraction=self._fraction_cap(),
+            )
+            self._order_executor.set_user(self._user_id)
 
     @staticmethod
     def _extract_balance_amount(balance: Any, currency: str) -> float:
@@ -88,35 +97,69 @@ class TradingEngine:
         except Exception:
             return 0.0
 
-    def set_parameters(self, tp: TradingParameters, ec: EngineConfig):
+    @staticmethod
+    def _derive_quote_currency(symbol: str) -> str:
+        if "/" in symbol:
+            return symbol.split("/")[-1].upper()
+        if "-" in symbol:
+            return symbol.split("-")[-1].upper()
+        return "USDT"
+
+    def set_parameters(self, tp: TradingParameters, ec: EngineConfig) -> None:
         """Set trading parameters and configuration."""
         try:
             if hasattr(tp, "validate"):
                 tp.validate()
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - walidacja
             raise ValueError(f"Invalid trading parameters: {exc}") from exc
         try:
             if hasattr(ec, "validate"):
                 ec.validate()
-        except Exception as exc:
+        except Exception as exc:  # pragma: no cover - walidacja
             raise ValueError(f"Invalid engine config: {exc}") from exc
         self.tp = tp
         self.ec = ec
         if self.db_manager:
-            asyncio.create_task(self.db_manager.log(self._user_id, "INFO", f"Parameters set: {tp.__dict__}, {ec.__dict__}", category="engine"))
+            async def _log_params() -> None:
+                await self.db_manager.log(
+                    self._user_id,
+                    "INFO",
+                    f"Parameters set: {tp.__dict__}, {ec.__dict__}",
+                    category="engine",
+                )
 
-    def on_event(self, callback: Callable):
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(_log_params())
+            else:
+                loop.create_task(_log_params())
+        if self._order_executor:
+            self._order_executor.set_user(self._user_id)
+            self._order_executor.max_fraction = self._fraction_cap()
+
+    def on_event(self, callback: Callable[[Dict[str, Any]], None]) -> None:
         """Register event callback for GUI updates."""
         self._event_callback = callback
 
-    async def _emit_event(self, event: Dict[str, Any]):
+    async def _emit_event(self, event: Dict[str, Any]) -> None:
         """Emit an event to the callback."""
         if self._event_callback:
             self._event_callback(event)
         if self.db_manager:
-            await self.db_manager.log(self._user_id, "INFO", f"Event emitted: {event}", category="engine")
+            await self.db_manager.log(
+                self._user_id,
+                "INFO",
+                f"Event emitted: {event}",
+                category="engine",
+            )
 
-    async def execute_live_tick(self, symbol: str, df: pd.DataFrame, preds: pd.Series) -> Optional[Dict[str, Any]]:
+    async def execute_live_tick(
+        self,
+        symbol: str,
+        df: pd.DataFrame,
+        preds: pd.Series,
+    ) -> Optional[Dict[str, Any]]:
         """
         Execute trading logic for a single tick.
 
@@ -126,18 +169,21 @@ class TradingEngine:
             preds: Series with AI predictions (in basis points).
 
         Returns:
-            Trading plan or None if no action is taken.
+            Trading plan (possibly with execution details) or ``None`` if no action is taken.
         """
         async with self._lock:
             try:
                 if not symbol or not isinstance(symbol, str):
                     raise ValueError("Invalid symbol")
                 if df.empty or len(df) < self.ec.min_data_points:
-                    raise ValueError(f"Insufficient data: {len(df)} bars, required {self.ec.min_data_points}")
+                    raise ValueError(
+                        f"Insufficient data: {len(df)} bars, required {self.ec.min_data_points}"
+                    )
                 if len(preds) != len(df):
                     raise ValueError("Predictions length does not match data length")
+                if not self.ex_mgr or not self.ai_mgr or not self.risk_mgr:
+                    raise TradingError("Trading engine is not fully configured")
 
-                # Check current positions
                 positions = await self.db_manager.get_positions(self._user_id) if self.db_manager else []
                 max_positions = getattr(self.tp, "max_position_size", getattr(self.tp, "max_positions", 5))
                 try:
@@ -145,60 +191,183 @@ class TradingEngine:
                 except Exception:
                     max_positions = 5
                 if len(positions) >= max_positions:
-                    await self._emit_event({"type": "max_positions_reached", "symbol": symbol, "positions": len(positions)})
+                    await self._emit_event(
+                        {"type": "max_positions_reached", "symbol": symbol, "positions": len(positions)}
+                    )
                     return None
 
                 if hasattr(self.strategies, "run_strategy"):
                     try:
                         self.strategies.run_strategy(df, self.tp)
-                    except Exception as exc:
+                    except Exception as exc:  # pragma: no cover - ostrzeżenie
                         logger.warning("Strategy execution skipped: %s", exc)
 
-                # Get latest prediction and price
-                latest_pred = preds.iloc[-1]
-                latest_price = df["close"].iloc[-1]
+                latest_pred = float(preds.iloc[-1])
+                latest_price = float(df["close"].iloc[-1])
+                if latest_price <= 0:
+                    raise ValueError("Latest price must be positive")
 
-                # Determine trade side
-                side = "buy" if latest_pred > 0 else "sell" if self.ec.enable_shorting else None
-                if side is None:
-                    await self._emit_event({"type": "shorting_disabled", "symbol": symbol})
+                shorting_enabled = bool(getattr(self.ec, "enable_shorting", False))
+                if latest_pred > 0:
+                    side = "buy"
+                elif latest_pred < 0 and shorting_enabled:
+                    side = "sell"
+                else:
+                    await self._emit_event({"type": "no_trade_signal", "symbol": symbol})
                     return None
 
-                # Calculate position size
-                balance_data = self.ex_mgr.fetch_balance() if self.ex_mgr else {}
+                balance_data = self.ex_mgr.fetch_balance()
                 if asyncio.iscoroutine(balance_data):
                     balance_data = await balance_data
-                capital = self._extract_balance_amount(balance_data, currency="USDT")
+                quote_currency = self._derive_quote_currency(symbol)
+                capital = self._extract_balance_amount(balance_data, currency=quote_currency)
                 if capital <= 0:
                     raise TradingError("Insufficient balance")
-                portfolio = {"capital": capital, "positions": positions}
-                qty = self.risk_mgr.calculate_position_size(symbol, latest_pred, df, portfolio)
 
-                # Create trading plan
-                plan = {
+                portfolio_ctx = {"positions": positions, "capital": capital}
+                sizing_outcome = self.risk_mgr.calculate_position_size(
+                    symbol,
+                    latest_pred,
+                    df,
+                    portfolio_ctx,
+                    return_details=True,
+                )
+                risk_details: Optional[Dict[str, Any]]
+                if isinstance(sizing_outcome, tuple):
+                    qty_hint, risk_details = sizing_outcome
+                else:
+                    qty_hint = sizing_outcome
+                    getter = getattr(self.risk_mgr, "last_position_details", None)
+                    risk_details = getter() if callable(getter) else None
+                try:
+                    qty_hint = float(qty_hint)
+                except Exception:
+                    qty_hint = 0.0
+                if risk_details is None:
+                    risk_details = {"recommended_size": qty_hint}
+                else:
+                    risk_details.setdefault("recommended_size", qty_hint)
+                if qty_hint <= 0:
+                    await self._emit_event({"type": "no_position_size", "symbol": symbol})
+                    return None
+
+                fraction_cap = self._fraction_cap()
+                risk_details["max_fraction_cap"] = fraction_cap
+                if fraction_cap <= 0:
+                    await self._emit_event({"type": "fraction_cap_zero", "symbol": symbol})
+                    return None
+
+                atr_window = max(1, int(getattr(self.tp, "atr_period", 14)))
+                tr = (df["high"] - df["low"]).abs()
+                atr = float(tr.tail(atr_window).mean()) if not tr.empty else 0.0
+                if atr <= 0:
+                    atr = latest_price * 0.01
+
+                threshold_bps = float(getattr(self.ai_mgr, "ai_threshold_bps", 1.0) or 1.0)
+                plan: Dict[str, Any] = {
                     "symbol": symbol,
                     "side": side,
-                    "qty_hint": qty,
+                    "qty_hint": qty_hint,
                     "price_ref": latest_price,
-                    "strength": abs(latest_pred) / self.ai_mgr.ai_threshold_bps,
-                    "stop_loss": latest_price * (1 - self.tp.stop_loss_atr_mult if side == "buy" else 1 + self.tp.stop_loss_atr_mult),
-                    "take_profit": latest_price * (1 + self.tp.take_profit_atr_mult if side == "buy" else 1 - self.tp.take_profit_atr_mult)
+                    "strength": abs(latest_pred) / threshold_bps,
+                    "stop_loss": latest_price - atr * self.tp.stop_loss_atr_mult
+                    if side == "buy"
+                    else latest_price + atr * self.tp.stop_loss_atr_mult,
+                    "take_profit": latest_price + atr * self.tp.take_profit_atr_mult
+                    if side == "buy"
+                    else latest_price - atr * self.tp.take_profit_atr_mult,
+                    "order_type": "market",
+                    "capital": capital,
+                    "portfolio": {"positions": positions},
+                    "allow_short": shorting_enabled,
+                    "quote_currency": quote_currency,
+                    "user_id": self._user_id,
+                    "max_fraction": fraction_cap,
+                    "risk": risk_details,
                 }
+
+                if qty_hint <= 1.0:
+                    plan["applied_fraction"] = min(max(qty_hint, 0.0), fraction_cap)
 
                 await self._emit_event({"type": "plan_created", "symbol": symbol, "plan": plan})
                 if self.db_manager:
-                    await self.db_manager.log(self._user_id, "INFO", f"Trading plan created for {symbol}: {plan}", category="trade")
+                    await self.db_manager.log(
+                        self._user_id,
+                        "INFO",
+                        f"Trading plan created for {symbol}: {plan}",
+                        category="trade",
+                    )
+
+                auto_execute = bool(getattr(self.ec, "auto_execute", True))
+                if auto_execute and self._order_executor:
+                    await self._emit_event(
+                        {"type": "order_submitting", "symbol": symbol, "plan": plan}
+                    )
+                    execution: ExecutionResult = await self._order_executor.execute_plan(plan)
+                    plan["execution"] = execution.to_dict()
+                    if plan.get("risk") and isinstance(plan["risk"], dict):
+                        plan["risk"]["executed_fraction"] = plan.get("applied_fraction")
+                    event_payload = {
+                        "symbol": symbol,
+                        "execution": plan["execution"],
+                        "type": "order_filled"
+                        if execution.status.upper() == "FILLED"
+                        else "order_submitted",
+                    }
+                    if execution.error:
+                        event_payload["type"] = "order_failed"
+                        event_payload["error"] = execution.error
+                    await self._emit_event(event_payload)
+                    if self.db_manager:
+                        await self.db_manager.log(
+                            self._user_id,
+                            "ERROR" if execution.error else "INFO",
+                            f"Order execution result for {symbol}: {plan['execution']}",
+                            category="trade",
+                        )
+
                 return plan
 
-            except ValueError as e:
-                logger.error(f"Trading tick failed for {symbol}: {e}")
+            except ValueError as exc:
+                logger.error("Trading tick failed for %s: %s", symbol, exc)
                 if self.db_manager:
-                    await self.db_manager.log(self._user_id, "ERROR", f"Trading tick failed for {symbol}: {e}", category="trade")
-                await self._emit_event({"type": "error", "symbol": symbol, "error": str(e)})
+                    await self.db_manager.log(
+                        self._user_id,
+                        "ERROR",
+                        f"Trading tick failed for {symbol}: {exc}",
+                        category="trade",
+                    )
+                await self._emit_event({"type": "error", "symbol": symbol, "error": str(exc)})
                 raise
-            except Exception as e:
-                logger.error(f"Trading tick failed for {symbol}: {e}")
+            except Exception as exc:
+                logger.error("Trading tick failed for %s: %s", symbol, exc, exc_info=True)
                 if self.db_manager:
-                    await self.db_manager.log(self._user_id, "ERROR", f"Trading tick failed for {symbol}: {e}", category="trade")
-                await self._emit_event({"type": "error", "symbol": symbol, "error": str(e)})
-                return None
+                    await self.db_manager.log(
+                        self._user_id,
+                        "ERROR",
+                        f"Trading tick failed for {symbol}: {exc}",
+                        category="trade",
+                    )
+                await self._emit_event({"type": "error", "symbol": symbol, "error": str(exc)})
+                raise TradingError(str(exc)) from exc
+
+    def _fraction_cap(self) -> float:
+        """Określ maksymalną frakcję kapitału na trade z konfiguracji."""
+
+        raw_values = []
+        for candidate in (
+            getattr(self.ec, "capital_fraction", None),
+            getattr(self.tp, "position_size", None),
+        ):
+            if candidate is None:
+                continue
+            try:
+                raw_values.append(float(candidate))
+            except Exception:
+                continue
+        if not raw_values:
+            return 1.0
+        normalised = [max(0.0, min(1.0, value)) for value in raw_values if value >= 0.0]
+        if not normalised:
+            return 1.0
+        return min(normalised)

--- a/KryptoLowca/managers/risk_manager_adapter.py
+++ b/KryptoLowca/managers/risk_manager_adapter.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
@@ -14,6 +14,7 @@ class RiskManager:
 
     def __init__(self, config: Dict[str, Any]):
         self.risk_mgr = create_risk_manager(config)
+        self._last_details: Optional[Dict[str, Any]] = None
 
     def calculate_position_size(
         self,
@@ -21,7 +22,9 @@ class RiskManager:
         signal: Any,
         market_data: Any,
         portfolio: Optional[Dict[str, Any]] = None,
-    ) -> float:
+        *,
+        return_details: bool = False,
+    ) -> float | Tuple[float, Dict[str, Any]]:
         """
         Zwraca rekomendowaną frakcję kapitału (0..1).
 
@@ -59,10 +62,44 @@ class RiskManager:
 
         sizing = self.risk_mgr.calculate_position_size(symbol, signal_payload, market_df, portfolio_ctx)
 
-        if hasattr(sizing, "recommended_size"):
-            return float(getattr(sizing, "recommended_size", 0.0))
+        details: Dict[str, Any] = {}
+        recommended = 0.0
 
-        try:
-            return float(sizing)
-        except Exception:
-            return 0.0
+        if hasattr(sizing, "recommended_size"):
+            recommended = float(getattr(sizing, "recommended_size", 0.0))
+            details = {
+                "recommended_size": recommended,
+                "max_allowed_size": float(getattr(sizing, "max_allowed_size", recommended)),
+                "kelly_size": float(getattr(sizing, "kelly_size", recommended)),
+                "risk_adjusted_size": float(getattr(sizing, "risk_adjusted_size", recommended)),
+                "confidence_level": float(getattr(sizing, "confidence_level", 0.0)),
+                "reasoning": getattr(sizing, "reasoning", ""),
+            }
+        elif isinstance(sizing, dict):
+            try:
+                recommended = float(sizing.get("recommended_size", sizing.get("size", 0.0)))
+            except Exception:
+                recommended = 0.0
+            details = dict(sizing)
+            details.setdefault("recommended_size", recommended)
+        else:
+            try:
+                recommended = float(sizing)
+            except Exception:
+                recommended = 0.0
+
+        recommended = max(0.0, min(1.0, recommended))
+        if not details:
+            details = {"recommended_size": recommended}
+        else:
+            details["recommended_size"] = recommended
+
+        self._last_details = details
+        if return_details:
+            return recommended, details
+        return recommended
+
+    def last_position_details(self) -> Optional[Dict[str, Any]]:
+        """Zwróć ostatnie szczegóły kalkulacji wielkości pozycji."""
+
+        return self._last_details

--- a/KryptoLowca/tests/test_config_manager.py
+++ b/KryptoLowca/tests/test_config_manager.py
@@ -1,97 +1,105 @@
-# test_config_manager.py
+# tests/test_config_manager.py
 # -*- coding: utf-8 -*-
-"""
-Unit tests for config_manager.py.
-"""
-import asyncio
-import pytest
-import yaml
+"""Testy walidacji presetów w :mod:`managers.config_manager`."""
+
+from __future__ import annotations
+
+import sys
 from pathlib import Path
-from cryptography.fernet import Fernet
 
-from config_manager import ConfigManager, ConfigError, ValidationError, AIConfig, DBConfig, TradeConfig, ExchangeConfig
+import pytest
 
-@pytest.fixture
-async def config_manager(tmp_path):
-    config_path = tmp_path / "config.yaml"
-    encryption_key = Fernet.generate_key()
-    manager = await ConfigManager.create(config_path=str(config_path), encryption_key=encryption_key)
-    return manager
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-@pytest.mark.asyncio
-async def test_load_save_config(config_manager, tmp_path):
-    config = {
-        "ai": {"threshold_bps": 7.0, "model_types": ["rf", "lstm"], "seq_len": 20, "epochs": 10, "batch_size": 32, "model_dir": "models"},
-        "db": {"db_url": "sqlite+aiosqlite:///test.db", "timeout_s": 15.0, "pool_size": 10, "max_overflow": 5},
-        "trade": {"risk_per_trade": 0.02, "max_leverage": 2.0, "stop_loss_pct": 0.03, "take_profit_pct": 0.06, "max_open_positions": 3},
-        "exchange": {"api_key": "test_key", "api_secret": "test_secret", "exchange_name": "binance", "testnet": True}
+from managers.config_manager import ConfigManager
+
+
+@pytest.fixture()
+def sample_preset() -> dict:
+    return {
+        "network": "Testnet",
+        "mode": "Spot",
+        "timeframe": "5m",
+        "fraction": 0.25,
+        "ai": {
+            "enable": True,
+            "seq_len": 256,
+            "epochs": 20,
+            "batch": 64,
+            "retrain_min": 30,
+            "train_window": 720,
+            "valid_window": 120,
+            "ai_threshold_bps": 4.5,
+            "train_all": False,
+        },
+        "risk": {
+            "max_daily_loss_pct": 0.08,
+            "soft_halt_losses": 2,
+            "trade_cooldown_on_error": 60,
+            "risk_per_trade": 0.02,
+            "portfolio_risk": 0.3,
+            "one_trade_per_bar": True,
+            "cooldown_s": 15,
+            "min_move_pct": 0.01,
+        },
+        "dca_trailing": {
+            "use_trailing": True,
+            "atr_period": 14,
+            "trail_atr_mult": 2.5,
+            "take_atr_mult": 3.5,
+            "dca_enabled": True,
+            "dca_max_adds": 2,
+            "dca_step_atr": 1.5,
+        },
+        "slippage": {"use_orderbook_vwap": True, "fallback_bps": 6.0},
+        "advanced": {
+            "rsi_period": 14,
+            "ema_fast": 12,
+            "ema_slow": 26,
+            "atr_period": 14,
+            "rsi_buy": 30.0,
+            "rsi_sell": 70.0,
+        },
+        "paper": {"capital": 15_000.0},
+        "selected_symbols": ["btc/usdt", "eth/usdt", "btc/usdt"],
     }
-    await config_manager.save_config(config)
-    loaded = await config_manager.load_config()
-    assert loaded["ai"]["threshold_bps"] == 7.0
-    assert loaded["exchange"]["api_key"] == "test_key"  # Decrypted
-    assert config_manager.config_path.exists()
-    with open(config_manager.config_path, "r") as f:
-        saved = yaml.safe_load(f)
-    assert saved["ai"]["threshold_bps"] == 7.0
 
-@pytest.mark.asyncio
-async def test_user_config(config_manager):
-    user_id = await config_manager.db_manager.ensure_user("tester@example.com")
-    config = {
-        "ai": {"threshold_bps": 10.0, "model_types": ["gb"], "seq_len": 30, "epochs": 15, "batch_size": 16},
-        "trade": {"risk_per_trade": 0.015}
-    }
-    await config_manager.save_user_config(user_id, "custom", config)
-    loaded = await config_manager.load_config(preset_name="custom", user_id=user_id)
-    assert loaded["ai"]["threshold_bps"] == 10.0
-    assert loaded["trade"]["risk_per_trade"] == 0.015
 
-@pytest.mark.asyncio
-async def test_specific_configs(config_manager):
-    config = {
-        "ai": {"threshold_bps": 6.0, "model_types": ["rf"], "seq_len": 25, "epochs": 20, "batch_size": 48},
-        "db": {"db_url": "sqlite+aiosqlite:///test2.db", "timeout_s": 20.0},
-        "trade": {"risk_per_trade": 0.01, "max_leverage": 1.5},
-        "exchange": {"exchange_name": "kraken", "testnet": False}
-    }
-    await config_manager.save_config(config)
-    ai_config = config_manager.load_ai_config()
-    db_config = config_manager.load_db_config()
-    trade_config = config_manager.load_trade_config()
-    exchange_config = config_manager.load_exchange_config()
-    assert ai_config.threshold_bps == 6.0
-    assert db_config.db_url == "sqlite+aiosqlite:///test2.db"
-    assert trade_config.max_leverage == 1.5
-    assert exchange_config.exchange_name == "kraken"
+@pytest.fixture()
+def cfg(tmp_path: Path) -> ConfigManager:
+    return ConfigManager(tmp_path)
 
-@pytest.mark.asyncio
-async def test_encryption(config_manager):
-    config = {
-        "exchange": {"api_key": "sensitive_key", "api_secret": "sensitive_secret"}
-    }
-    await config_manager.save_config(config)
-    with open(config_manager.config_path, "r") as f:
-        saved = yaml.safe_load(f)
-    assert saved["exchange"]["api_key"] != "sensitive_key"  # Encrypted
-    loaded = await config_manager.load_config()
-    assert loaded["exchange"]["api_key"] == "sensitive_key"  # Decrypted
 
-@pytest.mark.asyncio
-async def test_invalid_config(config_manager):
-    config = {
-        "ai": {"threshold_bps": -1.0},  # Invalid
-        "db": {"db_url": ""},  # Invalid
-        "trade": {"risk_per_trade": 2.0},  # Invalid
-        "exchange": {"api_key": 123}  # Invalid
-    }
-    with pytest.raises(ValidationError):
-        await config_manager.save_config(config)
+def test_save_and_load_roundtrip(cfg: ConfigManager, sample_preset: dict) -> None:
+    path = cfg.save_preset("demo", sample_preset)
+    assert path.exists()
 
-@pytest.mark.asyncio
-async def test_default_config(config_manager):
-    config = await config_manager.load_config()
-    assert config["ai"]["threshold_bps"] == 5.0
-    assert config["db"]["db_url"] == "sqlite+aiosqlite:///trading.db"
-    assert config["trade"]["risk_per_trade"] == 0.01
-    assert config["exchange"]["exchange_name"] == "binance"
+    loaded = cfg.load_preset("demo")
+    assert loaded["network"] == "Testnet"
+    assert loaded["mode"] == "Spot"
+    assert loaded["timeframe"] == "5m"
+    assert loaded["fraction"] == pytest.approx(0.25)
+    # symbole oczyszczone i bez duplikatów
+    assert loaded["selected_symbols"] == ["BTC/USDT", "ETH/USDT"]
+    # sekcje dodatkowe obecne
+    assert loaded["ai"]["epochs"] == 20
+    assert loaded["risk"]["risk_per_trade"] == pytest.approx(0.02)
+
+
+def test_invalid_fraction_rejected(cfg: ConfigManager, sample_preset: dict) -> None:
+    sample_preset["fraction"] = 1.5
+    with pytest.raises(ValueError):
+        cfg.save_preset("bad_fraction", sample_preset)
+
+
+def test_defaults_and_normalisation(cfg: ConfigManager) -> None:
+    minimal = {"selected_symbols": [" sol/usdt ", "ada/usdt"], "fraction": 0.0}
+    preset = cfg.validate_preset(minimal)
+
+    assert preset.network == "Testnet"
+    assert preset.mode == "Spot"
+    assert preset.timeframe == "1m"
+    assert preset.selected_symbols == ["SOL/USDT", "ADA/USDT"]
+    assert preset.fraction == pytest.approx(0.0)
+    data = preset.to_dict()
+    assert "ai" in data and "risk" in data

--- a/KryptoLowca/tests/test_trading_engine.py
+++ b/KryptoLowca/tests/test_trading_engine.py
@@ -1,109 +1,228 @@
 # tests/test_trading_engine.py
 # -*- coding: utf-8 -*-
-"""
-Unit tests for trading_engine.py.
-"""
-import pytest
+"""Unit tests for :mod:`core.trading_engine`."""
+
+from __future__ import annotations
+
 import asyncio
-import pandas as pd
+import sys
+from pathlib import Path
+
 import numpy as np
+import pandas as pd
+import pytest
 from unittest.mock import AsyncMock
-from core.trading_engine import TradingEngine, TradingError
-from trading_strategies import TradingParameters, EngineConfig, TradingStrategies
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.trading_engine import TradingEngine
+from managers.exchange_core import Mode, OrderDTO, OrderSide, OrderStatus, OrderType
+from trading_strategies import EngineConfig, TradingParameters
+
 
 class MockExchange:
+    def __init__(self) -> None:
+        self.mode = Mode.PAPER
+        self.created_orders = []
+
     async def fetch_balance(self):
-        return {"USDT": 10000.0}
+        return {"USDT": 10_000.0, "free": {"USDT": 10_000.0}}
+
+    def quantize_amount(self, symbol: str, amount: float) -> float:
+        return round(float(amount), 6)
+
+    def quantize_price(self, symbol: str, price: float) -> float:
+        return round(float(price), 2)
+
+    def min_notional(self, symbol: str) -> float:
+        return 10.0
+
+    def create_order(
+        self,
+        symbol: str,
+        side: str,
+        type: str,
+        quantity: float,
+        price: float | None = None,
+        client_order_id: str | None = None,
+    ) -> OrderDTO:
+        self.created_orders.append(
+            {
+                "symbol": symbol,
+                "side": side,
+                "type": type,
+                "quantity": quantity,
+                "price": price,
+                "client_order_id": client_order_id,
+            }
+        )
+        return OrderDTO(
+            id=123,
+            client_order_id=client_order_id,
+            symbol=symbol,
+            side=OrderSide.BUY if side.upper() == "BUY" else OrderSide.SELL,
+            type=OrderType.MARKET if type.upper() == "MARKET" else OrderType.LIMIT,
+            quantity=quantity,
+            price=price or 100.5,
+            status=OrderStatus.FILLED,
+            mode=self.mode,
+        )
+
 
 class MockAI:
-    async def predict_series(self, symbol, df):
-        return pd.Series(np.full(len(df), 10.0), index=df.index)
     ai_threshold_bps = 5.0
 
+
 class MockRisk:
-    def calculate_position_size(self, symbol, signal, market_data, portfolio):
-        return 0.1
+    def __init__(self) -> None:
+        self.return_value = 0.1
+
+    def calculate_position_size(self, symbol, signal, market_data, portfolio, return_details=False):
+        details = {
+            "recommended_size": self.return_value,
+            "max_allowed_size": 0.5,
+            "kelly_size": 0.05,
+            "risk_adjusted_size": self.return_value,
+            "confidence_level": 0.75,
+            "reasoning": "mock",
+        }
+        if return_details:
+            return self.return_value, details
+        return self.return_value
+
 
 class MockDB:
-    async def ensure_user(self, email):
+    def __init__(self) -> None:
+        self.orders = []
+        self.order_updates = []
+        self.logs = []
+        self.positions = []
+
+    async def ensure_user(self, email: str) -> int:
         return 1
-    async def log(self, user_id, level, msg, category="general", context=None):
-        pass
+
+    async def log(self, user_id, level, message, category="general", context=None):
+        self.logs.append((level, message, category, context))
+
     async def get_positions(self, user_id):
-        return []
+        return list(self.positions)
+
+    async def record_order(self, order):
+        self.orders.append(order)
+        return len(self.orders)
+
+    async def update_order_status(
+        self,
+        *,
+        order_id=None,
+        client_order_id=None,
+        status=None,
+        price=None,
+        exchange_order_id=None,
+        extra=None,
+    ):
+        self.order_updates.append(
+            {
+                "order_id": order_id,
+                "client_order_id": client_order_id,
+                "status": status,
+                "price": price,
+                "exchange_order_id": exchange_order_id,
+                "extra": extra,
+            }
+        )
+
 
 @pytest.fixture
-async def engine(monkeypatch):
-    monkeypatch.setattr("core.trading_engine.ExchangeManager", MockExchange)
-    monkeypatch.setattr("core.trading_engine.AIManager", MockAI)
-    monkeypatch.setattr("core.trading_engine.RiskManager", MockRisk)
-    monkeypatch.setattr("core.trading_engine.DatabaseManager", MockDB)
-    engine = TradingEngine(db_manager=MockDB())
-    await engine.configure(MockExchange(), MockAI(), MockRisk())
-    engine.set_parameters(TradingParameters(), EngineConfig())
+def engine():
+    exchange = MockExchange()
+    db = MockDB()
+    engine = TradingEngine(db_manager=db)
+
+    async def _setup():
+        await engine.configure(exchange, MockAI(), MockRisk())
+        engine.set_parameters(TradingParameters(), EngineConfig())
+
+    asyncio.run(_setup())
     return engine
 
-@pytest.mark.asyncio
-async def test_execute_live_tick(engine):
-    df = pd.DataFrame({
-        "timestamp": pd.date_range("2025-08-21", periods=252, freq="T"),
-        "open": np.full(252, 100.0),
-        "high": np.full(252, 101.0),
-        "low": np.full(252, 99.0),
-        "close": np.full(252, 100.5),
-        "volume": np.full(252, 10.0)
-    })
-    preds = pd.Series(np.full(252, 10.0), index=df.index)
-    plan = await engine.execute_live_tick("BTC/USDT", df, preds)
+
+def _sample_df(size: int = 252) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2025-08-21", periods=size, freq="T"),
+            "open": np.full(size, 100.0),
+            "high": np.full(size, 101.0),
+            "low": np.full(size, 99.0),
+            "close": np.full(size, 100.5),
+            "volume": np.full(size, 10.0),
+        }
+    )
+
+
+def test_execute_live_tick(engine):
+    df = _sample_df()
+    preds = pd.Series(np.full(len(df), 10.0), index=df.index)
+
+    plan = asyncio.run(engine.execute_live_tick("BTC/USDT", df, preds))
+
     assert plan is not None
     assert plan["symbol"] == "BTC/USDT"
     assert plan["side"] == "buy"
-    assert plan["qty_hint"] == 0.1
-    assert plan["price_ref"] == 100.5
+    assert plan["max_fraction"] <= 0.2
+    assert plan["applied_fraction"] <= plan["max_fraction"]
+    assert plan["risk"]["recommended_size"] == pytest.approx(engine.risk_mgr.return_value)  # type: ignore[attr-defined]
+    assert "execution" in plan
+    assert plan["execution"]["status"] == "FILLED"
+    assert engine.ex_mgr.created_orders  # type: ignore[attr-defined]
+    assert engine.db_manager.orders  # type: ignore[attr-defined]
 
-@pytest.mark.asyncio
-async def test_no_signal(engine, monkeypatch):
-    monkeypatch.setattr(engine.strategies, "run_strategy", lambda *args: ({}, [], pd.Series()))
-    df = pd.DataFrame({
-        "timestamp": pd.date_range("2025-08-21", periods=252, freq="T"),
-        "open": np.full(252, 100.0),
-        "high": np.full(252, 101.0),
-        "low": np.full(252, 99.0),
-        "close": np.full(252, 100.5),
-        "volume": np.full(252, 10.0)
-    })
-    preds = pd.Series(np.full(252, 0.0), index=df.index)
-    plan = await engine.execute_live_tick("BTC/USDT", df, preds)
+
+def test_no_signal(engine):
+    df = _sample_df()
+    preds = pd.Series(np.zeros(len(df)), index=df.index)
+
+    plan = asyncio.run(engine.execute_live_tick("BTC/USDT", df, preds))
+
     assert plan is None
 
-@pytest.mark.asyncio
-async def test_max_positions(engine, monkeypatch):
-    monkeypatch.setattr(engine.db_manager, "get_positions", AsyncMock(return_value=[{}]*1))
+
+def test_max_positions(engine, monkeypatch):
+    monkeypatch.setattr(engine.db_manager, "positions", [{"symbol": "BTC/USDT"}])
+    monkeypatch.setattr(engine.db_manager, "get_positions", AsyncMock(return_value=[{"symbol": "BTC/USDT"}]))
     engine.tp = TradingParameters(max_position_size=1)
-    df = pd.DataFrame({
-        "timestamp": pd.date_range("2025-08-21", periods=252, freq="T"),
-        "open": np.full(252, 100.0),
-        "high": np.full(252, 101.0),
-        "low": np.full(252, 99.0),
-        "close": np.full(252, 100.5),
-        "volume": np.full(252, 10.0)
-    })
-    preds = pd.Series(np.full(252, 10.0), index=df.index)
-    plan = await engine.execute_live_tick("BTC/USDT", df, preds)
+
+    df = _sample_df()
+    preds = pd.Series(np.full(len(df), 10.0), index=df.index)
+
+    plan = asyncio.run(engine.execute_live_tick("BTC/USDT", df, preds))
+
     assert plan is None
 
-@pytest.mark.asyncio
-async def test_invalid_input(engine):
-    df = pd.DataFrame({
-        "timestamp": pd.date_range("2025-08-21", periods=10, freq="T"),
-        "open": np.full(10, 100.0),
-        "high": np.full(10, 101.0),
-        "low": np.full(10, 99.0),
-        "close": np.full(10, 100.5),
-        "volume": np.full(10, 10.0)
-    })
-    preds = pd.Series(np.full(10, 10.0), index=df.index)
+
+def test_invalid_input(engine):
+    df_short = _sample_df(size=10)
+    preds_short = pd.Series(np.full(len(df_short), 10.0), index=df_short.index)
+
     with pytest.raises(ValueError):
-        await engine.execute_live_tick("", df, preds)
+        asyncio.run(engine.execute_live_tick("", df_short, preds_short))
     with pytest.raises(ValueError):
-        await engine.execute_live_tick("BTC/USDT", df, preds)
+        asyncio.run(engine.execute_live_tick("BTC/USDT", df_short, preds_short))
+
+
+def test_fraction_cap_limit(engine):
+    engine.risk_mgr.return_value = 0.9  # type: ignore[attr-defined]
+    cfg = EngineConfig(capital_fraction=0.25)
+    engine.set_parameters(engine.tp, cfg)
+
+    df = _sample_df()
+    preds = pd.Series(np.full(len(df), 15.0), index=df.index)
+
+    plan = asyncio.run(engine.execute_live_tick("ETH/USDT", df, preds))
+
+    assert plan is not None
+    assert plan["max_fraction"] == pytest.approx(0.25)
+    assert plan["applied_fraction"] <= 0.25
+    execution = plan["execution"]
+    notional = execution["quantity"] * execution["price"]
+    assert notional <= 10_000 * 0.26  # niewielka nadwyżka na bufory/zaokrąglenia

--- a/KryptoLowca/trading_strategies.py
+++ b/KryptoLowca/trading_strategies.py
@@ -68,6 +68,7 @@ class EngineConfig:
     """Configuration for trading engine."""
     max_position_size: float = 1.0
     max_portfolio_risk: float = 0.02
+    capital_fraction: float = 0.2
     enable_stop_loss: bool = True
     enable_take_profit: bool = True
     enable_position_sizing: bool = True


### PR DESCRIPTION
## Summary
- propagate structured position-sizing details from the risk manager through the trading engine and skip trades when the configured fraction cap is zero
- extend the order executor to honour plan-level fraction limits, persist applied fractions in order records and expose them to downstream consumers
- add a capital_fraction field to EngineConfig, expose risk details via the adapter and refresh trading engine unit tests

## Testing
- pytest KryptoLowca/tests/test_trading_engine.py
- pytest KryptoLowca/tests/test_config_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d42171bb64832a86f846b12cc6fb0d