### PR TITLE
Add telemetry persistence, config versioning, and risk logging

### DIFF
--- a/KryptoLowca/config_manager.py
+++ b/KryptoLowca/config_manager.py
@@ -96,6 +96,10 @@ class ExchangeConfig:
     rate_limit_window_seconds: float = 60.0
     rate_limit_alert_threshold: float = 0.85
     error_alert_threshold: int = 3
+    rate_limit_buckets: List[Dict[str, Any]] = field(default_factory=list)
+    retry_attempts: int = 1
+    retry_delay: float = 0.05
+    require_demo_mode: bool = True
 
     def validate(self) -> "ExchangeConfig":
         if not self.exchange_name:
@@ -108,6 +112,26 @@ class ExchangeConfig:
             raise ValidationError("rate_limit_alert_threshold musi być w zakresie (0, 1]")
         if self.error_alert_threshold <= 0:
             raise ValidationError("error_alert_threshold musi być dodatnie")
+        if self.retry_attempts < 0:
+            raise ValidationError("retry_attempts musi być >= 0")
+        if self.retry_delay < 0:
+            raise ValidationError("retry_delay musi być >= 0")
+        if not isinstance(self.rate_limit_buckets, list):
+            raise ValidationError("rate_limit_buckets musi być listą")
+        cleaned_buckets: List[Dict[str, Any]] = []
+        for bucket in self.rate_limit_buckets:
+            if not isinstance(bucket, dict):
+                continue
+            capacity = int(bucket.get("capacity", 0))
+            window = float(bucket.get("window_seconds", 0.0))
+            if capacity <= 0 or window <= 0:
+                continue
+            name = str(bucket.get("name") or f"bucket_{len(cleaned_buckets) + 1}")
+            cleaned_buckets.append({"name": name, "capacity": capacity, "window_seconds": window})
+        self.rate_limit_buckets = cleaned_buckets
+        self.retry_attempts = int(self.retry_attempts)
+        self.retry_delay = float(self.retry_delay)
+        self.require_demo_mode = bool(self.require_demo_mode)
         return self
 
 

--- a/KryptoLowca/database_manager.py
+++ b/KryptoLowca/database_manager.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Warstwa kompatybilności z historycznym API ``database_manager``.
+"""Warstwa zgodności dla menedżera bazy danych.
 
-Nowa implementacja znajduje się w ``managers.database_manager``. Ten plik
-zapewnia jedynie przyjazne aliasy (``DBOptions``) oraz ujednolicone wyjątki,
-tak aby starsze testy oraz skrypty mogły działać bez zmian.
+Nowa implementacja znajduje się w ``managers.database_manager``. Ten moduł
+zapewnia przyjazne aliasy (``DBOptions``) oraz ujednolicone wyjątki, tak aby
+starsze testy oraz skrypty mogły działać bez zmian.
 """
 from __future__ import annotations
 

