### PR TITLE
Fix telemetry optional deps and audit persistence

### DIFF
--- a/KryptoLowca/alerts.py
+++ b/KryptoLowca/alerts.py
@@ -1,0 +1,154 @@
+"""Centralny dispatcher alertów i wspólne wyjątki dla całego bota."""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+
+class AlertSeverity(str, Enum):
+    """Stopnie ważności alertów przekazywanych do dashboardu."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+    CRITICAL = "critical"
+
+
+@dataclass(slots=True)
+class AlertEvent:
+    """Struktura pojedynczego alertu przekazywanego do słuchaczy."""
+
+    message: str
+    severity: AlertSeverity
+    source: str
+    context: Dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.time)
+    exception: Optional[BaseException] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = dict(self.context)
+        payload.update(
+            {
+                "message": self.message,
+                "severity": self.severity.value,
+                "source": self.source,
+                "timestamp": self.timestamp,
+            }
+        )
+        if self.exception is not None:
+            payload.setdefault("exception", repr(self.exception))
+        return payload
+
+
+class BotError(Exception):
+    """Bazowy wyjątek domenowy – mapowany na alerty."""
+
+    severity: AlertSeverity = AlertSeverity.ERROR
+    source: str = "core"
+
+    def __init__(self, message: str, *, context: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(message)
+        self.context = context or {}
+
+    def to_alert(self) -> AlertEvent:
+        return AlertEvent(
+            message=str(self),
+            severity=self.severity,
+            source=self.source,
+            context=dict(self.context),
+            exception=self,
+        )
+
+
+class AlertDispatcher:
+    """Prosty dispatcher przekazujący alerty do zarejestrowanych słuchaczy."""
+
+    def __init__(self) -> None:
+        self._listeners: Dict[str, Callable[[AlertEvent], None]] = {}
+        self._lock = threading.Lock()
+        self._counter = 0
+
+    def register(self, listener: Callable[[AlertEvent], None], *, name: Optional[str] = None) -> str:
+        """Zarejestruj słuchacza i zwróć jego identyfikator."""
+
+        with self._lock:
+            token = name or f"listener-{self._counter}"  # prosty identyfikator
+            while token in self._listeners:
+                self._counter += 1
+                token = f"listener-{self._counter}"
+            self._listeners[token] = listener
+            self._counter += 1
+            return token
+
+    def unregister(self, token: str) -> None:
+        """Usuń słuchacza – brak błędu gdy nie istnieje."""
+
+        with self._lock:
+            self._listeners.pop(token, None)
+
+    def dispatch(self, event: AlertEvent) -> None:
+        listeners: Dict[str, Callable[[AlertEvent], None]]
+        with self._lock:
+            listeners = dict(self._listeners)
+        for name, listener in listeners.items():
+            try:
+                listener(event)
+            except Exception:  # pragma: no cover - logujemy, ale nie przerywamy
+                logger.exception("Alert listener '%s' zgłosił wyjątek", name)
+
+    def clear(self) -> None:
+        """Usuń wszystkich słuchaczy (używane w testach)."""
+
+        with self._lock:
+            self._listeners.clear()
+
+
+_DISPATCHER = AlertDispatcher()
+
+
+def get_alert_dispatcher() -> AlertDispatcher:
+    """Zwróć globalny dispatcher alertów."""
+
+    return _DISPATCHER
+
+
+def emit_alert(
+    message: str,
+    *,
+    severity: AlertSeverity = AlertSeverity.WARNING,
+    source: str = "core",
+    context: Optional[Dict[str, Any]] = None,
+    exception: Optional[BaseException] = None,
+) -> AlertEvent:
+    """Zbuduj i roześlij alert do wszystkich słuchaczy."""
+
+    event = AlertEvent(
+        message=message,
+        severity=severity,
+        source=source,
+        context=dict(context or {}),
+        exception=exception,
+    )
+    _DISPATCHER.dispatch(event)
+    return event
+
+
+__all__ = [
+    "AlertDispatcher",
+    "AlertEvent",
+    "AlertSeverity",
+    "BotError",
+    "emit_alert",
+    "get_alert_dispatcher",
+]

--- a/KryptoLowca/auto_trader.py
+++ b/KryptoLowca/auto_trader.py
@@ -23,6 +23,10 @@ except Exception:
         def popleft(self): return super().pop(0)
 
 from KryptoLowca.event_emitter_adapter import EventEmitter
+from KryptoLowca.logging_utils import get_logger
+
+
+logger = get_logger(__name__)
 
 class AutoTrader:
     """
@@ -52,6 +56,7 @@ class AutoTrader:
         self.emitter = emitter
         self.gui = gui
         self.symbol_getter = symbol_getter
+        self._db_manager = getattr(gui, "db", None)
 
         self.pf_min = pf_min
         self.expectancy_min = expectancy_min
@@ -95,18 +100,20 @@ class AutoTrader:
         t2.start()
         self._threads.append(t2)
         self.emitter.log("AutoTrader started.", component="AutoTrader")
+        logger.info("AutoTrader worker threads started")
 
     def stop(self) -> None:
         self._stop.set()
         self.emitter.off("trade_closed", tag="autotrader")
         self.emitter.off("bar", tag="autotrader")
         self.emitter.log("AutoTrader stopped.", component="AutoTrader")
+        logger.info("AutoTrader stop requested")
         for t in list(self._threads):
             try:
                 if t.is_alive():
                     t.join(timeout=2.0)
             except Exception:
-                pass
+                logger.exception("Error while joining AutoTrader thread")
         self._threads.clear()
 
     def set_enable_auto_trade(self, flag: bool) -> None:
@@ -126,8 +133,16 @@ class AutoTrader:
     # -- Event handlers --
     def _on_trade_closed(self, symbol: str, side: str, entry: float, exit: float, pnl: float, ts: float, meta: Dict[str, Any] | None = None, **_) -> None:
         self._closed_pnls.append(pnl)
-        pf, exp = self._compute_metrics()
-        self.emitter.emit("metrics_updated", pf=pf, expectancy=exp, window=len(self._closed_pnls), ts=time.time())
+        pf, exp, win_rate = self._compute_metrics()
+        self.emitter.emit(
+            "metrics_updated",
+            pf=pf,
+            expectancy=exp,
+            win_rate=win_rate,
+            window=len(self._closed_pnls),
+            ts=time.time(),
+        )
+        self._persist_performance_metrics(symbol, pf, exp, win_rate)
         # Check thresholds
         trigger_reason = None
         details = {}
@@ -156,9 +171,9 @@ class AutoTrader:
                 self._maybe_reoptimize("atr_spike", {"atr": atr, "baseline": baseline, "ratio": ratio})
 
     # -- Helpers --
-    def _compute_metrics(self) -> tuple[Optional[float], Optional[float]]:
+    def _compute_metrics(self) -> tuple[Optional[float], Optional[float], Optional[float]]:
         if not self._closed_pnls:
-            return (None, None)
+            return (None, None, None)
         pnls = list(self._closed_pnls)
         wins = [p for p in pnls if p > 0]
         losses = [-p for p in pnls if p < 0]
@@ -167,7 +182,77 @@ class AutoTrader:
         pf = (gross_profit / gross_loss) if gross_loss > 0 else (float('inf') if gross_profit > 0 else None)
         # Expectancy per trade (avg pnl)
         expectancy = statistics.mean(pnls) if pnls else None
