### PR TITLE
Add logging utilities and tighten auto-trade safety

### DIFF
--- a/KryptoLowca/auto_trader.py
+++ b/KryptoLowca/auto_trader.py
@@ -23,6 +23,10 @@ except Exception:
         def popleft(self): return super().pop(0)
 
 from KryptoLowca.event_emitter_adapter import EventEmitter
+from KryptoLowca.logging_utils import get_logger
+
+
+logger = get_logger(__name__)
 
 class AutoTrader:
     """
@@ -95,18 +99,20 @@ class AutoTrader:
         t2.start()
         self._threads.append(t2)
         self.emitter.log("AutoTrader started.", component="AutoTrader")
+        logger.info("AutoTrader worker threads started")
 
     def stop(self) -> None:
         self._stop.set()
         self.emitter.off("trade_closed", tag="autotrader")
         self.emitter.off("bar", tag="autotrader")
         self.emitter.log("AutoTrader stopped.", component="AutoTrader")
+        logger.info("AutoTrader stop requested")
         for t in list(self._threads):
             try:
                 if t.is_alive():
                     t.join(timeout=2.0)
             except Exception:
-                pass
+                logger.exception("Error while joining AutoTrader thread")
         self._threads.clear()
 
     def set_enable_auto_trade(self, flag: bool) -> None:
@@ -184,6 +190,7 @@ class AutoTrader:
                 threading.Thread(target=self._call_train_safe, args=(ai,), daemon=True).start()
             except Exception as e:
                 self.emitter.log(f"AI retrain failed to start: {e!r}", level="ERROR", component="AutoTrader")
+                logger.exception("AI retrain thread failed to start")
         else:
             self.emitter.log("AI manager not available; reopt event emitted only.", level="WARNING", component="AutoTrader")
 
@@ -194,6 +201,7 @@ class AutoTrader:
             self.emitter.log("AI retrain finished.", component="AutoTrader")
         except Exception as e:
             self.emitter.log(f"AI retrain error: {e!r}", level="ERROR", component="AutoTrader")
+            logger.exception("AI retrain raised an exception")
 
     # -- Loops --
     def _walkforward_loop(self) -> None:
@@ -211,6 +219,7 @@ class AutoTrader:
                     last_ts = now
             except Exception as e:
                 self.emitter.log(f"Walk-forward loop error: {e!r}", level="ERROR", component="AutoTrader")
+                logger.exception("Walk-forward loop error")
             self._stop.wait(1.0)
 
     def _auto_trade_loop(self) -> None:
@@ -234,6 +243,19 @@ class AutoTrader:
                 ex = getattr(self.gui, "ex_mgr", None)
                 ai = getattr(self.gui, "ai_mgr", None)
 
+                if hasattr(self.gui, "is_demo_mode_active"):
+                    try:
+                        if not self.gui.is_demo_mode_active():
+                            guard_fn = getattr(self.gui, "is_live_trading_allowed", None)
+                            if callable(guard_fn) and not guard_fn():
+                                msg = "Auto-trade blocked: live trading requires explicit confirmation."
+                                self.emitter.log(msg, level="WARNING", component="AutoTrader")
+                                logger.warning("%s Skipping auto trade for %s", msg, symbol)
+                                self._stop.wait(self.auto_trade_interval_s)
+                                continue
+                    except Exception:
+                        logger.exception("Failed to evaluate live trading guard")
+
                 df: Optional[pd.DataFrame] = None
                 last_price: Optional[float] = None
                 last_pred: Optional[float] = None
@@ -245,6 +267,7 @@ class AutoTrader:
                         self.emitter.log(
                             f"predict_series failed: {e!r}", level="ERROR", component="AutoTrader"
                         )
+                        logger.exception("predict_series failed during auto trade loop")
 
                 if last_price is None:
                     last_price = self._resolve_market_price(symbol, ex, df)
@@ -265,25 +288,41 @@ class AutoTrader:
                     elif last_pred <= -threshold:
                         side = "SELL"
 
-                if side is None and last_price is not None:
-                    # fallback – prosty przełącznik BUY/SELL aby utrzymać aktywność w trybie demo
-                    side = "BUY" if int(time.time() / max(1, self.auto_trade_interval_s)) % 2 == 0 else "SELL"
+                if side is None:
+                    self.emitter.log(
+                        f"Auto-trade skipped for {symbol}: no valid model signal.",
+                        level="WARNING",
+                        component="AutoTrader",
+                    )
+                    logger.info("Skipping auto trade for %s due to missing model signal", symbol)
+                    self._stop.wait(self.auto_trade_interval_s)
+                    continue
 
-                if side is None or last_price is None:
+                if last_price is None:
+                    self.emitter.log(
+                        f"Auto-trade skipped for {symbol}: missing market price.",
+                        level="WARNING",
+                        component="AutoTrader",
+                    )
+                    logger.warning("Skipping auto trade for %s due to missing market price", symbol)
                     self._stop.wait(self.auto_trade_interval_s)
                     continue
 
                 if hasattr(self.gui, "_bridge_execute_trade"):
                     self.gui._bridge_execute_trade(symbol, side.lower(), float(last_price))
                     self.emitter.emit("auto_trade_tick", symbol=symbol, ts=time.time())
+                    self.emitter.log(f"Auto-trade executed: {symbol} {side}", component="AutoTrader")
+                    logger.info("Auto trade executed for %s (%s)", symbol, side)
                 else:
                     self.emitter.log(
                         "_bridge_execute_trade missing on GUI",
                         level="ERROR",
                         component="AutoTrader",
                     )
+                    logger.error("GUI bridge missing for auto trade execution")
             except Exception as e:
                 self.emitter.log(f"Auto trade tick error: {e!r}", level="ERROR", component="AutoTrader")
+                logger.exception("Unhandled exception inside auto trade loop")
             self._stop.wait(self.auto_trade_interval_s)
 
     # --- Prediction helpers ---

--- a/KryptoLowca/config_manager.py
+++ b/KryptoLowca/config_manager.py
@@ -96,6 +96,10 @@ class ExchangeConfig:
     rate_limit_window_seconds: float = 60.0
     rate_limit_alert_threshold: float = 0.85
     error_alert_threshold: int = 3
+    rate_limit_buckets: List[Dict[str, Any]] = field(default_factory=list)
+    retry_attempts: int = 1
+    retry_delay: float = 0.05
+    require_demo_mode: bool = True
 
     def validate(self) -> "ExchangeConfig":
         if not self.exchange_name:
@@ -108,6 +112,26 @@ class ExchangeConfig:
             raise ValidationError("rate_limit_alert_threshold musi być w zakresie (0, 1]")
         if self.error_alert_threshold <= 0:
             raise ValidationError("error_alert_threshold musi być dodatnie")
+        if self.retry_attempts < 0:
+            raise ValidationError("retry_attempts musi być >= 0")
+        if self.retry_delay < 0:
+            raise ValidationError("retry_delay musi być >= 0")
+        if not isinstance(self.rate_limit_buckets, list):
+            raise ValidationError("rate_limit_buckets musi być listą")
+        cleaned_buckets: List[Dict[str, Any]] = []
+        for bucket in self.rate_limit_buckets:
+            if not isinstance(bucket, dict):
+                continue
+            capacity = int(bucket.get("capacity", 0))
+            window = float(bucket.get("window_seconds", 0.0))
+            if capacity <= 0 or window <= 0:
+                continue
+            name = str(bucket.get("name") or f"bucket_{len(cleaned_buckets) + 1}")
+            cleaned_buckets.append({"name": name, "capacity": capacity, "window_seconds": window})
+        self.rate_limit_buckets = cleaned_buckets
+        self.retry_attempts = int(self.retry_attempts)
+        self.retry_delay = float(self.retry_delay)
+        self.require_demo_mode = bool(self.require_demo_mode)
         return self
 
 

--- a/KryptoLowca/exchange_manager.py
+++ b/KryptoLowca/exchange_manager.py
@@ -10,8 +10,8 @@ import sys
 import time
 import types
 from collections import defaultdict
-from dataclasses import asdict, dataclass
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 # ---- ccxt async importy odporne na różne wersje / brak biblioteki ----
 try:  # pragma: no cover - importowany tylko jeśli ccxt jest dostępne
@@ -69,6 +69,40 @@ class _APIMetrics:
     last_endpoint: Optional[str] = None
 
 
+@dataclass(slots=True)
+class _RateLimitBucket:
+    """Opis pojedynczego limitu czasowego API."""
+
+    name: str
+    capacity: int
+    window_seconds: float
+    count: int = 0
+    window_start: float = field(default_factory=time.monotonic)
+    alert_active: bool = False
+    last_usage: float = 0.0
+    max_usage: float = 0.0
+
+    def reset(self, *, now: Optional[float] = None, hard: bool = False) -> None:
+        self.count = 0
+        self.window_start = now if now is not None else time.monotonic()
+        self.alert_active = False
+        self.last_usage = 0.0
+        if hard:
+            self.max_usage = 0.0
+
+    def snapshot(self) -> Dict[str, Any]:
+        remaining = max(0.0, self.window_seconds - (time.monotonic() - self.window_start))
+        return {
+            "name": self.name,
+            "capacity": self.capacity,
+            "window_seconds": self.window_seconds,
+            "count": self.count,
+            "usage": self.last_usage,
+            "max_usage": self.max_usage,
+            "reset_in_seconds": remaining,
+        }
+
+
 class ExchangeError(RuntimeError):
     """Podstawowy wyjątek warstwy wymiany."""
 
@@ -114,6 +148,7 @@ class ExchangeManager:
         self._rate_limit_window = 60.0
         self._rate_limit_per_minute: Optional[int] = None
         self._max_calls_per_window: Optional[int] = None
+        self._rate_limit_buckets: List[_RateLimitBucket] = []
         self._alert_usage_threshold = 0.85
         self._rate_alert_active = False
         self._alert_cooldown_seconds = 5.0
@@ -168,14 +203,21 @@ class ExchangeManager:
             except ValueError:
                 pass
 
+        require_demo = bool(getattr(config, "require_demo_mode", False))
+        if require_demo and not getattr(config, "testnet", True):
+            raise ExchangeError(
+                "Polityka bezpieczeństwa wymaga uruchomienia bota w trybie testnet/paper na tym etapie."
+            )
+
         # Konfiguracja limitów/alertów z configu
         per_minute = max(0, int(getattr(config, "rate_limit_per_minute", 0) or 0))
         window_seconds = float(getattr(config, "rate_limit_window_seconds", 60.0) or 60.0)
         manager._rate_limit_window = max(0.1, window_seconds)
-        manager._rate_limit_per_minute = per_minute or None
-        if per_minute > 0:
-            calls_per_window = per_minute * (manager._rate_limit_window / 60.0)
-            manager._max_calls_per_window = max(1, int(math.floor(calls_per_window)))
+        manager.configure_rate_limits(
+            per_minute=per_minute or None,
+            window_seconds=manager._rate_limit_window,
+            buckets=getattr(config, "rate_limit_buckets", None),
+        )
         manager._alert_usage_threshold = max(
             0.1,
             min(1.0, float(getattr(config, "rate_limit_alert_threshold", 0.85) or 0.85)),
@@ -189,52 +231,172 @@ class ExchangeManager:
             manager._min_interval = 0.0
         manager._window_start = time.monotonic()
         manager._window_count = 0
+        manager.set_retry_policy(
+            attempts=getattr(config, "retry_attempts", manager._retry_attempts),
+            delay=getattr(config, "retry_delay", manager._retry_delay),
+        )
         return manager
+
+    # --------------------------- konfiguracja ---------------------------
+    def set_retry_policy(self, *, attempts: int, delay: float) -> None:
+        """Skonfiguruj politykę ponawiania żądań."""
+
+        try:
+            attempts_int = max(0, int(attempts))
+        except Exception:
+            attempts_int = self._retry_attempts
+        try:
+            delay_float = max(0.0, float(delay))
+        except Exception:
+            delay_float = self._retry_delay
+        self._retry_attempts = attempts_int
+        self._retry_delay = delay_float
+
+    def configure_rate_limits(
+        self,
+        *,
+        per_minute: Optional[int] = None,
+        window_seconds: float = 60.0,
+        buckets: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> None:
+        """Zaktualizuj konfigurację limitów API i wyzeruj liczniki."""
+
+        self._rate_limit_window = max(0.1, float(window_seconds or 60.0))
+        self._rate_limit_per_minute = None
+        self._max_calls_per_window = None
+        new_buckets: List[_RateLimitBucket] = []
+
+        if per_minute:
+            try:
+                per_minute_int = max(0, int(per_minute))
+            except Exception:
+                per_minute_int = 0
+            if per_minute_int > 0:
+                calls_per_window = per_minute_int * (self._rate_limit_window / 60.0)
+                capacity = max(1, int(math.floor(calls_per_window)))
+                new_buckets.append(
+                    _RateLimitBucket(name="global", capacity=capacity, window_seconds=self._rate_limit_window)
+                )
+                self._rate_limit_per_minute = per_minute_int
+                self._max_calls_per_window = capacity
+
+        if buckets:
+            for raw in buckets:
+                if not isinstance(raw, dict):
+                    continue
+                name = str(raw.get("name") or f"bucket_{len(new_buckets) + 1}")
+                try:
+                    capacity = int(raw.get("capacity", 0))
+                    window = float(raw.get("window_seconds", 0.0))
+                except Exception:
+                    continue
+                if capacity <= 0 or window <= 0:
+                    continue
+                new_buckets.append(
+                    _RateLimitBucket(name=name, capacity=capacity, window_seconds=float(window))
+                )
+
+        if not new_buckets:
+            new_buckets.append(
+                _RateLimitBucket(
+                    name="unbounded",
+                    capacity=1_000_000_000,
+                    window_seconds=self._rate_limit_window,
+                )
+            )
+
+        self._rate_limit_buckets = new_buckets
+        self._reset_rate_windows()
+
+    def _reset_rate_windows(self) -> None:
+        now = time.monotonic()
+        self._window_start = now
+        self._window_count = 0
+        self._metrics.window_calls = 0
+        self._metrics.window_errors = 0
+        self._rate_alert_active = False
+        for bucket in self._rate_limit_buckets:
+            bucket.reset(now=now, hard=True)
+
+    def _ensure_rate_buckets(self) -> None:
+        if not self._rate_limit_buckets:
+            self._rate_limit_buckets = [
+                _RateLimitBucket(
+                    name="unbounded",
+                    capacity=1_000_000_000,
+                    window_seconds=self._rate_limit_window,
+                )
+            ]
 
     # --------------------------- operacje pomocnicze ---------------------------
     async def _before_call(self, endpoint: str) -> None:
         wait_time = 0.0
-        should_alert = False
-        usage_pct = 0.0
+        alerts: List[Tuple[str, Dict[str, Any], str]] = []
         async with self._throttle_lock:
             now = time.monotonic()
             if now - self._window_start >= self._rate_limit_window:
-                self._window_start = now
-                self._window_count = 0
-                self._metrics.window_calls = 0
-                self._metrics.window_errors = 0
-                self._rate_alert_active = False
-            if self._max_calls_per_window:
-                usage_pct = (self._window_count + 1) / self._max_calls_per_window
-                if self._window_count >= self._max_calls_per_window:
-                    wait_time = max(wait_time, self._rate_limit_window - (now - self._window_start))
-                if usage_pct >= self._alert_usage_threshold and not self._rate_alert_active:
-                    should_alert = True
-                    self._rate_alert_active = True
+                self._reset_rate_windows()
+
+            self._ensure_rate_buckets()
+
+            for bucket in self._rate_limit_buckets:
+                elapsed = now - bucket.window_start
+                if elapsed >= bucket.window_seconds:
+                    bucket.reset(now=now, hard=True)
+                    elapsed = 0.0
+
+                projected = bucket.count + 1
+                if bucket.capacity > 0:
+                    usage_pct = projected / bucket.capacity
+                else:
+                    usage_pct = 0.0
+                bucket.last_usage = min(usage_pct, 1.0 if bucket.capacity > 0 else usage_pct)
+                bucket.max_usage = max(bucket.max_usage, bucket.last_usage)
+
+                if bucket.capacity > 0 and bucket.count >= bucket.capacity:
+                    wait_time = max(wait_time, bucket.window_seconds - elapsed)
+
+                if (
+                    bucket.capacity > 0
+                    and usage_pct >= self._alert_usage_threshold
+                    and not bucket.alert_active
+                ):
+                    bucket.alert_active = True
+                    context = {
+                        "endpoint": endpoint,
+                        "bucket": bucket.name,
+                        "usage": bucket.last_usage,
+                        "capacity": bucket.capacity,
+                        "window_seconds": bucket.window_seconds,
+                        "reset_in_seconds": max(0.0, bucket.window_seconds - elapsed),
+                    }
+                    alerts.append(
+                        (
+                            f"Zużyto {bucket.last_usage * 100:.1f}% limitu API dla kubełka '{bucket.name}'.",
+                            context,
+                            f"rate_limit::{bucket.name}",
+                        )
+                    )
+
+                bucket.count = projected
+
+            if self._rate_limit_buckets:
+                self._window_count = self._rate_limit_buckets[0].count
+                self._rate_alert_active = any(bucket.alert_active for bucket in self._rate_limit_buckets)
+
             if self._min_interval > 0:
                 delta = now - self._last_request_ts
                 if delta < self._min_interval:
                     wait_time = max(wait_time, self._min_interval - delta)
-            self._window_count += 1
+
             self._metrics.window_calls = self._window_count
             self._last_request_ts = now + wait_time if wait_time > 0 else now
+
         if wait_time > 0:
             await asyncio.sleep(wait_time)
-        if should_alert and self._max_calls_per_window:
-            remaining = max(0.0, self._rate_limit_window - (time.monotonic() - self._window_start))
-            context = {
-                "endpoint": endpoint,
-                "usage": usage_pct,
-                "calls_in_window": self._window_count,
-                "max_calls": self._max_calls_per_window,
-                "window_seconds": self._rate_limit_window,
-                "reset_in_seconds": remaining,
-            }
-            self._raise_alert(
-                f"Zużyto {usage_pct * 100:.1f}% dostępnego limitu API w bieżącym oknie.",
-                context=context,
-                key="rate_limit",
-            )
+
+        for message, context, key in alerts:
+            self._raise_alert(message, context=context, key=key)
 
     def _record_metrics(self, endpoint: str, latency_ms: float, *, success: bool) -> None:
         metrics = self._metrics
@@ -636,11 +798,18 @@ class ExchangeManager:
         """Zarejestruj zewnętrzny handler alertów (np. GUI / moduł powiadomień)."""
         self._alert_callback = callback
 
+    def get_rate_limit_snapshot(self) -> List[Dict[str, Any]]:
+        """Szybki podgląd stanu kubełków limitów API."""
+
+        return [bucket.snapshot() for bucket in self._rate_limit_buckets]
+
     def get_api_metrics(self) -> Dict[str, Any]:
         """Zwróć metryki zużycia API (łącznie i per-endpoint)."""
         usage = None
         if self._max_calls_per_window:
-            usage = self._window_count / self._max_calls_per_window if self._max_calls_per_window else None
+            if self._max_calls_per_window:
+                usage = self._window_count / self._max_calls_per_window
+        buckets_snapshot = [bucket.snapshot() for bucket in self._rate_limit_buckets]
         return {
             "total_calls": self._metrics.total_calls,
             "total_errors": self._metrics.total_errors,
@@ -654,6 +823,7 @@ class ExchangeManager:
             "rate_limit_per_minute": self._rate_limit_per_minute,
             "rate_limit_window_seconds": self._rate_limit_window,
             "current_window_usage": usage,
+            "rate_limit_buckets": buckets_snapshot,
             "endpoints": {name: asdict(data) for name, data in self._endpoint_metrics.items()},
         }
 
@@ -661,10 +831,6 @@ class ExchangeManager:
         """Wyzeruj liczniki metryk (np. po raporcie)."""
         self._metrics = _APIMetrics()
         self._endpoint_metrics = defaultdict(lambda: _EndpointMetrics())
-        self._window_count = 0
-        self._metrics.window_calls = 0
-        self._metrics.window_errors = 0
         self._metrics.consecutive_errors = 0
-        self._window_start = time.monotonic()
-        self._rate_alert_active = False
         self._alert_last.clear()
+        self._reset_rate_windows()

--- a/KryptoLowca/logging_utils.py
+++ b/KryptoLowca/logging_utils.py
@@ -1,0 +1,78 @@
+"""Utilities for consistent logging configuration across the bot.
+
+This module centralises setup of rotating file handlers so that every
+component (GUI, background workers, integration tests) writes to the same
+log files without growing indefinitely.  Importing :func:`get_logger`
+ensures the handler exists and can be reused safely.
+"""
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional, Union
+
+# Repository root (folder that contains this module)
+_APP_ROOT = Path(__file__).resolve().parent
+LOGS_DIR = _APP_ROOT / "logs"
+LOGS_DIR.mkdir(parents=True, exist_ok=True)
+DEFAULT_LOG_FILE = LOGS_DIR / "trading.log"
+
+
+def _ensure_rotating_handler(
+    logger: logging.Logger,
+    log_file: Union[str, Path] = DEFAULT_LOG_FILE,
+    max_bytes: int = 2_000_000,
+    backup_count: int = 5,
+) -> None:
+    """Attach a RotatingFileHandler to ``logger`` if missing."""
+    log_path = Path(log_file)
+    identifier = "_krypto_rotating_handler"
+
+    for handler in logger.handlers:
+        if getattr(handler, identifier, False):
+            return
+
+    handler = RotatingFileHandler(
+        log_path,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        encoding="utf-8",
+    )
+    handler.setFormatter(
+        logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
+    )
+    setattr(handler, identifier, True)
+    logger.addHandler(handler)
+
+
+def setup_app_logging(
+    log_file: Union[str, Path] = DEFAULT_LOG_FILE,
+    level: int = logging.INFO,
+    max_bytes: int = 2_000_000,
+    backup_count: int = 5,
+) -> logging.Logger:
+    """Configure and return the shared application logger."""
+    root = logging.getLogger("KryptoLowca")
+    if getattr(root, "_krypto_logging_configured", False):
+        return root
+
+    _ensure_rotating_handler(root, log_file=log_file, max_bytes=max_bytes, backup_count=backup_count)
+    root.setLevel(level)
+    root.propagate = True
+    setattr(root, "_krypto_logging_configured", True)
+    return root
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger that uses the shared rotating handler."""
+    setup_app_logging()
+    return logging.getLogger(name if name else "KryptoLowca")
+
+
+__all__ = [
+    "LOGS_DIR",
+    "DEFAULT_LOG_FILE",
+    "get_logger",
+    "setup_app_logging",
+]