--- a/KryptoLowca/logging_utils.py
+++ b/KryptoLowca/logging_utils.py
@@ -1,0 +1,78 @@
+"""Utilities for consistent application logging.
+
+This module centralises setup of rotating file handlers so that every
+component (GUI, background workers, integration tests) writes to the same
+log files without growing indefinitely. Importing :func:`get_logger`
+ensures the handler exists and can be reused safely.
+"""
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional, Union
+
+# Repository root (folder that contains this module)
+_APP_ROOT = Path(__file__).resolve().parent
+LOGS_DIR = _APP_ROOT / "logs"
+LOGS_DIR.mkdir(parents=True, exist_ok=True)
+DEFAULT_LOG_FILE = LOGS_DIR / "trading.log"
+
+
+def _ensure_rotating_handler(
+    logger: logging.Logger,
+    log_file: Union[str, Path] = DEFAULT_LOG_FILE,
+    max_bytes: int = 2_000_000,
+    backup_count: int = 5,
+) -> None:
+    """Attach a RotatingFileHandler to ``logger`` if missing."""
+    log_path = Path(log_file)
+    identifier = "_krypto_rotating_handler"
+
+    for handler in logger.handlers:
+        if getattr(handler, identifier, False):
+            return
+
+    handler = RotatingFileHandler(
+        log_path,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        encoding="utf-8",
+    )
+    handler.setFormatter(
+        logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
+    )
+    setattr(handler, identifier, True)
+    logger.addHandler(handler)
+
+
+def setup_app_logging(
+    log_file: Union[str, Path] = DEFAULT_LOG_FILE,
+    level: int = logging.INFO,
+    max_bytes: int = 2_000_000,
+    backup_count: int = 5,
+) -> logging.Logger:
+    """Configure and return the shared application logger."""
+    root = logging.getLogger("KryptoLowca")
+    if getattr(root, "_krypto_logging_configured", False):
+        return root
+
+    _ensure_rotating_handler(root, log_file=log_file, max_bytes=max_bytes, backup_count=backup_count)
+    root.setLevel(level)
+    root.propagate = True
+    setattr(root, "_krypto_logging_configured", True)
+    return root
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger that uses the shared rotating handler."""
+    setup_app_logging()
+    return logging.getLogger(name if name else "KryptoLowca")
+
+
+__all__ = [
+    "LOGS_DIR",
+    "DEFAULT_LOG_FILE",
+    "get_logger",
+    "setup_app_logging",
+]

--- a/KryptoLowca/managers/database_manager.py
+++ b/KryptoLowca/managers/database_manager.py
@@ -36,7 +36,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncIterator, Dict, List, Optional, Union
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ValidationError, field_validator
 
@@ -64,7 +64,6 @@ if not logger.handlers:
     ))
     logger.addHandler(_h)
 logger.setLevel(logging.INFO)
-
 
 # --- SQLAlchemy Base ---
 class Base(DeclarativeBase):
@@ -168,6 +167,41 @@ class LogEntry(Base):
         Index("ix_logs_source_ts", "source", "ts"),
         Index("ix_logs_level_ts", "level", "ts"),
         Index("ix_logs_user_ts", "user_id", "ts"),
+    )
+
+
+class PerformanceMetric(Base):
+    __tablename__ = "performance_metrics"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    ts: Mapped[dt.datetime] = mapped_column(DateTime, default=dt.datetime.utcnow, index=True)
+    metric: Mapped[str] = mapped_column(String(64), index=True)
+    value: Mapped[float] = mapped_column(Float)
+    window: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    symbol: Mapped[Optional[str]] = mapped_column(String(50), index=True, nullable=True)
+    mode: Mapped[str] = mapped_column(String(10), default="live", index=True)
+    extra: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("ix_performance_metric_metric_ts", "metric", "ts"),
+        Index("ix_performance_metric_symbol_ts", "symbol", "ts"),
+    )
+
+
+class RiskLimitSnapshot(Base):
+    __tablename__ = "risk_limits"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    ts: Mapped[dt.datetime] = mapped_column(DateTime, default=dt.datetime.utcnow, index=True)
+    symbol: Mapped[str] = mapped_column(String(50), index=True)
+    max_fraction: Mapped[float] = mapped_column(Float)
+    recommended_size: Mapped[float] = mapped_column(Float)
+    mode: Mapped[str] = mapped_column(String(10), default="live", index=True)
+    details: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("ix_risk_limits_symbol_ts", "symbol", "ts"),
+        Index("ix_risk_limits_mode_ts", "mode", "ts"),
     )
 
 
@@ -276,6 +310,55 @@ class EquityIn(BaseModel):
         return v
 
 
+class PerformanceMetricIn(BaseModel):
+    metric: str
+    value: float
+    window: int | None = None
+    symbol: str | None = None
+    mode: str = "live"
+    context: Dict[str, Any] | None = None
+
+    @field_validator("metric")
+    @classmethod
+    def _metric(cls, v: str) -> str:
+        v = (v or "").strip()
+        if not v:
+            raise ValueError("metric is required")
+        return v
+
+    @field_validator("mode")
+    @classmethod
+    def _mode(cls, v: str) -> str:
+        v = v.lower()
+        if v not in {"live", "paper"}:
+            raise ValueError("mode must be 'live' or 'paper'")
+        return v
+
+
+class RiskLimitIn(BaseModel):
+    symbol: str
+    max_fraction: float
+    recommended_size: float
+    mode: str = "live"
+    details: Dict[str, Any] | None = None
+
+    @field_validator("symbol")
+    @classmethod
+    def _symbol(cls, v: str) -> str:
+        v = (v or "").strip().upper()
+        if not v:
+            raise ValueError("symbol is required")
+        return v
+
+    @field_validator("mode")
+    @classmethod
+    def _mode(cls, v: str) -> str:
+        v = v.lower()
+        if v not in {"live", "paper"}:
+            raise ValueError("mode must be 'live' or 'paper'")
+        return v
+
+
 # --- Database Manager ---
 @dataclass
 class _EngineState:
@@ -315,16 +398,44 @@ class DatabaseManager:
             async with self._state.engine.begin() as conn:  # type: ignore[union-attr]
                 await conn.run_sync(Base.metadata.create_all)
 
-            # 2) Wersjonowanie schematu – zwykłe operacje przez sesję
-            async with self.session() as s:
-                q = await s.execute(select(func.count(SchemaVersion.id)))
-                count = q.scalar() or 0
-                if count == 0:
-                    sv = SchemaVersion(version=1)
-                    s.add(sv)
-                    await s.commit()
+        await self._apply_migrations()
 
+        if create:
             logger.info("Database initialized (url=%s)", self.db_url)
+
+    async def _apply_migrations(self) -> None:
+        if self._state.session_factory is None:
+            return
+
+        async with self.session() as session:
+            existing = (
+                await session.execute(select(SchemaVersion.version))
+            ).scalars().all()
+            applied = set(int(v) for v in existing)
+            current = max(applied) if applied else 0
+            target = int(CURRENT_SCHEMA_VERSION)
+            updated = False
+
+            for version in range(current + 1, target + 1):
+                migration = MIGRATIONS.get(version)
+                logger.info("Applying database migration -> version %s", version)
+                if migration is not None:
+                    await migration(session, self)
+                session.add(SchemaVersion(version=version))
+                await session.flush()
+                updated = True
+
+            if updated:
+                await session.commit()
+
+    async def get_schema_version(self) -> int:
+        if self._state.session_factory is None:
+            return 0
+
+        async with self.session() as session:
+            result = await session.execute(select(func.max(SchemaVersion.version)))
+            version = result.scalar()
+            return int(version or 0)
 
     @contextlib.asynccontextmanager
     async def session(self) -> AsyncIterator[AsyncSession]:
@@ -617,6 +728,80 @@ class DatabaseManager:
             rows = (await s.execute(stmt)).scalars().all()
             return [self._row_to_dict(r) for r in rows]
 
+    # ---------- OPERACJE: Performance metrics ----------
+    async def log_performance_metric(
+        self, metric: Union[PerformanceMetricIn, Dict[str, Any]]
+    ) -> int:
+        try:
+            payload = metric if isinstance(metric, PerformanceMetricIn) else PerformanceMetricIn(**metric)
+        except ValidationError as exc:
+            logger.error("Performance metric validation error: %s", exc)
+            raise
+
+        async with self.transaction() as session:
+            rec = PerformanceMetric(
+                metric=payload.metric,
+                value=float(payload.value),
+                window=payload.window,
+                symbol=payload.symbol,
+                mode=payload.mode,
+                extra=json.dumps(payload.context) if payload.context is not None else None,
+            )
+            session.add(rec)
+            await session.flush()
+            return rec.id
+
+    async def fetch_performance_metrics(
+        self,
+        *,
+        metric: Optional[str] = None,
+        symbol: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        async with self.session() as session:
+            stmt = select(PerformanceMetric).order_by(PerformanceMetric.ts.desc()).limit(limit)
+            if metric:
+                stmt = stmt.where(PerformanceMetric.metric == metric)
+            if symbol:
+                stmt = stmt.where(PerformanceMetric.symbol == symbol)
+            rows = (await session.execute(stmt)).scalars().all()
+            return [self._row_to_dict(row) for row in rows]
+
+    # ---------- OPERACJE: Risk limits ----------
+    async def log_risk_limit(
+        self, snapshot: Union[RiskLimitIn, Dict[str, Any]]
+    ) -> int:
+        try:
+            payload = snapshot if isinstance(snapshot, RiskLimitIn) else RiskLimitIn(**snapshot)
+        except ValidationError as exc:
+            logger.error("Risk limit validation error: %s", exc)
+            raise
+
+        async with self.transaction() as session:
+            rec = RiskLimitSnapshot(
+                symbol=payload.symbol,
+                max_fraction=float(payload.max_fraction),
+                recommended_size=float(payload.recommended_size),
+                mode=payload.mode,
+                details=json.dumps(payload.details) if payload.details is not None else None,
+            )
+            session.add(rec)
+            await session.flush()
+            return rec.id
+
+    async def fetch_risk_limits(
+        self,
+        *,
+        symbol: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        async with self.session() as session:
+            stmt = select(RiskLimitSnapshot).order_by(RiskLimitSnapshot.ts.desc()).limit(limit)
+            if symbol:
+                stmt = stmt.where(RiskLimitSnapshot.symbol == symbol)
+            rows = (await session.execute(stmt)).scalars().all()
+            return [self._row_to_dict(row) for row in rows]
+
     # ---------- OPERACJE: Logi ----------
     async def add_log(self, *, level: str, source: str, message: str, extra: Optional[Dict[str, Any]] = None) -> int:
         payload = extra or {}
@@ -779,6 +964,34 @@ class DatabaseManager:
         def fetch_equity_curve(self, *, limit: int = 1000, mode: Optional[str] = None) -> List[Dict[str, Any]]:
             return self._run(self._outer.fetch_equity_curve(limit=limit, mode=mode))
 
+        def log_performance_metric(self, metric: Union[PerformanceMetricIn, Dict[str, Any]]) -> int:
+            return self._run(self._outer.log_performance_metric(metric))
+
+        def fetch_performance_metrics(
+            self,
+            *,
+            metric: Optional[str] = None,
+            symbol: Optional[str] = None,
+            limit: int = 100,
+        ) -> List[Dict[str, Any]]:
+            return self._run(
+                self._outer.fetch_performance_metrics(metric=metric, symbol=symbol, limit=limit)
+            )
+
+        def log_risk_limit(self, snapshot: Union[RiskLimitIn, Dict[str, Any]]) -> int:
+            return self._run(self._outer.log_risk_limit(snapshot))
+
+        def fetch_risk_limits(
+            self,
+            *,
+            symbol: Optional[str] = None,
+            limit: int = 100,
+        ) -> List[Dict[str, Any]]:
+            return self._run(self._outer.fetch_risk_limits(symbol=symbol, limit=limit))
+
+        def get_schema_version(self) -> int:
+            return self._run(self._outer.get_schema_version())
+
         def add_log(self, *, level: str, source: str, message: str, extra: Optional[Dict[str, Any]] = None) -> int:
             return self._run(self._outer.add_log(level=level, source=source, message=message, extra=extra))
 
@@ -791,3 +1004,24 @@ class DatabaseManager:
     @property
     def sync(self) -> "DatabaseManager._SyncWrapper":
         return DatabaseManager._SyncWrapper(self)
+
+
+async def _migration_initial(session: AsyncSession, manager: "DatabaseManager") -> None:
+    """Początkowa migracja – struktury tworzone przez ``create_all``."""
+    # Brak dodatkowych działań – pozostawiamy jako znacznik wersji 1.
+    return None
+
+
+async def _migration_performance_tables(session: AsyncSession, manager: "DatabaseManager") -> None:
+    """Migracja dodająca tabele metryk i limitów ryzyka."""
+    # Struktury tabel dodawane są przez ``Base.metadata.create_all`` w ``init_db``.
+    # Migracja pozostawiona dla kompatybilności – w razie potrzeby można dodać transformacje danych.
+    return None
+
+
+MIGRATIONS: Dict[int, Callable[[AsyncSession, "DatabaseManager"], Any]] = {
+    1: _migration_initial,
+    2: _migration_performance_tables,
+}
+
+CURRENT_SCHEMA_VERSION = max(MIGRATIONS)

--- a/KryptoLowca/managers/security_manager.py
+++ b/KryptoLowca/managers/security_manager.py
@@ -21,8 +21,9 @@ import json
 import base64
 import logging
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes, constant_time
@@ -35,6 +36,15 @@ if not logger.handlers:
     _h.setFormatter(logging.Formatter('[%(asctime)s] %(name)s - %(levelname)s - %(message)s'))
     logger.addHandler(_h)
 logger.setLevel(logging.INFO)
+
+audit_logger = logging.getLogger(f"{__name__}.audit")
+if not audit_logger.handlers:
+    _audit_handler = logging.StreamHandler()
+    _audit_handler.setFormatter(
+        logging.Formatter('[%(asctime)s] SECURITY-AUDIT %(levelname)s: %(message)s')
+    )
+    audit_logger.addHandler(_audit_handler)
+audit_logger.setLevel(logging.INFO)
 
 
 class SecurityError(Exception):
@@ -81,6 +91,7 @@ class SecurityManager:
         self.aws_secret_id = aws_secret_id
         self.aws_region_name = aws_region_name
         self._lock = threading.RLock()
+        self._audit_callback: Optional[Callable[[str, Dict[str, Any]], None]] = None
 
         # AWS opcjonalnie
         self._aws_available = False
@@ -204,6 +215,35 @@ class SecurityManager:
             raise SecurityError("You must specify a region.")
         return self._boto3.client("secretsmanager", region_name=region)
 
+    # --------------------- Audyt bezpieczeństwa ---------------------
+    def register_audit_callback(self, callback: Callable[[str, Dict[str, Any]], None]) -> None:
+        """Pozwala GUI/bazie na rejestrowanie zdarzeń audytowych (odszyfrowanie kluczy)."""
+
+        self._audit_callback = callback
+
+    def _emit_audit_event(self, action: str, **context: Any) -> None:
+        payload: Dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "action": action,
+            "backend": self.backend,
+        }
+        if self.backend == "local":
+            payload["key_file"] = str(self.key_file)
+        if self.backend == "aws" and self.aws_secret_id:
+            payload["secret_id"] = self.aws_secret_id
+        for key, value in context.items():
+            if key in {"secret", "secrets", "payload"}:
+                continue
+            payload[key] = value
+
+        safe_payload = {k: v for k, v in payload.items() if k != "action"}
+        audit_logger.info("%s %s", action.upper(), safe_payload)
+        if self._audit_callback:
+            try:
+                self._audit_callback(action, payload)
+            except Exception:  # pragma: no cover - callback nie powinien psuć logiki
+                logger.exception("Security audit callback zgłosił wyjątek")
+
     # --------------------- API PUBLICZNE ---------------------
 
     def save_encrypted_keys(self, keys: Dict[str, Any], password: str) -> None:
@@ -232,15 +272,32 @@ class SecurityManager:
                         SecretString=payload.decode("utf-8"),
                     )
                     logger.info("API keys saved to AWS Secrets Manager")
+                    self._emit_audit_event(
+                        "encrypt_keys",
+                        backend="aws",
+                        keys=list(keys.keys()),
+                        status="success",
+                    )
                 else:
                     # LOCAL
                     enc = self._local_encrypt(payload, password)
                     self.key_file.write_bytes(enc)
                     logger.info(f"API keys saved locally to {self.key_file}")
+                    self._emit_audit_event(
+                        "encrypt_keys",
+                        backend="local",
+                        keys=list(keys.keys()),
+                        status="success",
+                    )
             except SecurityError:
                 raise
             except Exception as e:
                 logger.error(f"Failed to save keys: {e}")
+                self._emit_audit_event(
+                    "encrypt_keys_failed",
+                    error=str(e),
+                    backend=self.backend,
+                )
                 raise SecurityError(f"Failed to save keys: {e}") from e
 
     def load_encrypted_keys(self, password: str) -> Dict[str, Any]:
@@ -269,6 +326,12 @@ class SecurityManager:
                     if not isinstance(data, dict):
                         raise SecurityError("Invalid key format in AWS secret")
                     logger.info("API keys loaded from AWS Secrets Manager")
+                    self._emit_audit_event(
+                        "decrypt_keys",
+                        backend="aws",
+                        keys=list(data.keys()),
+                        status="success",
+                    )
                     return data
 
                 # LOCAL
@@ -282,8 +345,19 @@ class SecurityManager:
                 if not isinstance(data, dict):
                     raise SecurityError("Invalid key format")
                 logger.info("API keys loaded from local file")
+                self._emit_audit_event(
+                    "decrypt_keys",
+                    backend="local",
+                    keys=list(data.keys()),
+                    status="success",
+                )
                 return data
             except SecurityError:
+                self._emit_audit_event(
+                    "decrypt_keys_failed",
+                    backend=self.backend,
+                    error="SecurityError",
+                )
                 raise
             except Exception as e:
                 # ujednolicone komunikaty dla GUI
@@ -291,4 +365,9 @@ class SecurityManager:
                 if "region" in msg.lower():
                     msg = "You must specify a region."
                 logger.error(f"Failed to load keys: {msg}")
+                self._emit_audit_event(
+                    "decrypt_keys_failed",
+                    backend=self.backend,
+                    error=msg,
+                )
                 raise SecurityError(f"Failed to load keys: {msg}") from e

--- a/KryptoLowca/tests/test_auto_trader.py
+++ b/KryptoLowca/tests/test_auto_trader.py
@@ -1,0 +1,123 @@
+"""Tests for safety guards in AutoTrader."""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable, Dict, List, Tuple
+
+import pytest
+
+from KryptoLowca.auto_trader import AutoTrader
+
+
+class DummyEmitter:
+    def __init__(self) -> None:
+        self.logs: List[Tuple[str, str, str]] = []
+
+    def on(self, *_, **__) -> None:  # pragma: no cover - interface placeholder
+        return None
+
+    def off(self, *_, **__) -> None:  # pragma: no cover - interface placeholder
+        return None
+
+    def emit(self, event: str, **payload: Any) -> None:
+        self.logs.append(("event", event, str(payload)))
+
+    def log(self, message: str, level: str = "INFO", component: str | None = None) -> None:
+        self.logs.append(("log", level, message))
+
+
+class DummyVar:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def get(self) -> str:
+        return self._value
+
+
+class NoSignalAI:
+    ai_threshold_bps = 5.0
+
+    def predict_series(self, *_, **__) -> None:
+        return None
+
+
+class DummyGUI:
+    def __init__(self, demo: bool, allow_live: bool) -> None:
+        self.timeframe_var = DummyVar("1m")
+        self.ai_mgr = NoSignalAI()
+        self.ex_mgr = self
+        self._demo = demo
+        self._allow_live = allow_live
+        self.executed: List[Tuple[str, str, float]] = []
+        self.db = DummyDB()
+
+    def is_demo_mode_active(self) -> bool:
+        return self._demo
+
+    def is_live_trading_allowed(self) -> bool:
+        return self._allow_live
+
+    def _bridge_execute_trade(self, symbol: str, side: str, price: float) -> None:
+        self.executed.append((symbol, side, price))
+
+    # Exchange-like API -------------------------------------------------
+    def fetch_ticker(self, symbol: str) -> Dict[str, float]:
+        return {"last": 100.0}
+
+
+class DummyDB:
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+        self.sync = self
+
+    def log_performance_metric(self, payload: Dict[str, Any]) -> int:
+        self.records.append(payload)
+        return len(self.records)
+
+
+@pytest.fixture()
+def demo_autotrader() -> Callable[[DummyGUI], AutoTrader]:
+    def factory(gui: DummyGUI) -> AutoTrader:
+        emitter = DummyEmitter()
+        trader = AutoTrader(emitter, gui, lambda: "BTC/USDT", auto_trade_interval_s=0.01)
+        trader.enable_auto_trade = True
+        return trader
+
+    return factory
+
+
+def _run_loop(trader: AutoTrader, duration: float = 0.1) -> None:
+    worker = threading.Thread(target=trader._auto_trade_loop, daemon=True)
+    worker.start()
+    time.sleep(duration)
+    trader._stop.set()
+    worker.join(timeout=1.0)
+    trader.stop()
+
+
+def test_no_fallback_trade_without_signal(demo_autotrader: Callable[[DummyGUI], AutoTrader]) -> None:
+    gui = DummyGUI(demo=True, allow_live=True)
+    trader = demo_autotrader(gui)
+    _run_loop(trader)
+    assert gui.executed == []
+    assert any("no valid model signal" in msg for kind, _, msg in trader.emitter.logs if kind == "log")
+
+
+def test_live_trading_blocked_without_confirmation(demo_autotrader: Callable[[DummyGUI], AutoTrader]) -> None:
+    gui = DummyGUI(demo=False, allow_live=False)
+    trader = demo_autotrader(gui)
+    _run_loop(trader)
+    assert gui.executed == []
+    assert any("live trading requires explicit confirmation" in msg for kind, _, msg in trader.emitter.logs if kind == "log")
+
+
+def test_metrics_persisted_on_trade_close(demo_autotrader: Callable[[DummyGUI], AutoTrader]) -> None:
+    gui = DummyGUI(demo=True, allow_live=True)
+    trader = demo_autotrader(gui)
+    trader._on_trade_closed("BTC/USDT", "BUY", 100.0, 110.0, 5.0, time.time())
+    metrics = gui.db.records
+    assert metrics, "Brak zapisanych metryk po zamknięciu transakcji"
+    names = {entry["metric"] for entry in metrics}
+    assert "auto_trader_expectancy" in names
+    assert any(entry["symbol"] == "BTC/USDT" for entry in metrics)

--- a/KryptoLowca/tests/test_config_manager.py
+++ b/KryptoLowca/tests/test_config_manager.py
@@ -88,6 +88,7 @@ def test_save_and_load_roundtrip(cfg: ConfigManager, sample_preset: dict) -> Non
     # sekcje dodatkowe obecne
     assert loaded["ai"]["epochs"] == 20
     assert loaded["risk"]["risk_per_trade"] == pytest.approx(0.02)
+    assert loaded["version"] == ConfigManager.current_version()
 
 
 def test_invalid_fraction_rejected(cfg: ConfigManager, sample_preset: dict) -> None:
@@ -107,3 +108,42 @@ def test_defaults_and_normalisation(cfg: ConfigManager) -> None:
     assert preset.fraction == pytest.approx(0.0)
     data = preset.to_dict()
     assert "ai" in data and "risk" in data
+    assert preset.version == ConfigManager.current_version()
+
+
+def test_demo_requirement_blocks_live(cfg: ConfigManager, sample_preset: dict) -> None:
+    sample_preset["network"] = "Live"
+    with pytest.raises(ValueError):
+        cfg.save_preset("live", sample_preset)
+
+    cfg.require_demo_mode(False)
+    path = cfg.save_preset("live_allowed", sample_preset)
+    assert path.exists()
+
+
+def test_create_preset_with_audit(cfg: ConfigManager, sample_preset: dict) -> None:
+    cfg.save_preset("base", sample_preset)
+    audit = cfg.create_preset(
+        "custom",
+        base="base",
+        overrides={"fraction": 0.3, "risk": {"max_daily_loss_pct": 0.25}},
+    )
+    assert audit["preset"]["network"] == "Testnet"
+    assert audit["warnings"], "Zbyt wysoka dzienna strata powinna zostać oznaczona"
+    assert "path" in audit and Path(audit["path"]).exists()
+    assert audit["version"] == ConfigManager.current_version()
+    assert audit["preset"]["version"] == ConfigManager.current_version()
+
+
+def test_preset_wizard_profiles(cfg: ConfigManager, sample_preset: dict) -> None:
+    cfg.save_preset("base", sample_preset)
+    wizard = cfg.preset_wizard().from_template("base").with_risk_profile("aggressive").with_symbols([
+        "btc/usdt",
+        "ada/usdt",
+    ])
+    audit = wizard.build("aggressive_profile")
+
+    assert audit["preset"]["selected_symbols"] == ["BTC/USDT", "ADA/USDT"]
+    assert audit["preset"]["fraction"] == pytest.approx(0.35)
+    assert audit["is_demo"] is True
+    assert audit["preset"]["version"] == ConfigManager.current_version()

--- a/KryptoLowca/tests/test_security_manager.py
+++ b/KryptoLowca/tests/test_security_manager.py
@@ -3,45 +3,77 @@
 """
 Unit tests for security_manager.py.
 """
-import pytest
-import json
+from __future__ import annotations
+
 from pathlib import Path
-from KryptoLowca.managers.security_manager import SecurityManager, SecurityError
-from cryptography.fernet import InvalidToken
+from typing import List, Tuple
+
+import pytest
+
+from KryptoLowca.managers.security_manager import SecurityError, SecurityManager
+
 
 @pytest.fixture
-def security_manager(tmp_path):
+def security_manager(tmp_path: Path) -> SecurityManager:
     key_file = tmp_path / "keys.enc"
     return SecurityManager(key_file=str(key_file))
 
-def test_save_and_load_keys(security_manager, tmp_path):
+
+def test_save_and_load_keys(security_manager: SecurityManager) -> None:
     keys = {
         "testnet": {"key": "test_key", "secret": "test_secret"},
-        "live": {"key": "live_key", "secret": "live_secret"}
+        "live": {"key": "live_key", "secret": "live_secret"},
     }
     password = "password123"
-    
+
     security_manager.save_encrypted_keys(keys, password)
     assert security_manager.key_file.exists()
-    
+
     loaded_keys = security_manager.load_encrypted_keys(password)
     assert loaded_keys == keys
 
-def test_invalid_password(security_manager):
+
+def test_invalid_password(security_manager: SecurityManager) -> None:
     keys = {"testnet": {"key": "test_key", "secret": "test_secret"}}
     security_manager.save_encrypted_keys(keys, "password123")
-    
+
     with pytest.raises(SecurityError, match="Invalid password"):
         security_manager.load_encrypted_keys("wrong_password")
 
-def test_missing_key_file(security_manager):
+
+def test_missing_key_file(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Key file .* not found"):
         security_manager.load_encrypted_keys("password123")
 
-def test_invalid_keys(security_manager):
+
+def test_invalid_keys(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Keys must be a non-empty dictionary"):
         security_manager.save_encrypted_keys({}, "password123")
 
-def test_invalid_password_type(security_manager):
+
+def test_invalid_password_type(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Password must be a non-empty string"):
         security_manager.save_encrypted_keys({"testnet": {"key": "k", "secret": "s"}}, "")
+
+
+def test_audit_callback_records_events(security_manager: SecurityManager) -> None:
+    events: List[Tuple[str, dict]] = []
+
+    def _callback(action: str, payload: dict) -> None:
+        events.append((action, payload))
+
+    security_manager.register_audit_callback(_callback)
+
+    keys = {
+        "testnet": {"key": "T" * 32, "secret": "S" * 32},
+        "live": {"key": "L" * 32, "secret": "Z" * 32},
+    }
+    password = "audit-pass"
+
+    security_manager.save_encrypted_keys(keys, password)
+    loaded = security_manager.load_encrypted_keys(password)
+
+    assert loaded == keys
+    actions = [action for action, _ in events]
+    assert "encrypt_keys" in actions
+    assert "decrypt_keys" in actions

--- a/KryptoLowca/tests/test_trading_engine.py
+++ b/KryptoLowca/tests/test_trading_engine.py
@@ -116,6 +116,7 @@ class MockDB:
         self.order_updates = []
         self.logs = []
         self.positions = []
+        self.risk_limits = []
 
     async def ensure_user(self, email: str) -> int:
         return 1
@@ -129,6 +130,10 @@ class MockDB:
     async def record_order(self, order):
         self.orders.append(order)
         return len(self.orders)
+
+    async def log_risk_limit(self, payload):
+        self.risk_limits.append(payload)
+        return len(self.risk_limits)
 
     async def update_order_status(
         self,
@@ -197,6 +202,7 @@ def test_execute_live_tick(engine):
     assert plan["execution"]["status"] == "FILLED"
     assert engine.ex_mgr.created_orders  # type: ignore[attr-defined]
     assert engine.db_manager.orders  # type: ignore[attr-defined]
+    assert engine.db_manager.risk_limits  # type: ignore[attr-defined]
 
 
 def test_no_signal(engine):

--- a/KryptoLowca/trading_gui.py
+++ b/KryptoLowca/trading_gui.py
@@ -46,17 +46,26 @@ except Exception:
 
 # --- LOGGING ---
 import logging
-logger = logging.getLogger(__name__)
-if not logger.handlers:
-    h = logging.StreamHandler(sys.stdout)
-    h.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
-    logger.addHandler(h)
+from KryptoLowca.logging_utils import (
+    LOGS_DIR as GLOBAL_LOGS_DIR,
+    DEFAULT_LOG_FILE,
+    get_logger,
+    setup_app_logging,
+)
+
+setup_app_logging()
+logger = get_logger(__name__)
+if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
+    logger.addHandler(stream_handler)
 logger.setLevel(logging.INFO)
 
 # --- ŚCIEŻKI APLIKACJI ---
 APP_ROOT = Path(__file__).resolve().parent
-LOGS_DIR = APP_ROOT / "logs"; LOGS_DIR.mkdir(parents=True, exist_ok=True)
-TEXT_LOG_FILE = LOGS_DIR / "trading.log"
+LOGS_DIR = GLOBAL_LOGS_DIR
+LOGS_DIR.mkdir(parents=True, exist_ok=True)
+TEXT_LOG_FILE = DEFAULT_LOG_FILE
 DB_FILE = APP_ROOT / "trading_bot.db"
 OPEN_POS_FILE = APP_ROOT / "open_positions.json"
 FAV_FILE = APP_ROOT / "favorites.json"
@@ -169,6 +178,7 @@ class TradingGUI:
         self.paper_balance = self.paper_capital.get()
         self.paper_balance_var = tk.StringVar(value=f"{self.paper_balance:,.2f}")
         self.account_balance_var = tk.StringVar(value="— (Live only)")
+        self._live_trading_confirmed = False
 
         # AI
         self.enable_ai_var = tk.BooleanVar(value=False)
@@ -449,12 +459,13 @@ class TradingGUI:
 
     # --------------- LOGS ---------------
     def _log(self, msg: str, level: str = "INFO"):
-        # 1) UI + plik teksowy
-        line = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {level}: {msg}\n"
+        level_name = (level or "INFO").upper()
+        log_level = getattr(logging, level_name, logging.INFO)
+        logger.log(log_level, msg)
+
+        # 1) UI log window
+        line = f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {level_name}: {msg}\n"
         try: self.log_text.insert("end", line); self.log_text.see("end")
-        except Exception: pass
-        try:
-            with open(TEXT_LOG_FILE, "a", encoding="utf-8") as f: f.write(line)
         except Exception: pass
 
         # 2) DB (obsługa sync/async + różnych sygnatur)
@@ -752,7 +763,14 @@ class TradingGUI:
 
     # ===================== Handlery =====================
     def _on_network_changed(self):
-        self.account_balance_var.set("…" if self.network_var.get()=="Live" else "— (Live only)")
+        net = self.network_var.get()
+        self.account_balance_var.set("…" if net == "Live" else "— (Live only)")
+        self._reset_live_confirmation()
+        if net == "Live":
+            self._log(
+                "Tryb LIVE: przed uruchomieniem handlu wykonaj pełne testy na koncie demo/testnet i przygotuj plan zarządzania ryzykiem.",
+                "WARNING",
+            )
 
     def _on_ai_threshold_changed(self):
         try:
@@ -845,11 +863,64 @@ class TradingGUI:
         self.selected_symbols = [s for s,v in self.symbol_vars.items() if v.get()]
         self._log(f"Applied {len(self.selected_symbols)} symbols", "INFO")
 
+    # Safety helpers -------------------------------------------------
+    def is_demo_mode_active(self) -> bool:
+        try:
+            network = (self.network_var.get() or "").strip().lower()
+            return network != "live"
+        except Exception:
+            return True
+
+    def is_live_trading_allowed(self) -> bool:
+        return bool(self._live_trading_confirmed)
+
+    def _has_valid_live_keys(self) -> bool:
+        key = (self.live_key.get() or "").strip()
+        secret = (self.live_secret.get() or "").strip()
+        if not key or not secret:
+            return False
+        try:
+            return SecurityManager.validate_api_key(key) and SecurityManager.validate_api_key(secret)
+        except Exception:
+            return False
+
+    def _reset_live_confirmation(self) -> None:
+        self._live_trading_confirmed = False
+
+    def _ensure_live_trading_prerequisites(self) -> bool:
+        if self.is_demo_mode_active():
+            return True
+
+        if not self._has_valid_live_keys():
+            messagebox.showwarning(
+                "Klucze API",
+                "Przed uruchomieniem handlu LIVE uzupełnij poprawne klucze API i upewnij się, "
+                "że konto ma włączone limity bezpieczeństwa. Na tym etapie zalecamy kontynuację w trybie demo/testnet.",
+            )
+            self._log("Live trading blocked: missing or invalid API keys.", "WARNING")
+            return False
+
+        if not self._live_trading_confirmed:
+            proceed = messagebox.askyesno(
+                "Potwierdzenie handlu LIVE",
+                "Handel na żywym rynku wiąże się z ryzykiem utraty środków. Bot jest w fazie rozwoju — uruchamiaj go wyłącznie po "
+                "pełnym przetestowaniu na koncie demo/testnet i upewnij się, że spełniasz wymogi KYC/AML swojej giełdy.\n\nCzy na pewno chcesz kontynuować?",
+            )
+            if not proceed:
+                self._log("Live trading start cancelled przez użytkownika.", "WARNING")
+                return False
+            self._live_trading_confirmed = True
+            self._log("Live trading confirmed przez użytkownika. Zachowaj ostrożność i monitoruj transakcje.", "WARNING")
+
+        return True
+
     # Start/Stop
     def _on_start(self):
         if self._worker_thread and self._worker_thread.is_alive(): return
         if not self.selected_symbols:
             messagebox.showwarning("No symbols", "Zaznacz symbole (po lewej) i kliknij Apply selection.")
+            return
+        if not self._ensure_live_trading_prerequisites():
             return
         self._run_flag.set()
         self._worker_thread = threading.Thread(target=self._worker, daemon=True)


### PR DESCRIPTION
## Summary
- extend the database manager with performance metric and risk limit tables, async migrations, and sync helpers so telemetry can be persisted for analysis
- introduce explicit preset versioning and upgrade logic in the config manager, carrying version data through audits and persistence
- persist AutoTrader performance snapshots, TradingEngine risk limits, and ExchangeManager API metrics into the database/log stream, and cover the changes with focused tests

## Testing
- pytest KryptoLowca/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d598f15558832aae1a56aaf34e509b