-        return (pf, expectancy)
+        win_rate = (len(wins) / len(pnls)) if pnls else None
+        return (pf, expectancy, win_rate)
+
+    def _resolve_db(self):
+        db = self._db_manager
+        if db is None:
+            candidate = getattr(self.gui, "db", None)
+            if candidate is not None:
+                db = candidate
+                self._db_manager = candidate
+        if db is None or not hasattr(db, "sync"):
+            return None
+        return db
+
+    def _resolve_mode(self) -> str:
+        network_var = getattr(self.gui, "network_var", None)
+        if network_var is not None and hasattr(network_var, "get"):
+            try:
+                network = str(network_var.get()).strip().lower()
+            except Exception:
+                network = ""
+            if network in {"testnet", "paper", "demo"}:
+                return "paper"
+        return "live"
+
+    def _log_metric(
+        self,
+        metric: str,
+        value: Optional[float],
+        *,
+        symbol: str,
+        window: int,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if value is None:
+            return
+        db = self._resolve_db()
+        if db is None:
+            return
+        context: Dict[str, Any] = {"symbol": symbol, "window": window, "source": "AutoTrader"}
+        if extra:
+            context.update(extra)
+        payload = {
+            "metric": metric,
+            "value": float(value),
+            "window": window,
+            "symbol": symbol,
+            "mode": self._resolve_mode(),
+            "context": context,
+        }
+        try:
+            db.sync.log_performance_metric(payload)
+        except Exception:
+            logger.exception("Nie udało się zapisać metryki %s", metric)
+
+    def _persist_performance_metrics(
+        self,
+        symbol: str,
+        pf: Optional[float],
+        expectancy: Optional[float],
+        win_rate: Optional[float],
+    ) -> None:
+        window = len(self._closed_pnls)
+        extra = {
+            "profit_factor": pf,
+            "expectancy": expectancy,
+            "win_rate": win_rate,
+        }
+        self._log_metric("auto_trader_expectancy", expectancy, symbol=symbol, window=window, extra=extra)
+        self._log_metric("auto_trader_profit_factor", pf, symbol=symbol, window=window, extra=extra)
+        self._log_metric("auto_trader_win_rate", win_rate, symbol=symbol, window=window, extra=extra)
 
     def _maybe_reoptimize(self, reason: str, details: Dict[str, Any]) -> None:
         now = time.time()
@@ -184,6 +269,7 @@ class AutoTrader:
                 threading.Thread(target=self._call_train_safe, args=(ai,), daemon=True).start()
             except Exception as e:
                 self.emitter.log(f"AI retrain failed to start: {e!r}", level="ERROR", component="AutoTrader")
+                logger.exception("AI retrain thread failed to start")
         else:
             self.emitter.log("AI manager not available; reopt event emitted only.", level="WARNING", component="AutoTrader")
 
@@ -194,6 +280,7 @@ class AutoTrader:
             self.emitter.log("AI retrain finished.", component="AutoTrader")
         except Exception as e:
             self.emitter.log(f"AI retrain error: {e!r}", level="ERROR", component="AutoTrader")
+            logger.exception("AI retrain raised an exception")
 
     # -- Loops --
     def _walkforward_loop(self) -> None:
@@ -211,6 +298,7 @@ class AutoTrader:
                     last_ts = now
             except Exception as e:
                 self.emitter.log(f"Walk-forward loop error: {e!r}", level="ERROR", component="AutoTrader")
+                logger.exception("Walk-forward loop error")
             self._stop.wait(1.0)
 
     def _auto_trade_loop(self) -> None:
@@ -234,6 +322,19 @@ class AutoTrader:
                 ex = getattr(self.gui, "ex_mgr", None)
                 ai = getattr(self.gui, "ai_mgr", None)
 
+                if hasattr(self.gui, "is_demo_mode_active"):
+                    try:
+                        if not self.gui.is_demo_mode_active():
+                            guard_fn = getattr(self.gui, "is_live_trading_allowed", None)
+                            if callable(guard_fn) and not guard_fn():
+                                msg = "Auto-trade blocked: live trading requires explicit confirmation."
+                                self.emitter.log(msg, level="WARNING", component="AutoTrader")
+                                logger.warning("%s Skipping auto trade for %s", msg, symbol)
+                                self._stop.wait(self.auto_trade_interval_s)
+                                continue
+                    except Exception:
+                        logger.exception("Failed to evaluate live trading guard")
+
                 df: Optional[pd.DataFrame] = None
                 last_price: Optional[float] = None
                 last_pred: Optional[float] = None
@@ -245,6 +346,7 @@ class AutoTrader:
                         self.emitter.log(
                             f"predict_series failed: {e!r}", level="ERROR", component="AutoTrader"
                         )
+                        logger.exception("predict_series failed during auto trade loop")
 
                 if last_price is None:
                     last_price = self._resolve_market_price(symbol, ex, df)
@@ -265,25 +367,41 @@ class AutoTrader:
                     elif last_pred <= -threshold:
                         side = "SELL"
 
-                if side is None and last_price is not None:
-                    # fallback – prosty przełącznik BUY/SELL aby utrzymać aktywność w trybie demo
-                    side = "BUY" if int(time.time() / max(1, self.auto_trade_interval_s)) % 2 == 0 else "SELL"
+                if side is None:
+                    self.emitter.log(
+                        f"Auto-trade skipped for {symbol}: no valid model signal.",
+                        level="WARNING",
+                        component="AutoTrader",
+                    )
+                    logger.info("Skipping auto trade for %s due to missing model signal", symbol)
+                    self._stop.wait(self.auto_trade_interval_s)
+                    continue
 
-                if side is None or last_price is None:
+                if last_price is None:
+                    self.emitter.log(
+                        f"Auto-trade skipped for {symbol}: missing market price.",
+                        level="WARNING",
+                        component="AutoTrader",
+                    )
+                    logger.warning("Skipping auto trade for %s due to missing market price", symbol)
                     self._stop.wait(self.auto_trade_interval_s)
                     continue
 
                 if hasattr(self.gui, "_bridge_execute_trade"):
                     self.gui._bridge_execute_trade(symbol, side.lower(), float(last_price))
                     self.emitter.emit("auto_trade_tick", symbol=symbol, ts=time.time())
+                    self.emitter.log(f"Auto-trade executed: {symbol} {side}", component="AutoTrader")
+                    logger.info("Auto trade executed for %s (%s)", symbol, side)
                 else:
                     self.emitter.log(
                         "_bridge_execute_trade missing on GUI",
                         level="ERROR",
                         component="AutoTrader",
                     )
+                    logger.error("GUI bridge missing for auto trade execution")
             except Exception as e:
                 self.emitter.log(f"Auto trade tick error: {e!r}", level="ERROR", component="AutoTrader")
+                logger.exception("Unhandled exception inside auto trade loop")
             self._stop.wait(self.auto_trade_interval_s)
 
     # --- Prediction helpers ---

--- a/KryptoLowca/database_manager.py
+++ b/KryptoLowca/database_manager.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Warstwa kompatybilności z historycznym API ``database_manager``.
+"""Warstwa zgodności dla menedżera bazy danych.
 
-Nowa implementacja znajduje się w ``managers.database_manager``. Ten plik
-zapewnia jedynie przyjazne aliasy (``DBOptions``) oraz ujednolicone wyjątki,
-tak aby starsze testy oraz skrypty mogły działać bez zmian.
+Nowa implementacja znajduje się w ``managers.database_manager``. Ten moduł
+zapewnia przyjazne aliasy (``DBOptions``) oraz ujednolicone wyjątki, tak aby
+starsze testy oraz skrypty mogły działać bez zmian.
 """
 from __future__ import annotations
 

--- a/KryptoLowca/docs/architecture_plan.md
+++ b/KryptoLowca/docs/architecture_plan.md
@@ -1,0 +1,69 @@
+# Plan refaktoryzacji GUI i warstwy backendowej
+
+## Cele
+- Rozdzielenie logiki biznesowej od prezentacji, aby uprościć testowanie i wdrożenia 24/7.
+- Zapewnienie interfejsu API (REST/WebSocket) możliwego do konsumpcji przez desktop, aplikację webową oraz automatyzację.
+- Przygotowanie pod wielo użytkowników, autoryzację i audyt (KYC/AML, ACL).
+
+## Etapy
+
+### Etap 1 – Audyt i przygotowanie kodu
+1. **Inwentaryzacja zależności GUI**: spisać funkcje, które dziś wywołują menedżery (AI, Exchange, Risk, Database).
+2. **Wydzielenie konfiguracji**: przenieść ustawienia Tkinter (`tk.Variable`) do klas DTO/Pydantic, aby backend mógł je przyjmować w API.
+3. **Centralne logowanie i alerty**: wszystkie moduły korzystają z `KryptoLowca.alerts`, co upraszcza przekierowanie zdarzeń do backendu.
+
+### Etap 2 – Backend FastAPI
+1. **Serwis `trading-service` (FastAPI)**
+   - endpointy `/auth`, `/presets`, `/strategies`, `/orders`, `/alerts`.
+   - integracja z `DatabaseManager` i `TradingEngine` jako usługami singleton.
+   - middleware uwierzytelniający (token API, w przyszłości OAuth/Keycloak).
+2. **WebSocket / SSE** do strumieniowania alertów i ticków strategii.
+3. **Zewnętrzny scheduler** (APScheduler/Celery) do zadań okresowych: retraining AI, rollowanie logów, backup.
+
+### Etap 3 – Lekki klient
+1. **Desktop**: Tkinter lub Qt ograniczone do prezentacji, komunikacja przez API.
+2. **Przeglądarkowy dashboard** (opcjonalnie React + vite) wykorzystujący te same endpointy.
+3. **Testy E2E**: scenariusze Playwright/Selenium na sandboxie paper tradingu.
+
+## Zależności i ryzyka
+- **Bezpieczeństwo kluczy**: backend przejmuje odpowiedzialność za odszyfrowywanie, dlatego należy stosować `SecurityManager` i separację sieciową.
+- **Migracje DB**: przed startem backendu wdrożyć Alembica, aby zmiany schematu nie blokowały deployu.
+- **Skalowanie**: backend przygotować pod konteneryzację (Docker Compose/Kubernetes) z osobnym workerem do backtestów.
+
+# Plan pipeline'u backtestu i schedulera strategii
+
+## Wymagania biznesowe
+- Obsługa wielu strategii (rule-based, AI, DCA) z rankingiem wyników.
+- Backtest typu walk-forward na danych historycznych zapisanych w bazie lub plikach Parquet.
+- Automatyczne publikowanie wyników do dashboardu i alertów.
+
+## Architektura docelowa
+1. **`BacktestService`** – moduł orchestrujący runy: pobiera dane z `DatabaseManager`, generuje pipeline cech (`data_preprocessor`), uruchamia strategie i risk manager.
+2. **`StrategyScheduler`** – kolejka zadań (APScheduler/Celery) planująca: live tick, backtest, retraining, rebalancing.
+3. **Repo wyników** – tabele `backtest_runs`, `strategy_results`, `walkforward_segments` + eksport raportów (HTML/PDF).
+4. **Integracja alertów** – niepowodzenia schedulera/backtestu trafiają do `alerts` z kategorią `backtest`.
+
+## Etapy wdrożenia
+1. **Minimalny pipeline**
+   - API do uruchomienia pojedynczego backtestu (symbol, zakres dat, strategia).
+   - Zapis wyników do DB + raport CSV.
+2. **Walk-forward & optymalizacja**
+   - segmentacja danych (train/test) + metryki (Sharpe, Sortino, hit-rate, max DD).
+   - automatyczne wybieranie najlepszych hiperparametrów (grid/Optuna).
+3. **Scheduler strategii**
+   - definicje crontab (`run_every`, `run_on_signal`), integracja z danymi live.
+   - możliwość pauzowania/awaryjnego stopu przez GUI/web.
+4. **Dashboard i alerty**
+   - widoki rankingów, porównanie equity curve vs benchmark.
+   - webhooki/SMS/e-mail przy przekroczeniu progów (np. drawdown > 10%).
+
+## Testy i walidacja
+- **Testy jednostkowe**: symulacje VaR, sizingu, poprawność schedulerów (mock czasu).
+- **Testy integracyjne**: backtest na danych z Binance testnet (np. 1 tydzień BTCUSDT) – weryfikacja PnL, VaR.
+- **Testy obciążeniowe**: uruchamianie wielu strategii równolegle, monitoring zużycia CPU/RAM.
+- **Tryb demo**: wszystkie nowe funkcje domyślnie w trybie paper/testnet, dopiero po walidacji można odblokować live.
+
+## Następne kroki operacyjne
+1. Zebranie wymagań użytkownika (preferowane giełdy, rynki, limity ryzyka) – wpływa na adaptery i scheduler.
+2. Przygotowanie backlogu technicznego (Jira/Linear) z zadaniami opisanymi powyżej.
+3. Uruchomienie środowiska staging z oddzielną bazą, aby testować backend bez wpływu na produkcję.

--- a/KryptoLowca/logging_utils.py
+++ b/KryptoLowca/logging_utils.py
@@ -1,0 +1,78 @@
+"""Utilities for consistent application logging.
+
+This module centralises setup of rotating file handlers so that every
+component (GUI, background workers, integration tests) writes to the same
+log files without growing indefinitely. Importing :func:`get_logger`
+ensures the handler exists and can be reused safely.
+"""
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional, Union
+
+# Repository root (folder that contains this module)
+_APP_ROOT = Path(__file__).resolve().parent
+LOGS_DIR = _APP_ROOT / "logs"
+LOGS_DIR.mkdir(parents=True, exist_ok=True)
+DEFAULT_LOG_FILE = LOGS_DIR / "trading.log"
+
+
+def _ensure_rotating_handler(
+    logger: logging.Logger,
+    log_file: Union[str, Path] = DEFAULT_LOG_FILE,
+    max_bytes: int = 2_000_000,
+    backup_count: int = 5,
+) -> None:
+    """Attach a RotatingFileHandler to ``logger`` if missing."""
+    log_path = Path(log_file)
+    identifier = "_krypto_rotating_handler"
+
+    for handler in logger.handlers:
+        if getattr(handler, identifier, False):
+            return
+
+    handler = RotatingFileHandler(
+        log_path,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        encoding="utf-8",
+    )
+    handler.setFormatter(
+        logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
+    )
+    setattr(handler, identifier, True)
+    logger.addHandler(handler)
+
+
+def setup_app_logging(
+    log_file: Union[str, Path] = DEFAULT_LOG_FILE,
+    level: int = logging.INFO,
+    max_bytes: int = 2_000_000,
+    backup_count: int = 5,
+) -> logging.Logger:
+    """Configure and return the shared application logger."""
+    root = logging.getLogger("KryptoLowca")
+    if getattr(root, "_krypto_logging_configured", False):
+        return root
+
+    _ensure_rotating_handler(root, log_file=log_file, max_bytes=max_bytes, backup_count=backup_count)
+    root.setLevel(level)
+    root.propagate = True
+    setattr(root, "_krypto_logging_configured", True)
+    return root
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger that uses the shared rotating handler."""
+    setup_app_logging()
+    return logging.getLogger(name if name else "KryptoLowca")
+
+
+__all__ = [
+    "LOGS_DIR",
+    "DEFAULT_LOG_FILE",
+    "get_logger",
+    "setup_app_logging",
+]

--- a/KryptoLowca/managers/config_manager.py
+++ b/KryptoLowca/managers/config_manager.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 import json
 import logging
 import re
+from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
@@ -42,6 +44,9 @@ except Exception:  # pragma: no cover - środowiska bez PyYAML
 
 _SANITIZE = re.compile(r"[^a-zA-Z0-9_\-\.]")
 _TIMEFRAME_PATTERN = re.compile(r"^[1-9][0-9]*(m|h|d|w)$", re.IGNORECASE)
+
+
+CONFIG_SCHEMA_VERSION = 3
 
 
 def _sanitize_name(name: str) -> str:
@@ -74,10 +79,10 @@ class AISettings(_SectionModel):
 
 
 class RiskSettings(_SectionModel):
-    max_daily_loss_pct: float = Field(default=0.10, ge=0.0, le=1.0)
+    max_daily_loss_pct: float = Field(default=0.02, ge=0.0, le=1.0)
     soft_halt_losses: int = Field(default=3, ge=0)
     trade_cooldown_on_error: int = Field(default=30, ge=0, le=3600)
-    risk_per_trade: float = Field(default=0.01, ge=0.0, le=1.0)
+    risk_per_trade: float = Field(default=0.005, ge=0.0, le=1.0)
     portfolio_risk: float = Field(default=0.20, ge=0.0, le=1.0)
     one_trade_per_bar: bool = True
     cooldown_s: int = Field(default=0, ge=0, le=86_400)
@@ -112,9 +117,19 @@ class PaperSettings(_SectionModel):
     capital: float = Field(default=10_000.0, ge=0.0, le=1_000_000_000.0)
 
 
+class TelemetrySettings(_SectionModel):
+    log_interval_s: float = Field(default=30.0, ge=1.0, le=600.0)
+    alert_threshold: float = Field(default=0.85, ge=0.1, le=1.0)
+    error_threshold: int = Field(default=3, ge=1, le=50)
+    schema_version: int = Field(default=1, ge=1, le=100)
+    storage_path: Optional[str] = None
+    grpc_target: Optional[str] = None
+
+
 class ConfigPreset(BaseModel):
     """Model najwyższego poziomu opisujący pojedynczy preset."""
 
+    version: int = Field(default=CONFIG_SCHEMA_VERSION, ge=1)
     network: Literal["Testnet", "Live"] = "Testnet"
     mode: Literal["Spot", "Futures"] = "Spot"
     timeframe: str = "1m"
@@ -125,6 +140,7 @@ class ConfigPreset(BaseModel):
     slippage: SlippageSettings = Field(default_factory=SlippageSettings)
     advanced: AdvancedSettings = Field(default_factory=AdvancedSettings)
     paper: PaperSettings = Field(default_factory=PaperSettings)
+    telemetry: TelemetrySettings = Field(default_factory=TelemetrySettings)
     selected_symbols: List[str] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="allow")
@@ -138,6 +154,17 @@ class ConfigPreset(BaseModel):
         if not _TIMEFRAME_PATTERN.match(tf):
             raise ValueError("Timeframe musi mieć format np. '1m', '4h', '1d'.")
         return tf.lower()
+
+    @field_validator("version")
+    @classmethod
+    def _validate_version(cls, value: Any) -> int:
+        try:
+            version = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Pole 'version' musi być liczbą całkowitą.") from exc
+        if version <= 0:
+            raise ValueError("Pole 'version' musi być dodatnie.")
+        return version
 
     @field_validator("fraction")
     @classmethod
@@ -188,6 +215,32 @@ class ConfigPreset(BaseModel):
                 "Preset posiada bardzo niski kapitał symulacyjny (%.2f). Rozważ >= 100 USD dla sensownych testów.",
                 self.paper.capital,
             )
+
+        equity = max(self.paper.capital, 0.0)
+        requested_notional = equity * self.fraction
+        spot_limit = equity * 0.25
+        futures_limit = equity * 0.15
+        if self.mode == "Spot" and requested_notional > spot_limit + 1e-8:
+            raise ValueError(
+                "Frakcja przekracza limit 25% kapitału dla rynku Spot zgodnie z polityką zarządzania ryzykiem."
+            )
+        if self.mode == "Futures" and requested_notional > futures_limit + 1e-8:
+            raise ValueError(
+                "Frakcja przekracza limit 15% kapitału dla rynku Futures zgodnie z polityką zarządzania ryzykiem."
+            )
+
+        max_daily_loss_pct = min(0.02, 2000.0 / equity) if equity > 0 else 0.02
+        if self.risk.max_daily_loss_pct > max_daily_loss_pct + 1e-9:
+            raise ValueError(
+                "Parametr max_daily_loss_pct przekracza politykę bezpieczeństwa (min(2% * kapitału, 2000 USDT))."
+            )
+
+        if self.risk.risk_per_trade > 0.005 + 1e-9:
+            raise ValueError("risk_per_trade nie może przekraczać 0.5% kapitału na transakcję.")
+
+        if self.risk.portfolio_risk > 0.5 + 1e-9:
+            raise ValueError("portfolio_risk nie może przekraczać 50% ekspozycji łącznej.")
+
         return self
 
     def to_dict(self) -> Dict[str, Any]:
@@ -198,23 +251,182 @@ class ConfigPreset(BaseModel):
 class ConfigManager:
     """Manager presetów wykorzystywany przez ``trading_gui.py``."""
 
-    def __init__(self, presets_dir: Path | str) -> None:
+    def __init__(self, presets_dir: Path | str, *, database: Any | None = None) -> None:
         self.presets_dir = Path(presets_dir)
         self.presets_dir.mkdir(parents=True, exist_ok=True)
         logger.info("ConfigManager: katalog presetów = %s", self.presets_dir)
+        self._demo_required = True
+        self._default_template = ConfigPreset().to_dict()
+        self._last_upgrade_from: Optional[int] = None
+        self._database = database
+        self._audit_history_path = self.presets_dir / "preset_migrations.jsonl"
+        self._preset_audit_path = self.presets_dir / "preset_audit_history.jsonl"
 
     # --- walidacja ---
     def validate_preset(self, data: Dict[str, Any]) -> ConfigPreset:
         """Zwróć obiekt ``ConfigPreset`` po walidacji danych wejściowych."""
 
+        upgraded = self._upgrade_payload(data)
         try:
-            preset = ConfigPreset.model_validate(data)
+            preset = ConfigPreset.model_validate(upgraded)
         except ValidationError as exc:  # pragma: no cover - trudne do pełnego pokrycia
             errors = "; ".join(
                 f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']}" for err in exc.errors()
             )
             raise ValueError(f"Preset validation failed: {errors}") from exc
+        if self._last_upgrade_from is not None:
+            logger.info(
+                "Preset został automatycznie zaktualizowany z wersji %s do %s.",
+                self._last_upgrade_from,
+                CONFIG_SCHEMA_VERSION,
+            )
+            self._record_migration_history(upgraded)
         return preset
+
+    def require_demo_mode(self, required: bool = True) -> None:
+        """Włącz/wyłącz wymóg zapisu presetów w trybie demo."""
+
+        self._demo_required = bool(required)
+
+    def demo_mode_required(self) -> bool:
+        """Zwraca informację, czy polityka bezpieczeństwa wymaga trybu demo."""
+
+        return self._demo_required
+
+    @staticmethod
+    def current_version() -> int:
+        return CONFIG_SCHEMA_VERSION
+
+    def last_upgrade_from(self) -> Optional[int]:
+        return self._last_upgrade_from
+
+    @staticmethod
+    def _merge_nested(base: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:
+        result = deepcopy(base)
+        for key, value in overrides.items():
+            if isinstance(value, dict) and isinstance(result.get(key), dict):
+                result[key] = ConfigManager._merge_nested(result[key], value)
+            else:
+                result[key] = value
+        return result
+
+    def _upgrade_payload(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        payload = deepcopy(data)
+        version_raw = payload.get("version", 1)
+        try:
+            version = int(version_raw)
+        except (TypeError, ValueError):
+            version = 1
+        if version < 1:
+            version = 1
+
+        upgraded_from = version if version < CONFIG_SCHEMA_VERSION else None
+        if upgraded_from is not None:
+            logger.info(
+                "Aktualizuję preset z wersji %s do %s",
+                upgraded_from,
+                CONFIG_SCHEMA_VERSION,
+            )
+            if upgraded_from < 2:
+                risk_section = payload.get("risk")
+                if isinstance(risk_section, dict):
+                    risk_section.setdefault("trade_cooldown_on_error", 30)
+                    risk_section.setdefault("soft_halt_losses", risk_section.get("soft_halt_losses", 3))
+                paper_section = payload.get("paper")
+                if isinstance(paper_section, dict):
+                    try:
+                        paper_section["capital"] = float(paper_section.get("capital", 10_000.0))
+                    except (TypeError, ValueError):
+                        paper_section["capital"] = 10_000.0
+            if upgraded_from < 3:
+                telemetry_section = payload.get("telemetry")
+                if not isinstance(telemetry_section, dict):
+                    telemetry_section = {}
+                telemetry_section.setdefault("log_interval_s", 30.0)
+                telemetry_section.setdefault("alert_threshold", 0.85)
+                telemetry_section.setdefault("error_threshold", 3)
+                telemetry_section.setdefault("schema_version", 1)
+                payload["telemetry"] = telemetry_section
+
+        payload["version"] = CONFIG_SCHEMA_VERSION
+        self._last_upgrade_from = upgraded_from
+        return payload
+
+    def _record_migration_history(self, upgraded_payload: Dict[str, Any]) -> None:
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "from_version": self._last_upgrade_from,
+            "to_version": CONFIG_SCHEMA_VERSION,
+            "preview": {k: upgraded_payload.get(k) for k in ("network", "mode", "timeframe")},
+        }
+        try:
+            with self._audit_history_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        except Exception:
+            logger.exception("Nie udało się zapisać historii migracji presetów")
+
+    def audit_preset(self, data: Dict[str, Any] | ConfigPreset) -> Dict[str, Any]:
+        """Przeprowadź szybki audyt bezpieczeństwa i ryzyka dla presetu."""
+
+        preset = data if isinstance(data, ConfigPreset) else self.validate_preset(data)
+        issues: List[str] = []
+        warnings: List[str] = []
+
+        is_demo = preset.network.lower() == "testnet"
+        if self._demo_required and not is_demo:
+            issues.append(
+                "Preset wymaga trybu Testnet zgodnie z polityką bezpieczeństwa. Zmień pole 'network' na 'Testnet'."
+            )
+        if preset.network.lower() == "live":
+            warnings.append(
+                "Przed uruchomieniem na Live wykonaj pełne testy na koncie demo i upewnij się, że klucze API mają ograniczone uprawnienia."
+            )
+
+        equity = max(preset.paper.capital, 0.0)
+        requested_notional = equity * preset.fraction
+        spot_limit = equity * 0.25
+        futures_limit = equity * 0.15
+        notional_limit = spot_limit if preset.mode == "Spot" else futures_limit
+        if requested_notional > notional_limit + 1e-9:
+            issues.append(
+                "Notional pozycji przekracza dopuszczalny limit ekspozycji dla profilu początkującego."
+            )
+
+        allowed_daily_loss = min(0.02, 2000.0 / equity) if equity > 0 else 0.02
+        if preset.risk.max_daily_loss_pct > allowed_daily_loss + 1e-9:
+            issues.append(
+                "max_daily_loss_pct przekracza limit bezpieczeństwa (min(2% * E, 2000 USDT))."
+            )
+
+        if preset.risk.risk_per_trade > 0.005 + 1e-9:
+            issues.append("risk_per_trade musi być <= 0.5% kapitału.")
+
+        if preset.risk.portfolio_risk > 0.5 + 1e-9:
+            issues.append("portfolio_risk nie może przekraczać 50% ekspozycji.")
+
+        if preset.paper.capital < 500:
+            warnings.append("Kapitał paper trading < 500 – wyniki backtestu mogą być mało reprezentatywne.")
+
+        if preset.risk.trade_cooldown_on_error < 60:
+            warnings.append("Zwiększ trade_cooldown_on_error do >= 60s aby respektować politykę cooldown.")
+
+        risk_state = "lock" if issues else ("warn" if warnings else "ok")
+
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "network": preset.network,
+            "version": preset.version,
+            "upgraded_from": self._last_upgrade_from,
+            "issues": issues,
+            "warnings": warnings,
+            "demo_required": self._demo_required,
+            "is_demo": is_demo,
+            "risk_state": risk_state,
+            "requested_notional": requested_notional,
+            "notional_limit": notional_limit,
+            "allowed_daily_loss_pct": allowed_daily_loss,
+            "schema_version": CONFIG_SCHEMA_VERSION,
+        }
 
     # --- ścieżki ---
     def _path_yaml(self, safe_name: str) -> Path:
@@ -239,6 +451,9 @@ class ConfigManager:
             raise ValueError("Preset musi być słownikiem (dict).")
 
         preset = self.validate_preset(data)
+        audit = self.audit_preset(preset)
+        if audit["issues"] and self._demo_required:
+            raise ValueError(audit["issues"][0])
         payload = preset.to_dict()
 
         if _HAS_YAML:
@@ -247,6 +462,7 @@ class ConfigManager:
                 with path.open("w", encoding="utf-8") as f:
                     yaml.safe_dump(payload, f, allow_unicode=True, sort_keys=False)  # type: ignore[arg-type]
                 logger.info("Zapisano preset YAML: %s", path)
+                self._log_audit_entry(name, audit, payload, path)
                 return path
             except Exception as e:  # pragma: no cover - zależne od dysku/środowiska
                 logger.error("Błąd zapisu YAML (%s): %s – próba JSON", path, e)
@@ -255,7 +471,71 @@ class ConfigManager:
         with path.open("w", encoding="utf-8") as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
         logger.info("Zapisano preset JSON: %s", path)
+        self._log_audit_entry(name, audit, payload, path)
         return path
+
+    def create_preset(
+        self,
+        name: str,
+        *,
+        base: Optional[str] = None,
+        overrides: Optional[Dict[str, Any]] = None,
+        ensure_demo: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Stwórz preset na bazie szablonu i nadpisów, zwracając raport audytu."""
+
+        payload = deepcopy(self._default_template)
+        if base:
+            base_payload = self.load_preset(base)
+            payload = ConfigManager._merge_nested(payload, base_payload)
+        if overrides:
+            payload = ConfigManager._merge_nested(payload, overrides)
+
+        preset = self.validate_preset(payload)
+        require_demo = self._demo_required if ensure_demo is None else bool(ensure_demo)
+        if require_demo and preset.network.lower() != "testnet":
+            preset = preset.copy(update={"network": "Testnet"})
+
+        audit = self.audit_preset(preset)
+        if require_demo and audit["issues"]:
+            raise ValueError(audit["issues"][0])
+
+        path = self.save_preset(name, preset.to_dict())
+        result = dict(audit)
+        result.update({
+            "name": name,
+            "path": str(path),
+            "preset": preset.to_dict(),
+        })
+        return result
+
+    def _log_audit_entry(
+        self,
+        name: str,
+        audit: Dict[str, Any],
+        payload: Dict[str, Any],
+        path: Path,
+    ) -> None:
+        record = dict(audit)
+        record.update({"name": name, "path": str(path)})
+        record["preset"] = payload
+        try:
+            with self._preset_audit_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception:
+            logger.exception("Nie udało się zapisać audytu presetu")
+
+        db = self._database
+        if db is not None and hasattr(db, "sync"):
+            try:
+                db.sync.add_log(
+                    level="INFO",
+                    source="config_audit",
+                    message=f"Preset audit {name}: {audit.get('risk_state', 'ok')}",
+                    extra={"category": "config_audit", "audit": audit},
+                )
+            except Exception:
+                logger.exception("Nie udało się zapisać audytu presetu do bazy")
 
     def load_preset(self, name: str) -> Dict[str, Any]:
         safe = _sanitize_name(name)
@@ -281,6 +561,11 @@ class ConfigManager:
         payload = preset.to_dict()
         logger.info("Załadowano preset %s (znormalizowany)", path)
         return payload
+
+    def preset_wizard(self) -> "PresetWizard":
+        """Utwórz kreator presetów ułatwiający stopniowe budowanie konfiguracji."""
+
+        return PresetWizard(self)
 
     # --- dodatki przydatne w GUI ---
     def list_presets(self) -> List[str]:
@@ -311,6 +596,75 @@ class ConfigManager:
         return p if p is not None else self._path_yaml(safe)
 
 
+class PresetWizard:
+    """Prosty kreator presetów wspierający profile ryzyka i kontrolę demo."""
+
+    def __init__(self, manager: ConfigManager) -> None:
+        self._manager = manager
+        self._base: Optional[str] = None
+        self._overrides: Dict[str, Any] = {}
+        self._ensure_demo: Optional[bool] = None
+
+    def from_template(self, name: str) -> "PresetWizard":
+        self._base = name
+        return self
+
+    def with_symbols(self, symbols: Iterable[str]) -> "PresetWizard":
+        cleaned: List[str] = []
+        for sym in symbols:
+            if not isinstance(sym, str):
+                continue
+            normalised = sym.strip().upper()
+            if normalised and normalised not in cleaned:
+                cleaned.append(normalised)
+        if cleaned:
+            self._overrides["selected_symbols"] = cleaned
+        return self
+
+    def with_risk_profile(self, profile: str) -> "PresetWizard":
+        presets = {
+            "conservative": {
+                "fraction": 0.1,
+                "risk": {"max_daily_loss_pct": 0.02, "risk_per_trade": 0.004},
+            },
+            "balanced": {
+                "fraction": 0.18,
+                "risk": {"max_daily_loss_pct": 0.02, "risk_per_trade": 0.005},
+            },
+            "aggressive": {
+                "fraction": 0.24,
+                "risk": {"max_daily_loss_pct": 0.02, "risk_per_trade": 0.005},
+            },
+        }
+        key = profile.strip().lower()
+        if key not in presets:
+            raise ValueError(f"Nieznany profil ryzyka: {profile}")
+        self._overrides = ConfigManager._merge_nested(self._overrides, presets[key])
+        return self
+
+    def ensure_demo(self, required: bool = True) -> "PresetWizard":
+        self._ensure_demo = required
+        return self
+
+    def override(self, **kwargs: Any) -> "PresetWizard":
+        if kwargs:
+            self._overrides = ConfigManager._merge_nested(self._overrides, kwargs)
+        return self
+
+    def build(self, name: str) -> Dict[str, Any]:
+        audit = self._manager.create_preset(
+            name,
+            base=self._base,
+            overrides=self._overrides or None,
+            ensure_demo=self._ensure_demo,
+        )
+        # reset stanu aby kreator można było użyć ponownie
+        self._base = None
+        self._overrides = {}
+        self._ensure_demo = None
+        return audit
+
+
 __all__ = [
     "ConfigManager",
     "ConfigPreset",
@@ -320,4 +674,6 @@ __all__ = [
     "SlippageSettings",
     "AdvancedSettings",
     "PaperSettings",
+    "TelemetrySettings",
+    "PresetWizard",
 ]

--- a/KryptoLowca/managers/risk_manager_adapter.py
+++ b/KryptoLowca/managers/risk_manager_adapter.py
@@ -2,18 +2,31 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import Any, Dict, Optional, Tuple
 
 import pandas as pd
 
+from KryptoLowca.alerts import AlertSeverity, emit_alert
 from KryptoLowca.risk_management import create_risk_manager  # istniejący moduł
+
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 
 class RiskManager:
     """Adapter zapewniający jednolity kontrakt dla GUI/TradingEngine."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], *, db_manager: Optional[Any] = None, mode: str = "paper"):
         self.risk_mgr = create_risk_manager(config)
+        self._db_manager = db_manager
+        self._mode = mode or str(config.get("mode", "paper"))
         self._last_details: Optional[Dict[str, Any]] = None
 
     def calculate_position_size(
@@ -95,6 +108,8 @@ class RiskManager:
             details["recommended_size"] = recommended
 
         self._last_details = details
+        self._log_risk_snapshot(symbol, recommended, details)
+        self._maybe_emit_alert(symbol, recommended, details)
         if return_details:
             return recommended, details
         return recommended
@@ -103,3 +118,89 @@ class RiskManager:
         """Zwróć ostatnie szczegóły kalkulacji wielkości pozycji."""
 
         return self._last_details
+
+    def set_mode(self, mode: str) -> None:
+        """Ustaw tryb pracy (paper/live) używany przy logowaniu limitów."""
+
+        if mode:
+            self._mode = mode
+
+    # ------------------------------ helpers ---------------------------------
+    def _log_risk_snapshot(self, symbol: str, recommended: float, details: Dict[str, Any]) -> None:
+        if not self._db_manager:
+            return
+
+        snapshot = {
+            "symbol": symbol,
+            "max_fraction": float(details.get("max_allowed_size", 0.0)),
+            "recommended_size": float(recommended),
+            "mode": self._mode,
+            "details": details,
+        }
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            sync = getattr(getattr(self._db_manager, "sync", None), "log_risk_limit", None)
+            if callable(sync):
+                try:
+                    sync(snapshot)
+                except Exception:  # pragma: no cover - logujemy i kontynuujemy
+                    logger.exception("Nie udało się zapisać limitu ryzyka (sync)")
+            return
+
+        log_method = getattr(self._db_manager, "log_risk_limit", None)
+        if callable(log_method):
+            try:
+                if asyncio.iscoroutinefunction(log_method):
+                    loop.create_task(log_method(snapshot))
+                else:
+                    log_method(snapshot)
+            except Exception:  # pragma: no cover
+                logger.exception("Nie udało się zapisać limitu ryzyka (async)")
+        else:
+            sync = getattr(getattr(self._db_manager, "sync", None), "log_risk_limit", None)
+            if callable(sync):
+                try:
+                    loop.run_in_executor(None, sync, snapshot)
+                except Exception:  # pragma: no cover
+                    logger.exception("Nie udało się zapisać limitu ryzyka (executor)")
+
+    def _maybe_emit_alert(self, symbol: str, recommended: float, details: Dict[str, Any]) -> None:
+        context = dict(details)
+        context.setdefault("symbol", symbol)
+        context.setdefault("mode", self._mode)
+
+        if recommended <= 0.0:
+            emit_alert(
+                f"RiskManager zablokował ekspozycję na {symbol} (rekomendacja 0%).",
+                severity=AlertSeverity.WARNING,
+                source="risk",
+                context=context,
+            )
+            return
+
+        max_allowed = float(details.get("max_allowed_size", 1.0))
+        if max_allowed > 0 and recommended >= max_allowed * 0.99:
+            emit_alert(
+                f"Rekomendowana wielkość pozycji dla {symbol} osiąga limit ryzyka.",
+                severity=AlertSeverity.WARNING,
+                source="risk",
+                context=context,
+            )
+        elif float(details.get("confidence_level", 1.0)) < 0.2:
+            emit_alert(
+                f"Niska pewność kalkulacji pozycji dla {symbol}.",
+                severity=AlertSeverity.INFO,
+                source="risk",
+                context=context,
+            )
+
+        reasoning = str(details.get("reasoning", ""))
+        if "error" in reasoning.lower():
+            emit_alert(
+                f"RiskManager zgłosił problem podczas kalkulacji dla {symbol}.",
+                severity=AlertSeverity.ERROR,
+                source="risk",
+                context=context,
+            )

--- a/KryptoLowca/telemetry.py
+++ b/KryptoLowca/telemetry.py
@@ -1,0 +1,277 @@
+"""Utility helpers for persisting and streaming telemetry snapshots."""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+try:
+    import pandas as _pd  # type: ignore
+except Exception:  # pragma: no cover - pandas optional
+    _pd = None
+
+try:  # pragma: no cover - grpc may be optional in tests
+    import grpc  # type: ignore
+except Exception:  # pragma: no cover
+    grpc = None  # type: ignore
+
+try:  # pragma: no cover
+    from grpc import aio as grpc_aio  # type: ignore
+except Exception:  # pragma: no cover
+    grpc_aio = None  # type: ignore
+
+from KryptoLowca.telemetry_pb import (
+    ApiTelemetrySnapshot,
+    TelemetryAck,
+    PROTOBUF_AVAILABLE,
+    build_snapshot_message,
+)
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+
+class TelemetryWriter:
+    """Persist telemetry snapshots to local storage and optionally stream via gRPC."""
+
+    def __init__(
+        self,
+        *,
+        storage_path: Path | str,
+        exchange: str,
+        mode: str = "paper",
+        grpc_target: Optional[str] = None,
+        aggregate_intervals: Sequence[int] = (1, 10, 60),
+    ) -> None:
+        self.storage_dir = Path(storage_path)
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.exchange = exchange
+        self.mode = mode
+        self.aggregate_intervals = tuple(int(x) for x in aggregate_intervals if int(x) > 0)
+        self.sqlite_path = self.storage_dir / "telemetry.sqlite"
+        self.parquet_path = self.storage_dir / "telemetry.parquet"
+        self.proto_path = self.storage_dir / "latest_snapshot.pb"
+        self._has_pandas = _pd is not None
+        self._ensure_sqlite()
+
+        self._grpc_target = grpc_target
+        self._grpc_channel = None
+        self._grpc_stub = None
+        if grpc_target and grpc is not None and PROTOBUF_AVAILABLE:
+            try:  # pragma: no cover - zależne od środowiska
+                self._grpc_channel = grpc.insecure_channel(grpc_target)
+                self._grpc_stub = self._grpc_channel.unary_unary(
+                    "/telemetry.TelemetryStream/PushSnapshot",
+                    request_serializer=ApiTelemetrySnapshot.SerializeToString,
+                    response_deserializer=TelemetryAck.FromString,
+                )
+            except Exception:
+                logger.exception("Nie udało się skonfigurować kanału gRPC")
+                self._grpc_channel = None
+                self._grpc_stub = None
+        elif grpc_target:
+            logger.warning(
+                "gRPC lub protobuf nie są dostępne – snapshoty będą zapisywane lokalnie (target=%s)",
+                grpc_target,
+            )
+
+    # -------------------- Public API --------------------
+    def write_snapshot(self, snapshot: Dict[str, Any]) -> None:
+        """Persist telemetry snapshot and forward it to optional sinks."""
+
+        message: Any | None = None
+        if PROTOBUF_AVAILABLE:
+            try:
+                message = build_snapshot_message(snapshot, exchange=self.exchange, mode=self.mode)
+            except Exception:
+                logger.exception("Nie udało się zbudować wiadomości protobuf – pomijam serializację binarną")
+                message = None
+        else:
+            logger.debug("Protobuf nie jest dostępny – zapisuję jedynie dane lokalne")
+
+        if message is not None:
+            self._write_proto(message)
+        self._write_sqlite(snapshot)
+        self._write_parquet(snapshot)
+        if message is not None:
+            self._send_grpc(message)
+
+    # -------------------- Helpers --------------------
+    def _write_proto(self, message: Any) -> None:
+        try:
+            self.proto_path.write_bytes(message.SerializeToString())
+        except Exception:  # pragma: no cover - zależne od IO
+            logger.exception("Nie udało się zapisać binarnego snapshotu telemetryjnego")
+
+    def _ensure_sqlite(self) -> None:
+        conn = sqlite3.connect(self.sqlite_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS telemetry_snapshots (
+                        timestamp_ns INTEGER,
+                        schema_version INTEGER,
+                        exchange TEXT,
+                        mode TEXT,
+                        total_calls INTEGER,
+                        total_errors INTEGER,
+                        avg_latency_ms REAL,
+                        max_latency_ms REAL,
+                        last_latency_ms REAL,
+                        consecutive_errors INTEGER,
+                        window_calls INTEGER,
+                        window_errors INTEGER,
+                        last_endpoint TEXT,
+                        current_window_usage REAL,
+                        rate_limit_window_seconds REAL
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS rate_limit_snapshots (
+                        timestamp_ns INTEGER,
+                        bucket_name TEXT,
+                        capacity INTEGER,
+                        count INTEGER,
+                        usage REAL,
+                        max_usage REAL,
+                        reset_in_seconds REAL,
+                        window_seconds REAL,
+                        alert_active INTEGER
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS telemetry_aggregates (
+                        interval_s INTEGER,
+                        bucket_ts_ns INTEGER,
+                        exchange TEXT,
+                        mode TEXT,
+                        avg_latency_ms REAL,
+                        total_calls INTEGER,
+                        total_errors INTEGER,
+                        PRIMARY KEY(interval_s, bucket_ts_ns, exchange, mode)
+                    )
+                    """
+                )
+        finally:
+            conn.close()
+
+    def _write_sqlite(self, snapshot: Dict[str, Any]) -> None:
+        conn = sqlite3.connect(self.sqlite_path)
+        ts_ns = int(snapshot.get("timestamp_ns", 0))
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO telemetry_snapshots (
+                        timestamp_ns, schema_version, exchange, mode, total_calls, total_errors,
+                        avg_latency_ms, max_latency_ms, last_latency_ms, consecutive_errors,
+                        window_calls, window_errors, last_endpoint, current_window_usage, rate_limit_window_seconds
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        ts_ns,
+                        int(snapshot.get("schema_version", 1)),
+                        self.exchange,
+                        self.mode,
+                        int(snapshot.get("total_calls", 0)),
+                        int(snapshot.get("total_errors", 0)),
+                        float(snapshot.get("avg_latency_ms", 0.0)),
+                        float(snapshot.get("max_latency_ms", 0.0)),
+                        float(snapshot.get("last_latency_ms", 0.0)),
+                        int(snapshot.get("consecutive_errors", 0)),
+                        int(snapshot.get("window_calls", 0)),
+                        int(snapshot.get("window_errors", 0)),
+                        snapshot.get("last_endpoint"),
+                        float(snapshot.get("current_window_usage") or 0.0),
+                        float(snapshot.get("rate_limit_window_seconds", 0.0)),
+                    ),
+                )
+                for bucket in snapshot.get("rate_limit_buckets", []):
+                    conn.execute(
+                        """
+                        INSERT INTO rate_limit_snapshots (
+                            timestamp_ns, bucket_name, capacity, count, usage, max_usage,
+                            reset_in_seconds, window_seconds, alert_active
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            ts_ns,
+                            bucket.get("name"),
+                            int(bucket.get("capacity", 0)),
+                            int(bucket.get("count", 0)),
+                            float(bucket.get("usage", 0.0)),
+                            float(bucket.get("max_usage", 0.0)),
+                            float(bucket.get("reset_in_seconds", 0.0)),
+                            float(bucket.get("window_seconds", 0.0)),
+                            1 if bucket.get("alert_active") else 0,
+                        ),
+                    )
+                for interval in self.aggregate_intervals:
+                    bucket_ts_ns = (ts_ns // (interval * 1_000_000_000)) * (interval * 1_000_000_000)
+                    conn.execute(
+                        """
+                        INSERT OR REPLACE INTO telemetry_aggregates (
+                            interval_s, bucket_ts_ns, exchange, mode, avg_latency_ms, total_calls, total_errors
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            interval,
+                            bucket_ts_ns,
+                            self.exchange,
+                            self.mode,
+                            float(snapshot.get("avg_latency_ms", 0.0)),
+                            int(snapshot.get("total_calls", 0)),
+                            int(snapshot.get("total_errors", 0)),
+                        ),
+                    )
+        except Exception:
+            logger.exception("Nie udało się zapisać snapshotu do SQLite")
+        finally:
+            conn.close()
+
+    def _write_parquet(self, snapshot: Dict[str, Any]) -> None:
+        if not self._has_pandas:
+            return
+        data = {
+            "timestamp": datetime.fromtimestamp(snapshot.get("timestamp_ns", 0) / 1_000_000_000 or 0, tz=timezone.utc),
+            "exchange": self.exchange,
+            "mode": self.mode,
+            "avg_latency_ms": snapshot.get("avg_latency_ms", 0.0),
+            "max_latency_ms": snapshot.get("max_latency_ms", 0.0),
+            "total_calls": snapshot.get("total_calls", 0),
+            "total_errors": snapshot.get("total_errors", 0),
+            "current_window_usage": snapshot.get("current_window_usage", 0.0),
+        }
+        frame = _pd.DataFrame([data])  # type: ignore[arg-type]
+        try:
+            if self.parquet_path.exists():
+                existing = _pd.read_parquet(self.parquet_path)  # type: ignore[assignment]
+                frame = _pd.concat([existing, frame], ignore_index=True)  # type: ignore[assignment]
+            frame.to_parquet(self.parquet_path, index=False)  # type: ignore[arg-type]
+        except Exception:  # pragma: no cover - zależne od pyarrow
+            logger.exception("Nie udało się zapisać snapshotów do Parquet – fallback CSV")
+            csv_path = self.parquet_path.with_suffix(".csv")
+            header = not csv_path.exists()
+            frame.to_csv(csv_path, mode="a", header=header, index=False)  # type: ignore[arg-type]
+
+    def _send_grpc(self, message: Any) -> None:
+        if self._grpc_stub is None:
+            return
+        try:  # pragma: no cover - zależne od środowiska
+            self._grpc_stub(message, timeout=1.0)
+        except Exception:
+            logger.exception("Wysłanie snapshotu telemetryjnego przez gRPC nie powiodło się")
+
+
+__all__ = ["TelemetryWriter"]

