### PR TITLE
Add bootstrap path handling for direct scripts

### DIFF
--- a/KryptoLowca/bot/quick_db_test.py
+++ b/KryptoLowca/bot/quick_db_test.py
@@ -1,6 +1,25 @@
 # quick_db_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import DatabaseManager
 
 def main():

--- a/KryptoLowca/bot/quick_exchange_adapter_test.py
+++ b/KryptoLowca/bot/quick_exchange_adapter_test.py
@@ -1,6 +1,25 @@
 # quick_exchange_adapter_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import DatabaseManager
 from KryptoLowca.managers.exchange_adapter import ExchangeAdapter
 

--- a/KryptoLowca/bot/quick_live_orders_test.py
+++ b/KryptoLowca/bot/quick_live_orders_test.py
@@ -1,6 +1,25 @@
 # quick_live_orders_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 import ccxt
 from KryptoLowca.managers.database_manager import DatabaseManager
 from KryptoLowca.managers.exchange_adapter import ExchangeAdapter

--- a/KryptoLowca/bot/quick_live_readonly_test.py
+++ b/KryptoLowca/bot/quick_live_readonly_test.py
@@ -1,6 +1,25 @@
 # quick_live_readonly_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import DatabaseManager
 from KryptoLowca.managers.exchange_adapter import ExchangeAdapter
 

--- a/KryptoLowca/bot/quick_paper_test.py
+++ b/KryptoLowca/bot/quick_paper_test.py
@@ -1,6 +1,25 @@
 # quick_paper_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import DatabaseManager
 from KryptoLowca.managers.paper_exchange import PaperExchange
 import datetime as dt

--- a/KryptoLowca/bot/run_autotrade_paper.py
+++ b/KryptoLowca/bot/run_autotrade_paper.py
@@ -2,11 +2,27 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from pathlib import Path
 import sys
-import time
-import signal
 import logging
+import signal
 import threading
+import time
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
 log = logging.getLogger("runner")
@@ -22,16 +38,20 @@ except Exception as e:
     log.error("Nie udało się zaimportować event_emitter_adapter: %s", e, exc_info=True)
     raise
 
-from services.order_router import PaperBroker, PaperBrokerConfig
-from services.performance_monitor import PerformanceMonitor, PerfMonitorConfig
-from services.walkforward_service import WalkForwardService, WFOServiceConfig, ObjectiveWeights
-from services.risk_manager import RiskManager, RiskConfig
-from services.strategy_engine import StrategyEngine, StrategyConfig
-from services.persistence import PersistenceService
-from services.risk_guard import RiskGuard, RiskGuardConfig
-from services.marketdata import MarketDataService, MarketDataConfig
-from services.position_sizer import PositionSizer, PositionSizerConfig
-from services.stop_tp import StopTPService, StopTPConfig
+from KryptoLowca.services.marketdata import MarketDataConfig, MarketDataService
+from KryptoLowca.services.order_router import PaperBroker, PaperBrokerConfig
+from KryptoLowca.services.performance_monitor import PerfMonitorConfig, PerformanceMonitor
+from KryptoLowca.services.persistence import PersistenceService
+from KryptoLowca.services.position_sizer import PositionSizer, PositionSizerConfig
+from KryptoLowca.services.risk_guard import RiskGuard, RiskGuardConfig
+from KryptoLowca.services.risk_manager import RiskConfig, RiskManager
+from KryptoLowca.services.stop_tp import StopTPConfig, StopTPService
+from KryptoLowca.services.strategy_engine import StrategyConfig, StrategyEngine
+from KryptoLowca.services.walkforward_service import (
+    ObjectiveWeights,
+    WFOServiceConfig,
+    WalkForwardService,
+)
 
 SYMBOL = "BTCUSDT"
 