--- a/KryptoLowca/managers/config_manager.py
+++ b/KryptoLowca/managers/config_manager.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 import json
 import logging
 import re
+from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
@@ -202,6 +204,8 @@ class ConfigManager:
         self.presets_dir = Path(presets_dir)
         self.presets_dir.mkdir(parents=True, exist_ok=True)
         logger.info("ConfigManager: katalog presetów = %s", self.presets_dir)
+        self._demo_required = True
+        self._default_template = ConfigPreset().to_dict()
 
     # --- walidacja ---
     def validate_preset(self, data: Dict[str, Any]) -> ConfigPreset:
@@ -215,6 +219,60 @@ class ConfigManager:
             )
             raise ValueError(f"Preset validation failed: {errors}") from exc
         return preset
+
+    def require_demo_mode(self, required: bool = True) -> None:
+        """Włącz/wyłącz wymóg zapisu presetów w trybie demo."""
+
+        self._demo_required = bool(required)
+
+    def demo_mode_required(self) -> bool:
+        """Zwraca informację, czy polityka bezpieczeństwa wymaga trybu demo."""
+
+        return self._demo_required
+
+    @staticmethod
+    def _merge_nested(base: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:
+        result = deepcopy(base)
+        for key, value in overrides.items():
+            if isinstance(value, dict) and isinstance(result.get(key), dict):
+                result[key] = ConfigManager._merge_nested(result[key], value)
+            else:
+                result[key] = value
+        return result
+
+    def audit_preset(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Przeprowadź szybki audyt bezpieczeństwa i ryzyka dla presetu."""
+
+        preset = self.validate_preset(data)
+        issues: List[str] = []
+        warnings: List[str] = []
+
+        is_demo = preset.network.lower() == "testnet"
+        if self._demo_required and not is_demo:
+            issues.append(
+                "Preset wymaga trybu Testnet zgodnie z polityką bezpieczeństwa. Zmień pole 'network' na 'Testnet'."
+            )
+        if preset.network.lower() == "live":
+            warnings.append(
+                "Przed uruchomieniem na Live wykonaj pełne testy na koncie demo i upewnij się, że klucze API mają ograniczone uprawnienia."
+            )
+        if preset.fraction > 0.5:
+            warnings.append("Frakcja kapitału przekracza 50% – rozważ niższą wartość dla redukcji ryzyka.")
+        if preset.risk.max_daily_loss_pct > 0.2:
+            warnings.append(
+                "Parametr max_daily_loss_pct przekracza 20% – może naruszać zasady zarządzania ryzykiem."
+            )
+        if preset.paper.capital < 500:
+            warnings.append("Kapitał paper trading < 500 – wyniki backtestu mogą być mało reprezentatywne.")
+
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "network": preset.network,
+            "issues": issues,
+            "warnings": warnings,
+            "demo_required": self._demo_required,
+            "is_demo": is_demo,
+        }
 
     # --- ścieżki ---
     def _path_yaml(self, safe_name: str) -> Path:
@@ -239,6 +297,11 @@ class ConfigManager:
             raise ValueError("Preset musi być słownikiem (dict).")
 
         preset = self.validate_preset(data)
+        if self._demo_required and preset.network.lower() != "testnet":
+            raise ValueError(
+                "Polityka bezpieczeństwa wymaga tworzenia presetów w trybie Testnet. "
+                "Zmień pole 'network' na 'Testnet' lub wyłącz ten wymóg metodą require_demo_mode(False)."
+            )
         payload = preset.to_dict()
 
         if _HAS_YAML:
@@ -256,6 +319,41 @@ class ConfigManager:
             json.dump(payload, f, ensure_ascii=False, indent=2)
         logger.info("Zapisano preset JSON: %s", path)
         return path
+
+    def create_preset(
+        self,
+        name: str,
+        *,
+        base: Optional[str] = None,
+        overrides: Optional[Dict[str, Any]] = None,
+        ensure_demo: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Stwórz preset na bazie szablonu i nadpisów, zwracając raport audytu."""
+
+        payload = deepcopy(self._default_template)
+        if base:
+            base_payload = self.load_preset(base)
+            payload = ConfigManager._merge_nested(payload, base_payload)
+        if overrides:
+            payload = ConfigManager._merge_nested(payload, overrides)
+
+        preset = self.validate_preset(payload)
+        require_demo = self._demo_required if ensure_demo is None else bool(ensure_demo)
+        if require_demo and preset.network.lower() != "testnet":
+            preset = preset.copy(update={"network": "Testnet"})
+
+        audit = self.audit_preset(preset.to_dict())
+        if require_demo and audit["issues"]:
+            # Próba zapisu bez trybu demo – blokujemy zanim powstanie plik.
+            raise ValueError(audit["issues"][0])
+
+        path = self.save_preset(name, preset.to_dict())
+        audit.update({
+            "name": name,
+            "path": str(path),
+        })
+        audit["preset"] = preset.to_dict()
+        return audit
 
     def load_preset(self, name: str) -> Dict[str, Any]:
         safe = _sanitize_name(name)
@@ -281,6 +379,11 @@ class ConfigManager:
         payload = preset.to_dict()
         logger.info("Załadowano preset %s (znormalizowany)", path)
         return payload
+
+    def preset_wizard(self) -> "PresetWizard":
+        """Utwórz kreator presetów ułatwiający stopniowe budowanie konfiguracji."""
+
+        return PresetWizard(self)
 
     # --- dodatki przydatne w GUI ---
     def list_presets(self) -> List[str]:
@@ -311,6 +414,75 @@ class ConfigManager:
         return p if p is not None else self._path_yaml(safe)
 
 
+class PresetWizard:
+    """Prosty kreator presetów wspierający profile ryzyka i kontrolę demo."""
+
+    def __init__(self, manager: ConfigManager) -> None:
+        self._manager = manager
+        self._base: Optional[str] = None
+        self._overrides: Dict[str, Any] = {}
+        self._ensure_demo: Optional[bool] = None
+
+    def from_template(self, name: str) -> "PresetWizard":
+        self._base = name
+        return self
+
+    def with_symbols(self, symbols: Iterable[str]) -> "PresetWizard":
+        cleaned: List[str] = []
+        for sym in symbols:
+            if not isinstance(sym, str):
+                continue
+            normalised = sym.strip().upper()
+            if normalised and normalised not in cleaned:
+                cleaned.append(normalised)
+        if cleaned:
+            self._overrides["selected_symbols"] = cleaned
+        return self
+
+    def with_risk_profile(self, profile: str) -> "PresetWizard":
+        presets = {
+            "conservative": {
+                "fraction": 0.1,
+                "risk": {"max_daily_loss_pct": 0.04, "risk_per_trade": 0.01},
+            },
+            "balanced": {
+                "fraction": 0.2,
+                "risk": {"max_daily_loss_pct": 0.08, "risk_per_trade": 0.02},
+            },
+            "aggressive": {
+                "fraction": 0.35,
+                "risk": {"max_daily_loss_pct": 0.15, "risk_per_trade": 0.04},
+            },
+        }
+        key = profile.strip().lower()
+        if key not in presets:
+            raise ValueError(f"Nieznany profil ryzyka: {profile}")
+        self._overrides = ConfigManager._merge_nested(self._overrides, presets[key])
+        return self
+
+    def ensure_demo(self, required: bool = True) -> "PresetWizard":
+        self._ensure_demo = required
+        return self
+
+    def override(self, **kwargs: Any) -> "PresetWizard":
+        if kwargs:
+            self._overrides = ConfigManager._merge_nested(self._overrides, kwargs)
+        return self
+
+    def build(self, name: str) -> Dict[str, Any]:
+        audit = self._manager.create_preset(
+            name,
+            base=self._base,
+            overrides=self._overrides or None,
+            ensure_demo=self._ensure_demo,
+        )
+        # reset stanu aby kreator można było użyć ponownie
+        self._base = None
+        self._overrides = {}
+        self._ensure_demo = None
+        return audit
+
+
 __all__ = [
     "ConfigManager",
     "ConfigPreset",
@@ -320,4 +492,5 @@ __all__ = [
     "SlippageSettings",
     "AdvancedSettings",
     "PaperSettings",
+    "PresetWizard",
 ]

--- a/KryptoLowca/managers/security_manager.py
+++ b/KryptoLowca/managers/security_manager.py
@@ -21,8 +21,9 @@ import json
 import base64
 import logging
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes, constant_time
@@ -35,6 +36,15 @@ if not logger.handlers:
     _h.setFormatter(logging.Formatter('[%(asctime)s] %(name)s - %(levelname)s - %(message)s'))
     logger.addHandler(_h)
 logger.setLevel(logging.INFO)
+
+audit_logger = logging.getLogger(f"{__name__}.audit")
+if not audit_logger.handlers:
+    _audit_handler = logging.StreamHandler()
+    _audit_handler.setFormatter(
+        logging.Formatter('[%(asctime)s] SECURITY-AUDIT %(levelname)s: %(message)s')
+    )
+    audit_logger.addHandler(_audit_handler)
+audit_logger.setLevel(logging.INFO)
 
 
 class SecurityError(Exception):
@@ -81,6 +91,7 @@ class SecurityManager:
         self.aws_secret_id = aws_secret_id
         self.aws_region_name = aws_region_name
         self._lock = threading.RLock()
+        self._audit_callback: Optional[Callable[[str, Dict[str, Any]], None]] = None
 
         # AWS opcjonalnie
         self._aws_available = False
@@ -204,6 +215,35 @@ class SecurityManager:
             raise SecurityError("You must specify a region.")
         return self._boto3.client("secretsmanager", region_name=region)
 
+    # --------------------- Audyt bezpieczeństwa ---------------------
+    def register_audit_callback(self, callback: Callable[[str, Dict[str, Any]], None]) -> None:
+        """Pozwala GUI/bazie na rejestrowanie zdarzeń audytowych (odszyfrowanie kluczy)."""
+
+        self._audit_callback = callback
+
+    def _emit_audit_event(self, action: str, **context: Any) -> None:
+        payload: Dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "action": action,
+            "backend": self.backend,
+        }
+        if self.backend == "local":
+            payload["key_file"] = str(self.key_file)
+        if self.backend == "aws" and self.aws_secret_id:
+            payload["secret_id"] = self.aws_secret_id
+        for key, value in context.items():
+            if key in {"secret", "secrets", "payload"}:
+                continue
+            payload[key] = value
+
+        safe_payload = {k: v for k, v in payload.items() if k != "action"}
+        audit_logger.info("%s %s", action.upper(), safe_payload)
+        if self._audit_callback:
+            try:
+                self._audit_callback(action, payload)
+            except Exception:  # pragma: no cover - callback nie powinien psuć logiki
+                logger.exception("Security audit callback zgłosił wyjątek")
+
     # --------------------- API PUBLICZNE ---------------------
 
     def save_encrypted_keys(self, keys: Dict[str, Any], password: str) -> None:
@@ -232,15 +272,32 @@ class SecurityManager:
                         SecretString=payload.decode("utf-8"),
                     )
                     logger.info("API keys saved to AWS Secrets Manager")
+                    self._emit_audit_event(
+                        "encrypt_keys",
+                        backend="aws",
+                        keys=list(keys.keys()),
+                        status="success",
+                    )
                 else:
                     # LOCAL
                     enc = self._local_encrypt(payload, password)
                     self.key_file.write_bytes(enc)
                     logger.info(f"API keys saved locally to {self.key_file}")
+                    self._emit_audit_event(
+                        "encrypt_keys",
+                        backend="local",
+                        keys=list(keys.keys()),
+                        status="success",
+                    )
             except SecurityError:
                 raise
             except Exception as e:
                 logger.error(f"Failed to save keys: {e}")
+                self._emit_audit_event(
+                    "encrypt_keys_failed",
+                    error=str(e),
+                    backend=self.backend,
+                )
                 raise SecurityError(f"Failed to save keys: {e}") from e
 
     def load_encrypted_keys(self, password: str) -> Dict[str, Any]:
@@ -269,6 +326,12 @@ class SecurityManager:
                     if not isinstance(data, dict):
                         raise SecurityError("Invalid key format in AWS secret")
                     logger.info("API keys loaded from AWS Secrets Manager")
+                    self._emit_audit_event(
+                        "decrypt_keys",
+                        backend="aws",
+                        keys=list(data.keys()),
+                        status="success",
+                    )
                     return data
 
                 # LOCAL
@@ -282,8 +345,19 @@ class SecurityManager:
                 if not isinstance(data, dict):
                     raise SecurityError("Invalid key format")
                 logger.info("API keys loaded from local file")
+                self._emit_audit_event(
+                    "decrypt_keys",
+                    backend="local",
+                    keys=list(data.keys()),
+                    status="success",
+                )
                 return data
             except SecurityError:
+                self._emit_audit_event(
+                    "decrypt_keys_failed",
+                    backend=self.backend,
+                    error="SecurityError",
+                )
                 raise
             except Exception as e:
                 # ujednolicone komunikaty dla GUI
@@ -291,4 +365,9 @@ class SecurityManager:
                 if "region" in msg.lower():
                     msg = "You must specify a region."
                 logger.error(f"Failed to load keys: {msg}")
+                self._emit_audit_event(
+                    "decrypt_keys_failed",
+                    backend=self.backend,
+                    error=msg,
+                )
                 raise SecurityError(f"Failed to load keys: {msg}") from e

--- a/KryptoLowca/tests/test_auto_trader.py
+++ b/KryptoLowca/tests/test_auto_trader.py
@@ -1,0 +1,101 @@
+"""Tests for safety guards in AutoTrader."""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable, Dict, List, Tuple
+
+import pytest
+
+from KryptoLowca.auto_trader import AutoTrader
+
+
+class DummyEmitter:
+    def __init__(self) -> None:
+        self.logs: List[Tuple[str, str, str]] = []
+
+    def on(self, *_, **__) -> None:  # pragma: no cover - interface placeholder
+        return None
+
+    def off(self, *_, **__) -> None:  # pragma: no cover - interface placeholder
+        return None
+
+    def emit(self, event: str, **payload: Any) -> None:
+        self.logs.append(("event", event, str(payload)))
+
+    def log(self, message: str, level: str = "INFO", component: str | None = None) -> None:
+        self.logs.append(("log", level, message))
+
+
+class DummyVar:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def get(self) -> str:
+        return self._value
+
+
+class NoSignalAI:
+    ai_threshold_bps = 5.0
+
+    def predict_series(self, *_, **__) -> None:
+        return None
+
+
+class DummyGUI:
+    def __init__(self, demo: bool, allow_live: bool) -> None:
+        self.timeframe_var = DummyVar("1m")
+        self.ai_mgr = NoSignalAI()
+        self.ex_mgr = self
+        self._demo = demo
+        self._allow_live = allow_live
+        self.executed: List[Tuple[str, str, float]] = []
+
+    def is_demo_mode_active(self) -> bool:
+        return self._demo
+
+    def is_live_trading_allowed(self) -> bool:
+        return self._allow_live
+
+    def _bridge_execute_trade(self, symbol: str, side: str, price: float) -> None:
+        self.executed.append((symbol, side, price))
+
+    # Exchange-like API -------------------------------------------------
+    def fetch_ticker(self, symbol: str) -> Dict[str, float]:
+        return {"last": 100.0}
+
+
+@pytest.fixture()
+def demo_autotrader() -> Callable[[DummyGUI], AutoTrader]:
+    def factory(gui: DummyGUI) -> AutoTrader:
+        emitter = DummyEmitter()
+        trader = AutoTrader(emitter, gui, lambda: "BTC/USDT", auto_trade_interval_s=0.01)
+        trader.enable_auto_trade = True
+        return trader
+
+    return factory
+
+
+def _run_loop(trader: AutoTrader, duration: float = 0.1) -> None:
+    worker = threading.Thread(target=trader._auto_trade_loop, daemon=True)
+    worker.start()
+    time.sleep(duration)
+    trader._stop.set()
+    worker.join(timeout=1.0)
+    trader.stop()
+
+
+def test_no_fallback_trade_without_signal(demo_autotrader: Callable[[DummyGUI], AutoTrader]) -> None:
+    gui = DummyGUI(demo=True, allow_live=True)
+    trader = demo_autotrader(gui)
+    _run_loop(trader)
+    assert gui.executed == []
+    assert any("no valid model signal" in msg for kind, _, msg in trader.emitter.logs if kind == "log")
+
+
+def test_live_trading_blocked_without_confirmation(demo_autotrader: Callable[[DummyGUI], AutoTrader]) -> None:
+    gui = DummyGUI(demo=False, allow_live=False)
+    trader = demo_autotrader(gui)
+    _run_loop(trader)
+    assert gui.executed == []
+    assert any("live trading requires explicit confirmation" in msg for kind, _, msg in trader.emitter.logs if kind == "log")

--- a/KryptoLowca/tests/test_security_manager.py
+++ b/KryptoLowca/tests/test_security_manager.py
@@ -3,45 +3,77 @@
 """
 Unit tests for security_manager.py.
 """
-import pytest
-import json
+from __future__ import annotations
+
 from pathlib import Path
-from KryptoLowca.managers.security_manager import SecurityManager, SecurityError
-from cryptography.fernet import InvalidToken
+from typing import List, Tuple
+
+import pytest
+
+from KryptoLowca.managers.security_manager import SecurityError, SecurityManager
+
 
 @pytest.fixture
-def security_manager(tmp_path):
+def security_manager(tmp_path: Path) -> SecurityManager:
     key_file = tmp_path / "keys.enc"
     return SecurityManager(key_file=str(key_file))
 
-def test_save_and_load_keys(security_manager, tmp_path):
+
+def test_save_and_load_keys(security_manager: SecurityManager) -> None:
     keys = {
         "testnet": {"key": "test_key", "secret": "test_secret"},
-        "live": {"key": "live_key", "secret": "live_secret"}
+        "live": {"key": "live_key", "secret": "live_secret"},
     }
     password = "password123"
-    
+
     security_manager.save_encrypted_keys(keys, password)
     assert security_manager.key_file.exists()
-    
+
     loaded_keys = security_manager.load_encrypted_keys(password)
     assert loaded_keys == keys
 
-def test_invalid_password(security_manager):
+
+def test_invalid_password(security_manager: SecurityManager) -> None:
     keys = {"testnet": {"key": "test_key", "secret": "test_secret"}}
     security_manager.save_encrypted_keys(keys, "password123")
-    
+
     with pytest.raises(SecurityError, match="Invalid password"):
         security_manager.load_encrypted_keys("wrong_password")
 
-def test_missing_key_file(security_manager):
+
+def test_missing_key_file(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Key file .* not found"):
         security_manager.load_encrypted_keys("password123")
 
-def test_invalid_keys(security_manager):
+
+def test_invalid_keys(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Keys must be a non-empty dictionary"):
         security_manager.save_encrypted_keys({}, "password123")
 
-def test_invalid_password_type(security_manager):
+
+def test_invalid_password_type(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Password must be a non-empty string"):
         security_manager.save_encrypted_keys({"testnet": {"key": "k", "secret": "s"}}, "")
+
+
+def test_audit_callback_records_events(security_manager: SecurityManager) -> None:
+    events: List[Tuple[str, dict]] = []
+
+    def _callback(action: str, payload: dict) -> None:
+        events.append((action, payload))
+
+    security_manager.register_audit_callback(_callback)
+
+    keys = {
+        "testnet": {"key": "T" * 32, "secret": "S" * 32},
+        "live": {"key": "L" * 32, "secret": "Z" * 32},
+    }
+    password = "audit-pass"
+
+    security_manager.save_encrypted_keys(keys, password)
+    loaded = security_manager.load_encrypted_keys(password)
+
+    assert loaded == keys
+    actions = [action for action, _ in events]
+    assert "encrypt_keys" in actions
+    assert "decrypt_keys" in actions

--- a/KryptoLowca/trading_gui.py
+++ b/KryptoLowca/trading_gui.py
@@ -46,17 +46,26 @@ except Exception:
 
 # --- LOGGING ---
 import logging
-logger = logging.getLogger(__name__)
-if not logger.handlers:
-    h = logging.StreamHandler(sys.stdout)
-    h.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
-    logger.addHandler(h)
+from KryptoLowca.logging_utils import (
+    LOGS_DIR as GLOBAL_LOGS_DIR,
+    DEFAULT_LOG_FILE,
+    get_logger,
+    setup_app_logging,
+)
+
+setup_app_logging()
+logger = get_logger(__name__)
+if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
+    logger.addHandler(stream_handler)
 logger.setLevel(logging.INFO)
 
 # --- ŚCIEŻKI APLIKACJI ---
 APP_ROOT = Path(__file__).resolve().parent
-LOGS_DIR = APP_ROOT / "logs"; LOGS_DIR.mkdir(parents=True, exist_ok=True)
-TEXT_LOG_FILE = LOGS_DIR / "trading.log"
+LOGS_DIR = GLOBAL_LOGS_DIR
+LOGS_DIR.mkdir(parents=True, exist_ok=True)
+TEXT_LOG_FILE = DEFAULT_LOG_FILE
 DB_FILE = APP_ROOT / "trading_bot.db"
 OPEN_POS_FILE = APP_ROOT / "open_positions.json"
 FAV_FILE = APP_ROOT / "favorites.json"
@@ -169,6 +178,7 @@ class TradingGUI:
         self.paper_balance = self.paper_capital.get()
         self.paper_balance_var = tk.StringVar(value=f"{self.paper_balance:,.2f}")
         self.account_balance_var = tk.StringVar(value="— (Live only)")
+        self._live_trading_confirmed = False
 
         # AI
         self.enable_ai_var = tk.BooleanVar(value=False)
@@ -449,12 +459,13 @@ class TradingGUI:
 
     # --------------- LOGS ---------------
     def _log(self, msg: str, level: str = "INFO"):
-        # 1) UI + plik teksowy
-        line = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {level}: {msg}\n"
+        level_name = (level or "INFO").upper()
+        log_level = getattr(logging, level_name, logging.INFO)
+        logger.log(log_level, msg)
+
+        # 1) UI log window
+        line = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {level_name}: {msg}\n"
         try: self.log_text.insert("end", line); self.log_text.see("end")
-        except Exception: pass
-        try:
-            with open(TEXT_LOG_FILE, "a", encoding="utf-8") as f: f.write(line)
         except Exception: pass
 
         # 2) DB (obsługa sync/async + różnych sygnatur)
@@ -752,7 +763,14 @@ class TradingGUI:
 
     # ===================== Handlery =====================
     def _on_network_changed(self):
-        self.account_balance_var.set("…" if self.network_var.get()=="Live" else "— (Live only)")
+        net = self.network_var.get()
+        self.account_balance_var.set("…" if net == "Live" else "— (Live only)")
+        self._reset_live_confirmation()
+        if net == "Live":
+            self._log(
+                "Tryb LIVE: przed uruchomieniem handlu wykonaj pełne testy na koncie demo/testnet i przygotuj plan zarządzania ryzykiem.",
+                "WARNING",
+            )
 
     def _on_ai_threshold_changed(self):
         try:
@@ -845,11 +863,64 @@ class TradingGUI:
         self.selected_symbols = [s for s,v in self.symbol_vars.items() if v.get()]
         self._log(f"Applied {len(self.selected_symbols)} symbols", "INFO")
 
+    # Safety helpers -------------------------------------------------
+    def is_demo_mode_active(self) -> bool:
+        try:
+            network = (self.network_var.get() or "").strip().lower()
+            return network != "live"
+        except Exception:
+            return True
+
+    def is_live_trading_allowed(self) -> bool:
+        return bool(self._live_trading_confirmed)
+
+    def _has_valid_live_keys(self) -> bool:
+        key = (self.live_key.get() or "").strip()
+        secret = (self.live_secret.get() or "").strip()
+        if not key or not secret:
+            return False
+        try:
+            return SecurityManager.validate_api_key(key) and SecurityManager.validate_api_key(secret)
+        except Exception:
+            return False
+
+    def _reset_live_confirmation(self) -> None:
+        self._live_trading_confirmed = False
+
+    def _ensure_live_trading_prerequisites(self) -> bool:
+        if self.is_demo_mode_active():
+            return True
+
+        if not self._has_valid_live_keys():
+            messagebox.showwarning(
+                "Klucze API",
+                "Przed uruchomieniem handlu LIVE uzupełnij poprawne klucze API i upewnij się, "
+                "że konto ma włączone limity bezpieczeństwa. Na tym etapie zalecamy kontynuację w trybie demo/testnet.",
+            )
+            self._log("Live trading blocked: missing or invalid API keys.", "WARNING")
+            return False
+
+        if not self._live_trading_confirmed:
+            proceed = messagebox.askyesno(
+                "Potwierdzenie handlu LIVE",
+                "Handel na żywym rynku wiąże się z ryzykiem utraty środków. Bot jest w fazie rozwoju — uruchamiaj go wyłącznie po "
+                "pełnym przetestowaniu na koncie demo/testnet i upewnij się, że spełniasz wymogi KYC/AML swojej giełdy.\n\nCzy na pewno chcesz kontynuować?",
+            )
+            if not proceed:
+                self._log("Live trading start cancelled przez użytkownika.", "WARNING")
+                return False
+            self._live_trading_confirmed = True
+            self._log("Live trading confirmed przez użytkownika. Zachowaj ostrożność i monitoruj transakcje.", "WARNING")
+
+        return True
+
     # Start/Stop
     def _on_start(self):
         if self._worker_thread and self._worker_thread.is_alive(): return
         if not self.selected_symbols:
             messagebox.showwarning("No symbols", "Zaznacz symbole (po lewej) i kliknij Apply selection.")
+            return
+        if not self._ensure_live_trading_prerequisites():
             return
         self._run_flag.set()
         self._worker_thread = threading.Thread(target=self._worker, daemon=True)


### PR DESCRIPTION
## Summary
- add a shared logging utility with rotating file support and hook it into the GUI for consistent log handling
- harden AutoTrader by removing the demo fallback trades, enforcing live-mode confirmation and improving exception logging
- guard the GUI against accidental live trading by validating API keys, requiring explicit consent and surfacing warnings
- cover the new safeguards with unit tests for AutoTrader

## Testing
- pytest KryptoLowca/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d598f15558832aae1a56aaf34e509b