--- a/KryptoLowca/telemetry_pb.py
+++ b/KryptoLowca/telemetry_pb.py
@@ -1,0 +1,223 @@
+"""Dynamic protobuf definitions for telemetry snapshots."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:
+    from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
+except ImportError:  # pragma: no cover - protobuf opcjonalny w środowisku testowym
+    descriptor_pb2 = descriptor_pool = message_factory = None  # type: ignore
+    PROTOBUF_AVAILABLE = False
+else:
+    PROTOBUF_AVAILABLE = True
+
+_FILE_NAME = "telemetry.proto"
+if PROTOBUF_AVAILABLE:
+    _POOL = descriptor_pool.Default()
+
+    try:
+        _POOL.FindFileByName(_FILE_NAME)
+    except KeyError:
+        file_proto = descriptor_pb2.FileDescriptorProto()
+        file_proto.name = _FILE_NAME
+        file_proto.package = "telemetry"
+
+        endpoint_msg = file_proto.message_type.add()
+        endpoint_msg.name = "EndpointMetric"
+        field = endpoint_msg.field.add()
+        field.name = "endpoint"
+        field.number = 1
+        field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+        field.type = descriptor_pb2.FieldDescriptorProto.TYPE_STRING
+
+    field = endpoint_msg.field.add()
+    field.name = "total_calls"
+    field.number = 2
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_UINT64
+
+    field = endpoint_msg.field.add()
+    field.name = "total_errors"
+    field.number = 3
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_UINT64
+
+    field = endpoint_msg.field.add()
+    field.name = "avg_latency_ms"
+    field.number = 4
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE
+
+    field = endpoint_msg.field.add()
+    field.name = "max_latency_ms"
+    field.number = 5
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE
+
+    field = endpoint_msg.field.add()
+    field.name = "last_latency_ms"
+    field.number = 6
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE
+
+    bucket_msg = file_proto.message_type.add()
+    bucket_msg.name = "RateLimitBucket"
+
+    field = bucket_msg.field.add()
+    field.name = "name"
+    field.number = 1
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_STRING
+
+    field = bucket_msg.field.add()
+    field.name = "capacity"
+    field.number = 2
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    field = bucket_msg.field.add()
+    field.name = "count"
+    field.number = 3
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_UINT32
+
+    field = bucket_msg.field.add()
+    field.name = "usage"
+    field.number = 4
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE
+
+    field = bucket_msg.field.add()
+    field.name = "max_usage"
+    field.number = 5
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE
+
+    field = bucket_msg.field.add()
+    field.name = "reset_in_seconds"
+    field.number = 6
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE
+
+    field = bucket_msg.field.add()
+    field.name = "window_seconds"
+    field.number = 7
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE
+
+    field = bucket_msg.field.add()
+    field.name = "alert_active"
+    field.number = 8
+    field.label = descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL
+    field.type = descriptor_pb2.FieldDescriptorProto.TYPE_BOOL
+
+    snapshot_msg = file_proto.message_type.add()
+    snapshot_msg.name = "ApiTelemetrySnapshot"
+
+    def _add_field(msg, name, number, field_type, label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL):
+        fld = msg.field.add()
+        fld.name = name
+        fld.number = number
+        fld.label = label
+        fld.type = field_type
+        return fld
+
+    _add_field(snapshot_msg, "schema_version", 1, descriptor_pb2.FieldDescriptorProto.TYPE_UINT32)
+    _add_field(snapshot_msg, "timestamp_ns", 2, descriptor_pb2.FieldDescriptorProto.TYPE_INT64)
+    _add_field(snapshot_msg, "exchange", 3, descriptor_pb2.FieldDescriptorProto.TYPE_STRING)
+    _add_field(snapshot_msg, "mode", 4, descriptor_pb2.FieldDescriptorProto.TYPE_STRING)
+    _add_field(snapshot_msg, "total_calls", 5, descriptor_pb2.FieldDescriptorProto.TYPE_UINT64)
+    _add_field(snapshot_msg, "total_errors", 6, descriptor_pb2.FieldDescriptorProto.TYPE_UINT64)
+    _add_field(snapshot_msg, "avg_latency_ms", 7, descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE)
+    _add_field(snapshot_msg, "max_latency_ms", 8, descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE)
+    _add_field(snapshot_msg, "last_latency_ms", 9, descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE)
+    _add_field(snapshot_msg, "consecutive_errors", 10, descriptor_pb2.FieldDescriptorProto.TYPE_UINT32)
+    _add_field(snapshot_msg, "window_calls", 11, descriptor_pb2.FieldDescriptorProto.TYPE_UINT32)
+    _add_field(snapshot_msg, "window_errors", 12, descriptor_pb2.FieldDescriptorProto.TYPE_UINT32)
+    _add_field(snapshot_msg, "last_endpoint", 13, descriptor_pb2.FieldDescriptorProto.TYPE_STRING)
+    fld = _add_field(snapshot_msg, "endpoints", 14, descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE, descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED)
+    fld.type_name = ".telemetry.EndpointMetric"
+    fld = _add_field(snapshot_msg, "buckets", 15, descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE, descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED)
+    fld.type_name = ".telemetry.RateLimitBucket"
+    _add_field(snapshot_msg, "current_window_usage", 16, descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE)
+    _add_field(snapshot_msg, "rate_limit_window_seconds", 17, descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE)
+
+    ack_msg = file_proto.message_type.add()
+    ack_msg.name = "TelemetryAck"
+    _add_field(ack_msg, "received", 1, descriptor_pb2.FieldDescriptorProto.TYPE_BOOL)
+
+    service = file_proto.service.add()
+    service.name = "TelemetryStream"
+    method = service.method.add()
+    method.name = "PushSnapshot"
+    method.input_type = ".telemetry.ApiTelemetrySnapshot"
+    method.output_type = ".telemetry.TelemetryAck"
+
+    _POOL.Add(file_proto)
+
+    _FACTORY = message_factory.MessageFactory(_POOL)
+
+    EndpointMetric = _FACTORY.GetPrototype(_POOL.FindMessageTypeByName("telemetry.EndpointMetric"))
+    RateLimitBucketMsg = _FACTORY.GetPrototype(_POOL.FindMessageTypeByName("telemetry.RateLimitBucket"))
+    ApiTelemetrySnapshot = _FACTORY.GetPrototype(_POOL.FindMessageTypeByName("telemetry.ApiTelemetrySnapshot"))
+    TelemetryAck = _FACTORY.GetPrototype(_POOL.FindMessageTypeByName("telemetry.TelemetryAck"))
+
+
+    def build_snapshot_message(snapshot: Dict[str, Any], *, exchange: str, mode: str) -> Any:
+        msg = ApiTelemetrySnapshot()
+        msg.schema_version = int(snapshot.get("schema_version", 1))
+        msg.timestamp_ns = int(snapshot.get("timestamp_ns", 0))
+        msg.exchange = exchange
+        msg.mode = mode
+        msg.total_calls = int(snapshot.get("total_calls", 0))
+        msg.total_errors = int(snapshot.get("total_errors", 0))
+        msg.avg_latency_ms = float(snapshot.get("avg_latency_ms", 0.0))
+        msg.max_latency_ms = float(snapshot.get("max_latency_ms", 0.0))
+        msg.last_latency_ms = float(snapshot.get("last_latency_ms", 0.0))
+        msg.consecutive_errors = int(snapshot.get("consecutive_errors", 0))
+        msg.window_calls = int(snapshot.get("window_calls", 0))
+        msg.window_errors = int(snapshot.get("window_errors", 0))
+        if snapshot.get("last_endpoint"):
+            msg.last_endpoint = str(snapshot["last_endpoint"])
+        msg.current_window_usage = float(snapshot.get("current_window_usage") or 0.0)
+        msg.rate_limit_window_seconds = float(snapshot.get("rate_limit_window_seconds", 0.0))
+
+        for endpoint_name, data in snapshot.get("endpoints", {}).items():
+            endpoint_msg = msg.endpoints.add()
+            endpoint_msg.endpoint = str(endpoint_name)
+            endpoint_msg.total_calls = int(data.get("total_calls", 0))
+            endpoint_msg.total_errors = int(data.get("total_errors", 0))
+            endpoint_msg.avg_latency_ms = float(data.get("avg_latency_ms", 0.0))
+            endpoint_msg.max_latency_ms = float(data.get("max_latency_ms", 0.0))
+            endpoint_msg.last_latency_ms = float(data.get("last_latency_ms", 0.0))
+
+        for bucket in snapshot.get("rate_limit_buckets", []):
+            bucket_msg = msg.buckets.add()
+            bucket_msg.name = str(bucket.get("name", ""))
+            bucket_msg.capacity = int(bucket.get("capacity", 0))
+            bucket_msg.count = int(bucket.get("count", 0))
+            bucket_msg.usage = float(bucket.get("usage", 0.0))
+            bucket_msg.max_usage = float(bucket.get("max_usage", 0.0))
+            bucket_msg.reset_in_seconds = float(bucket.get("reset_in_seconds", 0.0))
+            bucket_msg.window_seconds = float(bucket.get("window_seconds", 0.0))
+            bucket_msg.alert_active = bool(bucket.get("alert_active", False))
+
+        return msg
+
+else:  # pragma: no cover - fallback bez protobuf
+
+    EndpointMetric = RateLimitBucketMsg = ApiTelemetrySnapshot = TelemetryAck = None  # type: ignore
+
+    def build_snapshot_message(snapshot: Dict[str, Any], *, exchange: str, mode: str) -> Any:
+        raise RuntimeError(
+            "Obsługa protobuf jest niedostępna – zainstaluj pakiet 'protobuf' aby włączyć serializację telemetryjną."
+        )
+
+
+__all__ = [
+    "ApiTelemetrySnapshot",
+    "EndpointMetric",
+    "RateLimitBucketMsg",
+    "TelemetryAck",
+    "build_snapshot_message",
+]

--- a/KryptoLowca/tests/test_auto_trader.py
+++ b/KryptoLowca/tests/test_auto_trader.py
@@ -1,0 +1,123 @@
+"""Tests for safety guards in AutoTrader."""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Callable, Dict, List, Tuple
+
+import pytest
+
+from KryptoLowca.auto_trader import AutoTrader
+
+
+class DummyEmitter:
+    def __init__(self) -> None:
+        self.logs: List[Tuple[str, str, str]] = []
+
+    def on(self, *_, **__) -> None:  # pragma: no cover - interface placeholder
+        return None
+
+    def off(self, *_, **__) -> None:  # pragma: no cover - interface placeholder
+        return None
+
+    def emit(self, event: str, **payload: Any) -> None:
+        self.logs.append(("event", event, str(payload)))
+
+    def log(self, message: str, level: str = "INFO", component: str | None = None) -> None:
+        self.logs.append(("log", level, message))
+
+
+class DummyVar:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def get(self) -> str:
+        return self._value
+
+
+class NoSignalAI:
+    ai_threshold_bps = 5.0
+
+    def predict_series(self, *_, **__) -> None:
+        return None
+
+
+class DummyGUI:
+    def __init__(self, demo: bool, allow_live: bool) -> None:
+        self.timeframe_var = DummyVar("1m")
+        self.ai_mgr = NoSignalAI()
+        self.ex_mgr = self
+        self._demo = demo
+        self._allow_live = allow_live
+        self.executed: List[Tuple[str, str, float]] = []
+        self.db = DummyDB()
+
+    def is_demo_mode_active(self) -> bool:
+        return self._demo
+
+    def is_live_trading_allowed(self) -> bool:
+        return self._allow_live
+
+    def _bridge_execute_trade(self, symbol: str, side: str, price: float) -> None:
+        self.executed.append((symbol, side, price))
+
+    # Exchange-like API -------------------------------------------------
+    def fetch_ticker(self, symbol: str) -> Dict[str, float]:
+        return {"last": 100.0}
+
+
+class DummyDB:
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+        self.sync = self
+
+    def log_performance_metric(self, payload: Dict[str, Any]) -> int:
+        self.records.append(payload)
+        return len(self.records)
+
+
+@pytest.fixture()
+def demo_autotrader() -> Callable[[DummyGUI], AutoTrader]:
+    def factory(gui: DummyGUI) -> AutoTrader:
+        emitter = DummyEmitter()
+        trader = AutoTrader(emitter, gui, lambda: "BTC/USDT", auto_trade_interval_s=0.01)
+        trader.enable_auto_trade = True
+        return trader
+
+    return factory
+
+
+def _run_loop(trader: AutoTrader, duration: float = 0.1) -> None:
+    worker = threading.Thread(target=trader._auto_trade_loop, daemon=True)
+    worker.start()
+    time.sleep(duration)
+    trader._stop.set()
+    worker.join(timeout=1.0)
+    trader.stop()
+
+
+def test_no_fallback_trade_without_signal(demo_autotrader: Callable[[DummyGUI], AutoTrader]) -> None:
+    gui = DummyGUI(demo=True, allow_live=True)
+    trader = demo_autotrader(gui)
+    _run_loop(trader)
+    assert gui.executed == []
+    assert any("no valid model signal" in msg for kind, _, msg in trader.emitter.logs if kind == "log")
+
+
+def test_live_trading_blocked_without_confirmation(demo_autotrader: Callable[[DummyGUI], AutoTrader]) -> None:
+    gui = DummyGUI(demo=False, allow_live=False)
+    trader = demo_autotrader(gui)
+    _run_loop(trader)
+    assert gui.executed == []
+    assert any("live trading requires explicit confirmation" in msg for kind, _, msg in trader.emitter.logs if kind == "log")
+
+
+def test_metrics_persisted_on_trade_close(demo_autotrader: Callable[[DummyGUI], AutoTrader]) -> None:
+    gui = DummyGUI(demo=True, allow_live=True)
+    trader = demo_autotrader(gui)
+    trader._on_trade_closed("BTC/USDT", "BUY", 100.0, 110.0, 5.0, time.time())
+    metrics = gui.db.records
+    assert metrics, "Brak zapisanych metryk po zamknięciu transakcji"
+    names = {entry["metric"] for entry in metrics}
+    assert "auto_trader_expectancy" in names
+    assert any(entry["symbol"] == "BTC/USDT" for entry in metrics)

--- a/KryptoLowca/tests/test_database_manager.py
+++ b/KryptoLowca/tests/test_database_manager.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from KryptoLowca.database_manager import DatabaseManager, DBOptions, DatabaseConnectionError, MigrationError
+from KryptoLowca.managers.database_manager import CURRENT_SCHEMA_VERSION
 
 @pytest.fixture
 async def db(tmp_path):
@@ -96,3 +97,70 @@ async def test_invalid_input(db):
         await dbm.insert_trade(uid, {"ts": "2025-08-21", "qty": 1.0})
     with pytest.raises(ValueError):
         await dbm.upsert_position(uid, "BTCUSDT", -1.0, 30000.0)
+
+
+@pytest.mark.asyncio
+async def test_schema_version(db):
+    dbm, _ = db
+    version = await dbm.get_schema_version()
+    assert version == CURRENT_SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_performance_and_risk_logging(db):
+    dbm, _ = db
+    metric_id = await dbm.log_performance_metric(
+        {
+            "metric": "auto_trader_expectancy",
+            "value": 1.5,
+            "symbol": "BTC/USDT",
+            "mode": "paper",
+            "window": 10,
+            "context": {"source": "test"},
+        }
+    )
+    assert metric_id > 0
+    metrics = await dbm.fetch_performance_metrics(metric="auto_trader_expectancy")
+    assert metrics and metrics[0]["metric"] == "auto_trader_expectancy"
+
+    risk_id = await dbm.log_risk_limit(
+        {
+            "symbol": "BTC/USDT",
+            "max_fraction": 0.2,
+            "recommended_size": 0.1,
+            "mode": "paper",
+            "details": {"kelly": 0.05},
+        }
+    )
+    assert risk_id > 0
+    limits = await dbm.fetch_risk_limits(symbol="BTC/USDT")
+    assert limits and limits[0]["symbol"] == "BTC/USDT"
+
+    rate_id = await dbm.log_rate_limit_snapshot(
+        {
+            "bucket_name": "global",
+            "window_seconds": 60.0,
+            "capacity": 1200,
+            "count": 600,
+            "usage": 0.5,
+            "max_usage": 0.75,
+            "reset_in_seconds": 10.0,
+            "mode": "paper",
+            "context": {"limit_triggered": False},
+        }
+    )
+    assert rate_id > 0
+    rate_snapshots = await dbm.fetch_rate_limit_snapshots(bucket="global")
+    assert rate_snapshots and rate_snapshots[0]["bucket_name"] == "global"
+
+    audit_id = await dbm.log_security_audit(
+        {
+            "action": "decrypt_keys",
+            "status": "ok",
+            "detail": "unit-test",
+            "metadata": {"source": "tests"},
+        }
+    )
+    assert audit_id > 0
+    audits = await dbm.fetch_security_audit(action="decrypt_keys")
+    assert audits and audits[0]["detail"] == "unit-test"

--- a/KryptoLowca/tests/test_risk_management.py
+++ b/KryptoLowca/tests/test_risk_management.py
@@ -1,0 +1,86 @@
+import asyncio
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from KryptoLowca.alerts import AlertSeverity, get_alert_dispatcher
+from KryptoLowca.managers.database_manager import DatabaseManager
+from KryptoLowca.managers.risk_manager_adapter import RiskManager
+from KryptoLowca.risk_management import RiskLevel, RiskManagement
+
+
+async def test_risk_manager_logs_snapshot(tmp_path):
+    db_path = tmp_path / "risk.db"
+    db = DatabaseManager(f"sqlite+aiosqlite:///{db_path}")
+    await db.init_db()
+
+    adapter = RiskManager(config={}, db_manager=db, mode="paper")
+
+    df = pd.DataFrame(
+        {
+            "close": np.linspace(100, 105, 180),
+            "volume": np.linspace(1_000_000, 900_000, 180),
+        }
+    )
+
+    size, details = adapter.calculate_position_size(
+        "BTC/USDT",
+        {"strength": 0.6, "confidence": 0.7},
+        df,
+        {"ETH/USDT": {"size": 0.1, "volatility": 0.25}},
+        return_details=True,
+    )
+
+    assert 0.0 <= size <= 1.0
+    assert "recommended_size" in details
+
+    await asyncio.sleep(0)
+
+    rows = await db.fetch_risk_limits(symbol="BTC/USDT")
+    assert rows, "Oczekiwano zapisu limitów ryzyka w bazie"
+    latest = rows[0]
+    assert latest["recommended_size"] == pytest.approx(size)
+    assert latest["mode"] == "paper"
+
+
+def test_risk_metrics_and_alert_dispatch():
+    dispatcher = get_alert_dispatcher()
+    received = []
+
+    def _handler(event):
+        if event.source == "risk":
+            received.append(event)
+
+    token = dispatcher.register(_handler, name="test-risk")
+    try:
+        rm = RiskManagement({"max_portfolio_risk": 0.2, "max_risk_per_trade": 0.05})
+        rm.portfolio_value_history = [100, 102, 98, 95, 90, 87, 85, 84, 82, 80, 78, 77]
+
+        portfolio = {
+            "BTC/USDT": {"size": 0.12, "volatility": 0.3},
+            "ETH/USDT": {"size": 0.11, "volatility": 0.28},
+        }
+        base_prices = np.linspace(100, 110, 300)
+        df = pd.DataFrame(
+            {
+                "close": base_prices,
+                "volume": np.linspace(800_000, 700_000, 300),
+            }
+        )
+        market = {symbol: df.copy() for symbol in portfolio}
+
+        metrics = rm.calculate_risk_metrics(portfolio, market)
+        assert isinstance(metrics.var_95, float)
+        assert isinstance(metrics.risk_level, RiskLevel)
+
+        emergency = rm.emergency_risk_check(60_000, 100_000, portfolio)
+        assert isinstance(emergency, dict)
+        assert emergency["actions_required"], "Powinny istnieć działania awaryjne"
+
+        assert any(evt.source == "risk" for evt in received), "Alerty ryzyka powinny zostać zarejestrowane"
+        assert any(
+            evt.severity in (AlertSeverity.WARNING, AlertSeverity.CRITICAL) for evt in received if evt.source == "risk"
+        )
+    finally:
+        dispatcher.unregister(token)

--- a/KryptoLowca/tests/test_security_manager.py
+++ b/KryptoLowca/tests/test_security_manager.py
@@ -3,45 +3,107 @@
 """
 Unit tests for security_manager.py.
 """
-import pytest
-import json
+from __future__ import annotations
+
 from pathlib import Path
-from KryptoLowca.managers.security_manager import SecurityManager, SecurityError
-from cryptography.fernet import InvalidToken
+from typing import List, Tuple
+
+import pytest
+
+from KryptoLowca.alerts import AlertSeverity, get_alert_dispatcher
+from KryptoLowca.managers.security_manager import SecurityError, SecurityManager
+
 
 @pytest.fixture
-def security_manager(tmp_path):
+def security_manager(tmp_path: Path) -> SecurityManager:
     key_file = tmp_path / "keys.enc"
     return SecurityManager(key_file=str(key_file))
 
-def test_save_and_load_keys(security_manager, tmp_path):
+
+def test_save_and_load_keys(security_manager: SecurityManager) -> None:
     keys = {
         "testnet": {"key": "test_key", "secret": "test_secret"},
-        "live": {"key": "live_key", "secret": "live_secret"}
+        "live": {"key": "live_key", "secret": "live_secret"},
     }
     password = "password123"
-    
+
     security_manager.save_encrypted_keys(keys, password)
     assert security_manager.key_file.exists()
-    
+
     loaded_keys = security_manager.load_encrypted_keys(password)
     assert loaded_keys == keys
 
-def test_invalid_password(security_manager):
+
+def test_invalid_password(security_manager: SecurityManager) -> None:
     keys = {"testnet": {"key": "test_key", "secret": "test_secret"}}
     security_manager.save_encrypted_keys(keys, "password123")
-    
+
     with pytest.raises(SecurityError, match="Invalid password"):
         security_manager.load_encrypted_keys("wrong_password")
 
-def test_missing_key_file(security_manager):
+
+def test_missing_key_file(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Key file .* not found"):
         security_manager.load_encrypted_keys("password123")
 
-def test_invalid_keys(security_manager):
+
+def test_invalid_keys(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Keys must be a non-empty dictionary"):
         security_manager.save_encrypted_keys({}, "password123")
 
-def test_invalid_password_type(security_manager):
+
+def test_invalid_password_type(security_manager: SecurityManager) -> None:
     with pytest.raises(SecurityError, match="Password must be a non-empty string"):
         security_manager.save_encrypted_keys({"testnet": {"key": "k", "secret": "s"}}, "")
+
+
+def test_audit_callback_records_events(security_manager: SecurityManager) -> None:
+    events: List[Tuple[str, dict]] = []
+
+    def _callback(action: str, payload: dict) -> None:
+        events.append((action, payload))
+
+    security_manager.register_audit_callback(_callback)
+
+    keys = {
+        "testnet": {"key": "T" * 32, "secret": "S" * 32},
+        "live": {"key": "L" * 32, "secret": "Z" * 32},
+    }
+    password = "audit-pass"
+
+    security_manager.save_encrypted_keys(keys, password)
+    loaded = security_manager.load_encrypted_keys(password)
+
+    assert loaded == keys
+    actions = [action for action, _ in events]
+    assert "encrypt_keys" in actions
+    assert "decrypt_keys" in actions
+    encrypt_payload = next(payload for action, payload in events if action == "encrypt_keys")
+    assert encrypt_payload["status"] == "success"
+    masked_key = encrypt_payload["metadata"]["keys"]["testnet"]["key"]
+    assert masked_key != keys["testnet"]["key"]
+    assert "***" in masked_key
+    decrypt_payload = next(payload for action, payload in events if action == "decrypt_keys")
+    assert decrypt_payload["status"] == "success"
+    masked_secret = decrypt_payload["metadata"]["keys"]["live"]["secret"]
+    assert masked_secret != keys["live"]["secret"]
+    assert "***" in masked_secret
+
+
+def test_decrypt_failure_emits_alert(security_manager: SecurityManager) -> None:
+    dispatcher = get_alert_dispatcher()
+    received = []
+
+    def _listener(event):
+        received.append(event)
+
+    token = dispatcher.register(_listener, name="security-test")
+    keys = {"testnet": {"key": "T" * 32, "secret": "S" * 32}}
+    password = "demo-pass"
+    security_manager.save_encrypted_keys(keys, password)
+    try:
+        with pytest.raises(SecurityError):
+            security_manager.load_encrypted_keys("wrong-pass")
+    finally:
+        dispatcher.unregister(token)
+    assert any(event.severity == AlertSeverity.CRITICAL for event in received)

--- a/KryptoLowca/tests/test_trading_engine.py
+++ b/KryptoLowca/tests/test_trading_engine.py
@@ -116,6 +116,7 @@ class MockDB:
         self.order_updates = []
         self.logs = []
         self.positions = []
+        self.risk_limits = []
 
     async def ensure_user(self, email: str) -> int:
         return 1
@@ -129,6 +130,10 @@ class MockDB:
     async def record_order(self, order):
         self.orders.append(order)
         return len(self.orders)
+
+    async def log_risk_limit(self, payload):
+        self.risk_limits.append(payload)
+        return len(self.risk_limits)
 
     async def update_order_status(
         self,
@@ -197,6 +202,7 @@ def test_execute_live_tick(engine):
     assert plan["execution"]["status"] == "FILLED"
     assert engine.ex_mgr.created_orders  # type: ignore[attr-defined]
     assert engine.db_manager.orders  # type: ignore[attr-defined]
+    assert engine.db_manager.risk_limits  # type: ignore[attr-defined]
 
 
 def test_no_signal(engine):


### PR DESCRIPTION
## Summary
- rename the security audit metadata column and normalise JSON decoding so snapshots survive round-trips through the database layer
- tighten default risk settings to comply with daily loss and per-trade constraints and keep audit alerts wired into the dispatcher
- make telemetry protobuf support optional with a graceful fallback and reuse the writer for local persistence when google protobuf is missing

## Testing
- pytest KryptoLowca/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d598f15558832aae1a56aaf34e509b