### PR TITLE
Add integration test for auto trader risk management

### DIFF
--- a/KryptoLowca/tests/test_auto_trader.py
+++ b/KryptoLowca/tests/test_auto_trader.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import threading
 import time
+from dataclasses import asdict
+from types import MethodType
 from typing import Any, Callable, Dict, List, Tuple
 
 import pandas as pd
@@ -10,6 +12,7 @@ import pytest
 
 from KryptoLowca.auto_trader import AutoTrader
 from KryptoLowca.config_manager import StrategyConfig
+from KryptoLowca.risk_management import RiskManagement
 
 
 class DummyEmitter:
@@ -198,6 +201,34 @@ class SignalAI:
         return pd.Series([self._value] * len(df), index=df.index)
 
 
+def _convert_portfolio(portfolio_ctx: Dict[str, Any], fallback_price: float) -> Dict[str, Dict[str, float]]:
+    converted: Dict[str, Dict[str, float]] = {}
+    if not isinstance(portfolio_ctx, dict):
+        return converted
+    raw_positions = portfolio_ctx.get("positions", {})
+    if not isinstance(raw_positions, dict):
+        return converted
+    for sym, pos in raw_positions.items():
+        if not isinstance(pos, dict):
+            continue
+        try:
+            qty = abs(float(pos.get("qty", 0.0) or 0.0))
+        except Exception:
+            qty = 0.0
+        try:
+            entry = float(pos.get("entry") or pos.get("price") or fallback_price)
+        except Exception:
+            entry = fallback_price
+        notional = abs(float(pos.get("notional", qty * entry))) if entry or qty else 0.0
+        size = qty if entry <= 0 else (notional / entry if entry else qty)
+        converted[sym] = {
+            "size": size,
+            "volatility": float(pos.get("volatility", 0.2)),
+            "entry_price": entry,
+        }
+    return converted
+
+
 def test_risk_manager_blocks_trade_on_zero_fraction(
     demo_autotrader: Callable[[DummyGUI], AutoTrader]
 ) -> None:
@@ -210,3 +241,109 @@ def test_risk_manager_blocks_trade_on_zero_fraction(
     assert risk_mgr.calls > 0
     risk_events = [payload for kind, event, payload in trader.emitter.logs if kind == "event" and event == "risk_guard_event"]
     assert any("risk_fraction_zero" in payload for payload in risk_events)
+
+
+def test_real_risk_management_integration_handles_reduce_only(
+    demo_autotrader: Callable[[DummyGUI], AutoTrader]
+) -> None:
+    risk_engine = RiskManagement(
+        {
+            "max_risk_per_trade": 0.015,
+            "max_portfolio_risk": 0.2,
+            "max_positions": 5,
+        }
+    )
+    original_calc = RiskManagement.calculate_position_size
+
+    def adapted_calculate_position_size(
+        self: RiskManagement,
+        *,
+        symbol: str,
+        signal: Dict[str, Any],
+        market_data: Any,
+        portfolio: Dict[str, Any],
+        return_details: bool = False,
+    ) -> Any:
+        market_df = market_data if isinstance(market_data, pd.DataFrame) else pd.DataFrame(market_data)
+        fallback_price = float(market_df["close"].iloc[-1]) if "close" in market_df and not market_df.empty else 0.0
+        converted_portfolio = _convert_portfolio(portfolio, fallback_price)
+        sizing = original_calc(self, symbol, signal, market_df, converted_portfolio)
+        detail_payload = asdict(sizing)
+        detail_payload["engine"] = "RiskManagement"
+        if return_details:
+            return sizing.recommended_size, detail_payload
+        return sizing.recommended_size
+
+    risk_engine.calculate_position_size = MethodType(adapted_calculate_position_size, risk_engine)
+
+    gui = DummyGUI(demo=True, allow_live=True, ai=SignalAI(0.03), risk_mgr=risk_engine)
+    trader = demo_autotrader(gui)
+
+    periods = 120
+    index = pd.date_range("2024-01-01", periods=periods, freq="min")
+    steps = pd.Series(range(periods), dtype=float, index=index)
+    close = 100.0 + 0.05 * steps
+    market_df = pd.DataFrame(
+        {
+            "open": close - 0.02,
+            "high": close + 0.04,
+            "low": close - 0.06,
+            "close": close,
+            "volume": 100 + steps * 0.5,
+        },
+        index=index,
+    )
+
+    symbol = "BTC/USDT"
+    risk_engine.historical_returns[symbol] = market_df["close"].pct_change().dropna()
+    price = float(market_df["close"].iloc[-1])
+    signal_payload = AutoTrader._build_signal_payload(symbol, "BUY", 0.03)
+
+    portfolio_ctx = trader._build_portfolio_context(symbol, price)
+    expected_sizing = original_calc(
+        risk_engine,
+        symbol,
+        signal_payload,
+        market_df,
+        _convert_portfolio(portfolio_ctx, price),
+    )
+
+    decision = trader._evaluate_risk(symbol, "BUY", price, signal_payload, market_df)
+
+    assert decision.should_trade is True
+    assert decision.fraction == pytest.approx(expected_sizing.recommended_size, rel=1e-6)
+    assert decision.details["engine"] == "RiskManagement"
+    assert decision.details["risk_adjusted_size"] == pytest.approx(expected_sizing.risk_adjusted_size, rel=1e-6)
+    assert decision.mode == "demo"
+
+    tight_cfg = StrategyConfig(
+        preset="SAFE",
+        mode="demo",
+        max_leverage=0.05,
+        max_position_notional_pct=0.02,
+        trade_risk_pct=0.01,
+        default_sl=0.02,
+        default_tp=0.04,
+        violation_cooldown_s=60,
+        reduce_only_after_violation=True,
+    ).validate()
+    trader._update_strategy_config(tight_cfg)
+
+    gui.paper_balance = 100.0
+    gui._open_positions[symbol] = {"qty": 5.0, "entry": price, "side": "LONG"}
+
+    violation_decision = trader._evaluate_risk(symbol, "BUY", price, signal_payload, market_df)
+
+    assert violation_decision.should_trade is False
+    assert violation_decision.reason == "max_leverage_exceeded"
+    assert any(
+        event.get("type") == "max_leverage"
+        for event in violation_decision.details.get("limit_events", [])
+    )
+    ro_until = trader._reduce_only_until.get(symbol, 0.0)
+    assert ro_until > time.time()
+
+    reduce_only_decision = trader._evaluate_risk(symbol, "BUY", price, signal_payload, market_df)
+
+    assert reduce_only_decision.should_trade is False
+    assert reduce_only_decision.reason == "reduce_only_active"


### PR DESCRIPTION
## Summary
- add helper to translate GUI portfolio context for the risk engine
- cover AutoTrader._evaluate_risk with real RiskManagement sizing data
- verify reduce-only activation when leverage limits are breached

## Testing
- pytest KryptoLowca/tests/test_auto_trader.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c4122280832a85316c5413fc5668