--- a/KryptoLowca/bot/run_trading_gui_live.py
+++ b/KryptoLowca/bot/run_trading_gui_live.py
@@ -12,12 +12,30 @@ NIC nie modyfikuje trading_gui.py – importujemy i „doklejamy” funkcjonalno
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
 import math
 import traceback
 from typing import Optional, List, Dict, Any
 
 import tkinter as tk
 from tkinter import ttk, messagebox
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
 
 import KryptoLowca.trading_gui  # Twój oryginalny plik GUI (NIE MODYFIKUJEMY GO)
 

--- a/KryptoLowca/bot/run_trading_gui_paper.py
+++ b/KryptoLowca/bot/run_trading_gui_paper.py
@@ -19,11 +19,29 @@ Uwaga:
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
 import traceback
 from typing import Optional, List, Dict, Any, Set, Tuple
 
 import tkinter as tk
 from tkinter import ttk, messagebox
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
 
 import KryptoLowca.trading_gui  # oryginalne GUI
 from KryptoLowca.managers.database_manager import DatabaseManager

--- a/KryptoLowca/bot/run_trading_gui_paper_emitter.py
+++ b/KryptoLowca/bot/run_trading_gui_paper_emitter.py
@@ -1,9 +1,27 @@
 # run_trading_gui_paper_emitter.py
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 import logging
 import os
-import sys
 import threading
 import time
 from typing import Any, List

