### PR TITLE
Integrate strategy risk config and guards into auto trader

### DIFF
--- a/KryptoLowca/bot/tests/test_config_manager.py
+++ b/KryptoLowca/bot/tests/test_config_manager.py
@@ -4,12 +4,22 @@
 Unit tests for config_manager.py.
 """
 import asyncio
+from dataclasses import asdict
 import pytest
 import yaml
 from pathlib import Path
 from cryptography.fernet import Fernet
 
-from KryptoLowca.config_manager import ConfigManager, ConfigError, ValidationError, AIConfig, DBConfig, TradeConfig, ExchangeConfig
+from KryptoLowca.config_manager import (
+    ConfigManager,
+    ConfigError,
+    ValidationError,
+    AIConfig,
+    DBConfig,
+    TradeConfig,
+    ExchangeConfig,
+    StrategyConfig,
+)
 
 @pytest.fixture
 async def config_manager(tmp_path):
@@ -24,16 +34,19 @@ async def test_load_save_config(config_manager, tmp_path):
         "ai": {"threshold_bps": 7.0, "model_types": ["rf", "lstm"], "seq_len": 20, "epochs": 10, "batch_size": 32, "model_dir": "models"},
         "db": {"db_url": "sqlite+aiosqlite:///test.db", "timeout_s": 15.0, "pool_size": 10, "max_overflow": 5},
         "trade": {"risk_per_trade": 0.02, "max_leverage": 2.0, "stop_loss_pct": 0.03, "take_profit_pct": 0.06, "max_open_positions": 3},
-        "exchange": {"api_key": "test_key", "api_secret": "test_secret", "exchange_name": "binance", "testnet": True}
+        "exchange": {"api_key": "test_key", "api_secret": "test_secret", "exchange_name": "binance", "testnet": True},
+        "strategy": {"mode": "demo", "max_leverage": 1.5, "max_position_notional_pct": 0.04, "trade_risk_pct": 0.015, "default_sl": 0.025, "default_tp": 0.05},
     }
     await config_manager.save_config(config)
     loaded = await config_manager.load_config()
     assert loaded["ai"]["threshold_bps"] == 7.0
     assert loaded["exchange"]["api_key"] == "test_key"  # Decrypted
+    assert pytest.approx(loaded["strategy"]["max_position_notional_pct"], rel=1e-6) == 0.04
     assert config_manager.config_path.exists()
     with open(config_manager.config_path, "r") as f:
         saved = yaml.safe_load(f)
     assert saved["ai"]["threshold_bps"] == 7.0
+    assert saved["strategy"]["trade_risk_pct"] == pytest.approx(0.015)
 
 @pytest.mark.asyncio
 async def test_user_config(config_manager):
@@ -46,6 +59,7 @@ async def test_user_config(config_manager):
     loaded = await config_manager.load_config(preset_name="custom", user_id=user_id)
     assert loaded["ai"]["threshold_bps"] == 10.0
     assert loaded["trade"]["risk_per_trade"] == 0.015
+    assert "strategy" in loaded
 
 @pytest.mark.asyncio
 async def test_specific_configs(config_manager):
@@ -53,17 +67,20 @@ async def test_specific_configs(config_manager):
         "ai": {"threshold_bps": 6.0, "model_types": ["rf"], "seq_len": 25, "epochs": 20, "batch_size": 48},
         "db": {"db_url": "sqlite+aiosqlite:///test2.db", "timeout_s": 20.0},
         "trade": {"risk_per_trade": 0.01, "max_leverage": 1.5},
-        "exchange": {"exchange_name": "kraken", "testnet": False}
+        "exchange": {"exchange_name": "kraken", "testnet": False},
+        "strategy": asdict(StrategyConfig.from_preset("balanced")),
     }
     await config_manager.save_config(config)
     ai_config = config_manager.load_ai_config()
     db_config = config_manager.load_db_config()
     trade_config = config_manager.load_trade_config()
     exchange_config = config_manager.load_exchange_config()
+    strategy_config = config_manager.load_strategy_config()
     assert ai_config.threshold_bps == 6.0
     assert db_config.db_url == "sqlite+aiosqlite:///test2.db"
     assert trade_config.max_leverage == 1.5
     assert exchange_config.exchange_name == "kraken"
+    assert strategy_config.preset == "BALANCED"
 
 @pytest.mark.asyncio
 async def test_encryption(config_manager):
@@ -83,7 +100,8 @@ async def test_invalid_config(config_manager):
         "ai": {"threshold_bps": -1.0},  # Invalid
         "db": {"db_url": ""},  # Invalid
         "trade": {"risk_per_trade": 2.0},  # Invalid
-        "exchange": {"api_key": 123}  # Invalid
+        "exchange": {"api_key": 123},  # Invalid
+        "strategy": {"mode": "invalid", "max_position_notional_pct": 2.0},  # Invalid
     }
     with pytest.raises(ValidationError):
         await config_manager.save_config(config)
@@ -95,3 +113,4 @@ async def test_default_config(config_manager):
     assert config["db"]["db_url"] == "sqlite+aiosqlite:///trading.db"
     assert config["trade"]["risk_per_trade"] == 0.01
     assert config["exchange"]["exchange_name"] == "binance"
+    assert config["strategy"]["preset"] == "SAFE"


### PR DESCRIPTION
## Summary
- add a dedicated `StrategyConfig` section with SAFE/BALANCED presets to the configuration manager and expose loaders/preset listing
- connect `AutoTrader` to the risk manager and strategy config to enforce leverage/notional limits, reduce-only cooldowns, and audit logging
- expand auto-trader and config-manager tests to cover risk blocking logic and strategy persistence

## Testing
- pytest KryptoLowca/tests/test_auto_trader.py KryptoLowca/bot/tests/test_config_manager.py


------
https://chatgpt.com/codex/tasks/task_e_68d6ba0f11c0832a8ede02dd6be38e37