--- a/KryptoLowca/bot/tests/test_config_manager.py
+++ b/KryptoLowca/bot/tests/test_config_manager.py
@@ -4,12 +4,29 @@
 Unit tests for config_manager.py.
 """
 import asyncio
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
 import pytest
 import yaml
-from pathlib import Path
 from cryptography.fernet import Fernet
 
-from KryptoLowca.config_manager import ConfigManager, ConfigError, ValidationError, AIConfig, DBConfig, TradeConfig, ExchangeConfig
+# Ensure imports work when the test is executed as a script from its directory
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from KryptoLowca.config_manager import (
+    ConfigManager,
+    ConfigError,
+    ValidationError,
+    AIConfig,
+    DBConfig,
+    TradeConfig,
+    ExchangeConfig,
+    StrategyConfig,
+)
 
 @pytest.fixture
 async def config_manager(tmp_path):
@@ -24,16 +41,19 @@ async def test_load_save_config(config_manager, tmp_path):
         "ai": {"threshold_bps": 7.0, "model_types": ["rf", "lstm"], "seq_len": 20, "epochs": 10, "batch_size": 32, "model_dir": "models"},
         "db": {"db_url": "sqlite+aiosqlite:///test.db", "timeout_s": 15.0, "pool_size": 10, "max_overflow": 5},
         "trade": {"risk_per_trade": 0.02, "max_leverage": 2.0, "stop_loss_pct": 0.03, "take_profit_pct": 0.06, "max_open_positions": 3},
-        "exchange": {"api_key": "test_key", "api_secret": "test_secret", "exchange_name": "binance", "testnet": True}
+        "exchange": {"api_key": "test_key", "api_secret": "test_secret", "exchange_name": "binance", "testnet": True},
+        "strategy": {"mode": "demo", "max_leverage": 1.5, "max_position_notional_pct": 0.04, "trade_risk_pct": 0.015, "default_sl": 0.025, "default_tp": 0.05},
     }
     await config_manager.save_config(config)
     loaded = await config_manager.load_config()
     assert loaded["ai"]["threshold_bps"] == 7.0
     assert loaded["exchange"]["api_key"] == "test_key"  # Decrypted
+    assert pytest.approx(loaded["strategy"]["max_position_notional_pct"], rel=1e-6) == 0.04
     assert config_manager.config_path.exists()
     with open(config_manager.config_path, "r") as f:
         saved = yaml.safe_load(f)
     assert saved["ai"]["threshold_bps"] == 7.0
+    assert saved["strategy"]["trade_risk_pct"] == pytest.approx(0.015)
 
 @pytest.mark.asyncio
 async def test_user_config(config_manager):
@@ -46,6 +66,7 @@ async def test_user_config(config_manager):
     loaded = await config_manager.load_config(preset_name="custom", user_id=user_id)
     assert loaded["ai"]["threshold_bps"] == 10.0
     assert loaded["trade"]["risk_per_trade"] == 0.015
+    assert "strategy" in loaded
 
 @pytest.mark.asyncio
 async def test_specific_configs(config_manager):
@@ -53,17 +74,20 @@ async def test_specific_configs(config_manager):
         "ai": {"threshold_bps": 6.0, "model_types": ["rf"], "seq_len": 25, "epochs": 20, "batch_size": 48},
         "db": {"db_url": "sqlite+aiosqlite:///test2.db", "timeout_s": 20.0},
         "trade": {"risk_per_trade": 0.01, "max_leverage": 1.5},
-        "exchange": {"exchange_name": "kraken", "testnet": False}
+        "exchange": {"exchange_name": "kraken", "testnet": False},
+        "strategy": asdict(StrategyConfig.from_preset("balanced")),
     }
     await config_manager.save_config(config)
     ai_config = config_manager.load_ai_config()
     db_config = config_manager.load_db_config()
     trade_config = config_manager.load_trade_config()
     exchange_config = config_manager.load_exchange_config()
+    strategy_config = config_manager.load_strategy_config()
     assert ai_config.threshold_bps == 6.0
     assert db_config.db_url == "sqlite+aiosqlite:///test2.db"
     assert trade_config.max_leverage == 1.5
     assert exchange_config.exchange_name == "kraken"
+    assert strategy_config.preset == "BALANCED"
 
 @pytest.mark.asyncio
 async def test_encryption(config_manager):
@@ -83,7 +107,8 @@ async def test_invalid_config(config_manager):
         "ai": {"threshold_bps": -1.0},  # Invalid
         "db": {"db_url": ""},  # Invalid
         "trade": {"risk_per_trade": 2.0},  # Invalid
-        "exchange": {"api_key": 123}  # Invalid
+        "exchange": {"api_key": 123},  # Invalid
+        "strategy": {"mode": "invalid", "max_position_notional_pct": 2.0},  # Invalid
     }
     with pytest.raises(ValidationError):
         await config_manager.save_config(config)
@@ -95,3 +120,4 @@ async def test_default_config(config_manager):
     assert config["db"]["db_url"] == "sqlite+aiosqlite:///trading.db"
     assert config["trade"]["risk_per_trade"] == 0.01
     assert config["exchange"]["exchange_name"] == "binance"
+    assert config["strategy"]["preset"] == "SAFE"

--- a/KryptoLowca/bot/trading_gui.py
+++ b/KryptoLowca/bot/trading_gui.py
@@ -2,8 +2,26 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import os
+from pathlib import Path
 import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
+import os
 import re
 import json
 import time
@@ -14,7 +32,6 @@ import tempfile
 import webbrowser
 import asyncio
 import inspect
-from pathlib import Path
 from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional
 

--- a/KryptoLowca/bot/wfa_daemon.py
+++ b/KryptoLowca/bot/wfa_daemon.py
@@ -1,125 +1,31 @@
-# wfa_daemon.py
 # -*- coding: utf-8 -*-
-"""
-Prosty daemon WF:
-- Ładuje config JSON,
-- Buduje WalkForwardService,
-- Emisja eventów jako NDJSON (1 linia = {"event": "...", "payload": {...}}) na stdout.
-GUI może to czytać przez pipe/WebSocket bridge.
-
-Użycie:
-  python wfa_daemon.py --config wfa_config.json
-
-Jeśli chcesz tryb ciągły (live), ustaw w configu: "loop_forever": true.
-"""
+"""Alias uruchamiający głównego daemona WFO z pakietu KryptoLowca."""
 
 from __future__ import annotations
 
-import argparse
-import json
 import sys
-import time
-from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
 
-# import serwisu
-from services.walkforward_service import (
-    WalkForwardService,
-    WFConfig,
-    ReoptRules,
-    SubprocessCmds,
-)
+if __package__ in {None, ""}:
+    _current_file = Path(__file__).resolve()
+    for _parent in _current_file.parents:
+        candidate = _parent / "KryptoLowca" / "__init__.py"
+        if candidate.exists():
+            sys.path.insert(0, str(_parent))
+            __package__ = "KryptoLowca"
+            break
+    else:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "Nie można zlokalizować pakietu 'KryptoLowca'. Uruchom daemon z katalogu projektu lub"
+            " zainstaluj pakiet w środowisku (pip install -e .)."
+        )
 
-# ===== Emiter eventów -> stdout (NDJSON) =====
+from KryptoLowca.wfa_daemon import main as _main
 
-def emit_stdout(event: str, payload: Dict[str, Any]) -> None:
-    rec = {"ts": datetime.utcnow().isoformat(timespec="seconds"), "event": event, "payload": payload}
-    sys.stdout.write(json.dumps(rec, ensure_ascii=False) + "\n")
-    sys.stdout.flush()
 
-# ===== Opcjonalny provider OHLC =====
-# Podmień to na swój loader danych (DB, pliki, API).
-# Powinien zwrócić listę słowników: {"high": float, "low": float, "close": float} w kolejności po czasie.
-def ohlc_provider_stub(symbol: str, timeframe: str, dt_from, dt_to) -> Optional[List[Dict[str, float]]]:
-    # Brak realnego providera – zwracamy None (ATR wyłączony)
-    return None
+def main() -> None:
+    _main()
 
-# ===== Parsowanie configu =====
 
-def load_config(path: Path) -> Dict[str, Any]:
-    with open(path, "r", encoding="utf-8") as f:
-        text = f.read()
-    # prosty parser JSON (usuń //-komentarze jeśli używasz czystego JSON)
-    lines = []
-    for line in text.splitlines():
-        line = line.strip()
-        if line.startswith("//"):
-            continue
-        lines.append(line)
-    return json.loads("\n".join(lines))
-
-def build_service_from_config(cfg_dict: Dict[str, Any]) -> WalkForwardService:
-    rules = cfg_dict.get("rules") or {}
-    sp = cfg_dict.get("subprocess_cmds") or {}
-
-    wf_cfg = WFConfig(
-        symbols=cfg_dict["symbols"],
-        timeframe=cfg_dict["timeframe"],
-        max_bars=int(cfg_dict.get("max_bars", 12000)),
-        wf_train_bars=int(cfg_dict.get("wf_train_bars", 6000)),
-        wf_test_bars=int(cfg_dict.get("wf_test_bars", 1500)),
-        wf_step_bars=int(cfg_dict.get("wf_step_bars", 0)) or None,
-        min_trades=int(cfg_dict.get("min_trades", 10)),
-        ema_slow=int(cfg_dict.get("ema_slow", 150)),
-        capital=float(cfg_dict.get("capital", 10000.0)),
-        risk_pct=float(cfg_dict.get("risk_pct", 0.5)),
-        grids=cfg_dict.get("grids") or {},
-        workdir=Path(cfg_dict.get("workdir", "walkforwards")),
-        rules=ReoptRules(
-            reopt_pf_below=float(rules.get("reopt_pf_below", 1.20)),
-            reopt_pf_drop_pct=float(rules.get("reopt_pf_drop_pct", 35.0)),
-            reopt_exp_below=float(rules.get("reopt_exp_below", 0.0)),
-            reopt_exp_drop_pct=float(rules.get("reopt_exp_drop_pct", 40.0)),
-            atr_lookback=int(rules.get("atr_lookback", 14)),
-            atr_rise_pct=float(rules.get("atr_rise_pct", 25.0)),
-        ),
-        poll_interval_sec=float(cfg_dict.get("poll_interval_sec", 0.5)),
-        subprocess_cmds=SubprocessCmds(
-            optimize_cmd=sp.get("optimize_cmd"),
-            run_cmd=sp.get("run_cmd"),
-        ),
-        loop_forever=bool(cfg_dict.get("loop_forever", False)),
-        loop_sleep_sec=float(cfg_dict.get("loop_sleep_sec", 30.0)),
-    )
-
-    # ATR działa tylko, jeśli podasz realnego providera
-    service = WalkForwardService(cfg=wf_cfg, emit=emit_stdout, ohlc_provider=None)
-    return service
-
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--config", required=True, help="Ścieżka do pliku konfiguracyjnego JSON/JSON5")
-    args = ap.parse_args()
-
-    cfg_path = Path(args.config)
-    cfg = load_config(cfg_path)
-    service = build_service_from_config(cfg)
-
-    service.start()
-
-    # Prostolinijne oczekiwanie na zakończenie.
-    # W GUI zwykle nie używasz tej pętli – serwis żyje w tle, a GUI obsługuje interakcję.
-    try:
-        while service.is_running():
-            time.sleep(0.3)
-    except KeyboardInterrupt:
-        service.stop()
-        # daj mu ładnie się zamknąć
-        for _ in range(50):
-            if not service.is_running():
-                break
-            time.sleep(0.1)
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/KryptoLowca/quick_db_test.py
+++ b/KryptoLowca/quick_db_test.py
@@ -1,6 +1,25 @@
 # quick_db_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import DatabaseManager
 
 def main():

--- a/KryptoLowca/quick_exchange_adapter_test.py
+++ b/KryptoLowca/quick_exchange_adapter_test.py
@@ -1,6 +1,25 @@
 # quick_exchange_adapter_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import DatabaseManager
 from KryptoLowca.managers.exchange_adapter import ExchangeAdapter
 

--- a/KryptoLowca/quick_live_orders_test.py
+++ b/KryptoLowca/quick_live_orders_test.py
@@ -1,6 +1,25 @@
 # quick_live_orders_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 import ccxt
 from KryptoLowca.managers.database_manager import DatabaseManager
 from KryptoLowca.managers.exchange_adapter import ExchangeAdapter

--- a/KryptoLowca/quick_live_readonly_test.py
+++ b/KryptoLowca/quick_live_readonly_test.py
@@ -1,6 +1,25 @@
 # quick_live_readonly_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import DatabaseManager
 from KryptoLowca.managers.exchange_adapter import ExchangeAdapter
 

--- a/KryptoLowca/quick_paper_test.py
+++ b/KryptoLowca/quick_paper_test.py
@@ -1,6 +1,25 @@
 # quick_paper_test.py
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import DatabaseManager
 from KryptoLowca.managers.paper_exchange import PaperExchange
 import datetime as dt

--- a/KryptoLowca/run_autotrade_paper.py
+++ b/KryptoLowca/run_autotrade_paper.py
@@ -2,11 +2,27 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from pathlib import Path
 import sys
-import time
-import signal
 import logging
+import signal
 import threading
+import time
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
 log = logging.getLogger("runner")
@@ -22,16 +38,20 @@ except Exception as e:
     log.error("Nie udało się zaimportować event_emitter_adapter: %s", e, exc_info=True)
     raise
 
-from services.order_router import PaperBroker, PaperBrokerConfig
-from services.performance_monitor import PerformanceMonitor, PerfMonitorConfig
-from services.walkforward_service import WalkForwardService, WFOServiceConfig, ObjectiveWeights
-from services.risk_manager import RiskManager, RiskConfig
-from services.strategy_engine import StrategyEngine, StrategyConfig
-from services.persistence import PersistenceService
-from services.risk_guard import RiskGuard, RiskGuardConfig
-from services.marketdata import MarketDataService, MarketDataConfig
-from services.position_sizer import PositionSizer, PositionSizerConfig
-from services.stop_tp import StopTPService, StopTPConfig
+from KryptoLowca.services.marketdata import MarketDataConfig, MarketDataService
+from KryptoLowca.services.order_router import PaperBroker, PaperBrokerConfig
+from KryptoLowca.services.performance_monitor import PerfMonitorConfig, PerformanceMonitor
+from KryptoLowca.services.persistence import PersistenceService
+from KryptoLowca.services.position_sizer import PositionSizer, PositionSizerConfig
+from KryptoLowca.services.risk_guard import RiskGuard, RiskGuardConfig
+from KryptoLowca.services.risk_manager import RiskConfig, RiskManager
+from KryptoLowca.services.stop_tp import StopTPConfig, StopTPService
+from KryptoLowca.services.strategy_engine import StrategyConfig, StrategyEngine
+from KryptoLowca.services.walkforward_service import (
+    ObjectiveWeights,
+    WFOServiceConfig,
+    WalkForwardService,
+)
 
 SYMBOL = "BTCUSDT"
 

--- a/KryptoLowca/run_trading_gui_live.py
+++ b/KryptoLowca/run_trading_gui_live.py
@@ -12,12 +12,30 @@ NIC nie modyfikuje trading_gui.py – importujemy i „doklejamy” funkcjonalno
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
 import math
 import traceback
 from typing import Optional, List, Dict, Any
 
 import tkinter as tk
 from tkinter import ttk, messagebox
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
 
 import KryptoLowca.trading_gui  # Twój oryginalny plik GUI (NIE MODYFIKUJEMY GO)
 

--- a/KryptoLowca/run_trading_gui_paper.py
+++ b/KryptoLowca/run_trading_gui_paper.py
@@ -19,11 +19,29 @@ Uwaga:
 
 from __future__ import annotations
 
+from pathlib import Path
+import sys
 import traceback
 from typing import Optional, List, Dict, Any, Set, Tuple
 
 import tkinter as tk
 from tkinter import ttk, messagebox
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
 
 import KryptoLowca.trading_gui  # oryginalne GUI
 from KryptoLowca.managers.database_manager import DatabaseManager

--- a/KryptoLowca/run_trading_gui_paper_emitter.py
+++ b/KryptoLowca/run_trading_gui_paper_emitter.py
@@ -1,9 +1,27 @@
 # run_trading_gui_paper_emitter.py
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 import logging
 import os
-import sys
 import threading
 import time
 from typing import Any, List

--- a/KryptoLowca/tests/test_auto_trader.py
+++ b/KryptoLowca/tests/test_auto_trader.py
@@ -1,13 +1,22 @@
 """Tests for safety guards in AutoTrader."""
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 import threading
 import time
 from typing import Any, Callable, Dict, List, Tuple
 
+import pandas as pd
 import pytest
 
+# Ensure repository root is available on sys.path when running the test as a script
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from KryptoLowca.auto_trader import AutoTrader
+from KryptoLowca.config_manager import StrategyConfig
 
 
 class DummyEmitter:
@@ -52,15 +61,58 @@ class DummyDB:
         return len(self.records)
 
 
+class DummyRiskManager:
+    def __init__(self, fraction: float = 0.05) -> None:
+        self.fraction = fraction
+        self.calls = 0
+
+    def calculate_position_size(
+        self,
+        symbol: str,
+        signal: Any,
+        market_data: Any,
+        portfolio: Dict[str, Any],
+        return_details: bool = False,
+    ) -> Any:
+        self.calls += 1
+        if return_details:
+            return self.fraction, {"recommended_size": self.fraction, "reasoning": "ok"}
+        return self.fraction
+
+
+class DummyCfg:
+    def __init__(self, strategy: StrategyConfig | Dict[str, Any] | None = None) -> None:
+        self._strategy = strategy
+
+    def load_strategy_config(self) -> StrategyConfig | Dict[str, Any]:
+        if self._strategy is None:
+            return StrategyConfig()
+        return self._strategy
+
+
 class DummyGUI:
-    def __init__(self, demo: bool, allow_live: bool) -> None:
+    def __init__(
+        self,
+        demo: bool,
+        allow_live: bool,
+        *,
+        ai: Any | None = None,
+        risk_mgr: DummyRiskManager | None = None,
+        strategy: StrategyConfig | Dict[str, Any] | None = None,
+        paper_balance: float = 10_000.0,
+    ) -> None:
         self.timeframe_var = DummyVar("1m")
-        self.ai_mgr = NoSignalAI()
+        self.network_var = DummyVar("Testnet" if demo else "Live")
+        self.ai_mgr = ai or NoSignalAI()
         self.ex_mgr = self
         self._demo = demo
         self._allow_live = allow_live
         self.executed: List[Tuple[str, str, float]] = []
         self.db = DummyDB()
+        self.paper_balance = paper_balance
+        self._open_positions: Dict[str, Dict[str, Any]] = {}
+        self.risk_mgr = risk_mgr or DummyRiskManager()
+        self.cfg = DummyCfg(strategy)
 
     def is_demo_mode_active(self) -> bool:
         return self._demo
@@ -74,6 +126,21 @@ class DummyGUI:
     # Exchange-like API -------------------------------------------------
     def fetch_ticker(self, symbol: str) -> Dict[str, float]:
         return {"last": 100.0}
+
+    def fetch_ohlcv(self, symbol: str, timeframe: str = "1m", limit: int = 20) -> List[List[float]]:
+        base_ts = int(time.time() * 1000) - limit * 60_000
+        data: List[List[float]] = []
+        price = 100.0
+        for i in range(limit):
+            ts = base_ts + i * 60_000
+            open_ = price
+            high = open_ * 1.001
+            low = open_ * 0.999
+            close = open_ * 1.0005
+            volume = 10.0 + i
+            data.append([ts, open_, high, low, close, volume])
+            price = close
+        return data
 
 
 @pytest.fixture()
@@ -125,3 +192,28 @@ def test_metrics_persisted_on_trade_close(demo_autotrader: Callable[[DummyGUI], 
     names = {entry["metric"] for entry in metrics}
     assert "auto_trader_expectancy" in names
     assert any(entry["symbol"] == "BTC/USDT" for entry in metrics)
+
+
+class SignalAI:
+    def __init__(self, value: float = 0.02) -> None:
+        self.ai_threshold_bps = 5.0
+        self._value = value
+
+    def predict_series(self, df: pd.DataFrame | None = None, **_: Any) -> pd.Series:
+        if df is None or df.empty:
+            return pd.Series([self._value])
+        return pd.Series([self._value] * len(df), index=df.index)
+
+
+def test_risk_manager_blocks_trade_on_zero_fraction(
+    demo_autotrader: Callable[[DummyGUI], AutoTrader]
+) -> None:
+    risk_mgr = DummyRiskManager(fraction=0.0)
+    gui = DummyGUI(demo=True, allow_live=True, ai=SignalAI(0.02), risk_mgr=risk_mgr)
+    trader = demo_autotrader(gui)
+    _run_loop(trader, duration=0.2)
+
+    assert gui.executed == []
+    assert risk_mgr.calls > 0
+    risk_events = [payload for kind, event, payload in trader.emitter.logs if kind == "event" and event == "risk_guard_event"]
+    assert any("risk_fraction_zero" in payload for payload in risk_events)

--- a/KryptoLowca/trading_gui.py
+++ b/KryptoLowca/trading_gui.py
@@ -2,8 +2,26 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import os
+from pathlib import Path
 import sys
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
+import os
 import re
 import json
 import time
@@ -14,7 +32,6 @@ import tempfile
 import webbrowser
 import asyncio
 import inspect
-from pathlib import Path
 from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional
 

--- a/ai_manager.py
+++ b/ai_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``ai_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.ai_manager import *  # noqa: F401,F403

--- a/auto_trader.py
+++ b/auto_trader.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``auto_trader``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.auto_trader import *  # noqa: F401,F403

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``config_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.config_manager import *  # noqa: F401,F403

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``core``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.core import *  # noqa: F401,F403

--- a/data_preprocessor.py
+++ b/data_preprocessor.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``data_preprocessor``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.data_preprocessor import *  # noqa: F401,F403

--- a/database_manager.py
+++ b/database_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``database_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.database_manager import *  # noqa: F401,F403

--- a/event_emitter_adapter.py
+++ b/event_emitter_adapter.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``event_emitter_adapter``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.event_emitter_adapter import *  # noqa: F401,F403

--- a/exchange_manager.py
+++ b/exchange_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``exchange_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.exchange_manager import *  # noqa: F401,F403

--- a/managers/__init__.py
+++ b/managers/__init__.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers import *  # noqa: F401,F403

--- a/managers/ai_manager.py
+++ b/managers/ai_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.ai_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.ai_manager import *  # noqa: F401,F403

--- a/managers/config_manager.py
+++ b/managers/config_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.config_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.config_manager import *  # noqa: F401,F403

--- a/managers/database_manager.py
+++ b/managers/database_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.database_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.database_manager import *  # noqa: F401,F403

--- a/managers/exchange_adapter.py
+++ b/managers/exchange_adapter.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.exchange_adapter``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.exchange_adapter import *  # noqa: F401,F403

--- a/managers/exchange_core.py
+++ b/managers/exchange_core.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.exchange_core``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.exchange_core import *  # noqa: F401,F403

--- a/managers/exchange_manager.py
+++ b/managers/exchange_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.exchange_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.exchange_manager import *  # noqa: F401,F403

--- a/managers/paper_exchange.py
+++ b/managers/paper_exchange.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.paper_exchange``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.paper_exchange import *  # noqa: F401,F403

--- a/managers/report_manager.py
+++ b/managers/report_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.report_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.report_manager import *  # noqa: F401,F403

--- a/managers/risk_manager_adapter.py
+++ b/managers/risk_manager_adapter.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.risk_manager_adapter``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.risk_manager_adapter import *  # noqa: F401,F403

--- a/managers/security_manager.py
+++ b/managers/security_manager.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``managers.security_manager``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.managers.security_manager import *  # noqa: F401,F403

--- a/risk_management.py
+++ b/risk_management.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``risk_management``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.risk_management import *  # noqa: F401,F403

--- a/trading_gui.py
+++ b/trading_gui.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``trading_gui``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.trading_gui import *  # noqa: F401,F403

--- a/trading_strategies.py
+++ b/trading_strategies.py
@@ -1,1 +1,24 @@
+"""Wejściowy moduł zgodności dla ``trading_strategies``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_repo_root() -> None:
+    current_dir = Path(__file__).resolve().parent
+    for candidate in (current_dir, *current_dir.parents):
+        package_init = candidate / "KryptoLowca" / "__init__.py"
+        if package_init.exists():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                sys.path.insert(0, candidate_str)
+            break
+
+
+if __package__ in (None, ""):
+    _ensure_repo_root()
+
+
 from KryptoLowca.trading_strategies import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- add a consistent sys.path bootstrap helper to all root-level compatibility modules so imports work when executed from nested folders
- update GUI launchers, autotrade runner, quick demo scripts, and walk-forward daemon to locate the repository root automatically before importing the KryptoLowca package
- mirror the same path bootstrap in bot-facing wrappers to keep both entrypoint sets aligned

## Testing
- pytest KryptoLowca/tests/test_auto_trader.py KryptoLowca/bot/tests/test_config_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ba0f11c0832a8ede02dd6be38e37