### PR TITLE
Add async auto-trade loop test using real risk management

### DIFF
--- a/KryptoLowca/tests/test_auto_trader.py
+++ b/KryptoLowca/tests/test_auto_trader.py
@@ -1,6 +1,8 @@
 """Tests for safety guards in AutoTrader."""
 from __future__ import annotations
 
+import asyncio
+import ast
 import sys
 from pathlib import Path
 import threading
@@ -17,7 +19,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from KryptoLowca.auto_trader import AutoTrader
+from KryptoLowca.auto_trader import AutoTrader, RiskDecision
 from KryptoLowca.config_manager import StrategyConfig
 from KryptoLowca.risk_management import RiskManagement
 
@@ -354,3 +356,165 @@ def test_real_risk_management_integration_handles_reduce_only(
 
     assert reduce_only_decision.should_trade is False
     assert reduce_only_decision.reason == "reduce_only_active"
+
+
+@pytest.mark.asyncio
+async def test_auto_trade_loop_with_real_risk_management_emits_positive_fraction(
+    demo_autotrader: Callable[[DummyGUI], AutoTrader]
+) -> None:
+    risk_engine = RiskManagement(
+        {
+            "max_risk_per_trade": 0.05,
+            "max_portfolio_risk": 0.3,
+            "max_positions": 8,
+            "lookback_period": 60,
+        }
+    )
+    original_calc = RiskManagement.calculate_position_size
+
+    def adapted_calculate_position_size(self: RiskManagement, *args: Any, **kwargs: Any) -> Any:
+        if args:
+            symbol = args[0]
+            signal_data = args[1] if len(args) > 1 else kwargs.get("signal_data") or kwargs.get("signal")
+            market_data = args[2] if len(args) > 2 else kwargs.get("market_data")
+            current_portfolio = args[3] if len(args) > 3 else kwargs.get("current_portfolio")
+        else:
+            symbol = kwargs.get("symbol")
+            signal_data = kwargs.get("signal_data") or kwargs.get("signal")
+            market_data = kwargs.get("market_data")
+            current_portfolio = kwargs.get("current_portfolio") or kwargs.get("portfolio")
+
+        signal_data = signal_data or {}
+        market_df = (
+            market_data
+            if isinstance(market_data, pd.DataFrame)
+            else pd.DataFrame(market_data or [], columns=["timestamp", "open", "high", "low", "close", "volume"])
+        )
+        if "close" not in market_df.columns and not market_df.empty:
+            market_df = market_df.rename(
+                columns={
+                    market_df.columns[i]: name
+                    for i, name in enumerate(["timestamp", "open", "high", "low", "close", "volume"])
+                    if i < len(market_df.columns)
+                }
+            )
+        fallback_price = float(market_df["close"].iloc[-1]) if "close" in market_df.columns and not market_df.empty else 0.0
+        converted_portfolio = _convert_portfolio(current_portfolio or {}, fallback_price)
+        return original_calc(self, symbol, signal_data, market_df, converted_portfolio)
+
+    risk_engine.calculate_position_size = MethodType(adapted_calculate_position_size, risk_engine)
+
+    base_ts = int(pd.Timestamp("2024-03-01T00:00:00Z").timestamp() * 1000)
+    mini_ohlcv: List[List[float]] = []
+    price = 100.0
+    for step in range(48):
+        ts = base_ts + step * 60_000
+        open_ = price
+        close = open_ * (1 + 0.0008 * ((step % 5) + 1))
+        high = max(open_, close) * 1.001
+        low = min(open_, close) * 0.999
+        volume = 25.0 + step
+        mini_ohlcv.append([ts, open_, high, low, close, volume])
+        price = close
+
+    market_df = pd.DataFrame(
+        mini_ohlcv,
+        columns=["timestamp", "open", "high", "low", "close", "volume"],
+    )
+    symbol = "BTC/USDT"
+    risk_engine.historical_returns[symbol] = market_df["close"].pct_change().dropna()
+    risk_engine.historical_returns["ETH/USDT"] = risk_engine.historical_returns[symbol] * 0.5
+
+    strategy_cfg = StrategyConfig(
+        preset="CUSTOM",
+        mode="demo",
+        max_leverage=3.0,
+        max_position_notional_pct=0.5,
+        trade_risk_pct=0.02,
+        default_sl=0.01,
+        default_tp=0.03,
+        violation_cooldown_s=45,
+        reduce_only_after_violation=False,
+    ).validate()
+
+    gui = DummyGUI(
+        demo=True,
+        allow_live=True,
+        ai=SignalAI(0.04),
+        risk_mgr=risk_engine,
+        strategy=strategy_cfg,
+        paper_balance=25_000.0,
+    )
+    gui._open_positions["ETH/USDT"] = {"qty": 0.6, "entry": 1_850.0, "side": "LONG"}
+
+    def fetch_override(self: DummyGUI, *_: Any, **__: Any) -> List[List[float]]:
+        return mini_ohlcv
+
+    gui.fetch_ohlcv = MethodType(fetch_override, gui)
+
+    trader = demo_autotrader(gui)
+
+    captured: Dict[str, Any] = {}
+    original_evaluate = trader._evaluate_risk
+
+    def capture_evaluate(
+        self: AutoTrader,
+        capture_symbol: str,
+        side: str,
+        price_val: float,
+        signal_payload: Dict[str, Any],
+        market_payload: Any,
+    ) -> Any:
+        captured["symbol"] = capture_symbol
+        captured["price"] = price_val
+        captured["signal"] = dict(signal_payload)
+        if isinstance(market_payload, pd.DataFrame):
+            captured["market_df"] = market_payload.copy(deep=True)
+        else:
+            captured["market_df"] = pd.DataFrame(market_payload)
+        decision = original_evaluate(capture_symbol, side, price_val, signal_payload, market_payload)
+        captured["decision"] = decision
+        return decision
+
+    trader._evaluate_risk = MethodType(capture_evaluate, trader)
+
+    await asyncio.to_thread(_run_loop, trader, duration=0.2)
+
+    assert gui.executed, "Auto-trader powinien wykonać przynajmniej jedną transakcję"
+    assert "decision" in captured, "Brak zarejestrowanej decyzji ryzyka"
+
+    decision: RiskDecision = captured["decision"]
+    assert decision.should_trade is True
+    assert decision.details["recommended_size"] == pytest.approx(decision.fraction, rel=1e-9)
+
+    captured_df = captured["market_df"]
+    assert isinstance(captured_df, pd.DataFrame)
+
+    converted_portfolio = _convert_portfolio(
+        trader._build_portfolio_context(symbol, captured["price"]),
+        captured["price"],
+    )
+    expected_sizing = original_calc(
+        risk_engine,
+        captured["symbol"],
+        captured["signal"],
+        captured_df,
+        converted_portfolio,
+    )
+
+    assert expected_sizing.recommended_size > 0
+    assert decision.fraction == pytest.approx(expected_sizing.recommended_size, rel=1e-6)
+
+    risk_events = [
+        ast.literal_eval(payload)
+        for kind, event, payload in trader.emitter.logs
+        if kind == "event" and event == "risk_guard_event"
+    ]
+    assert risk_events, "risk_guard_event powinien zostać zapisany"
+
+    last_event = risk_events[-1]
+    assert last_event["fraction"] == pytest.approx(decision.fraction, rel=1e-9)
+    assert last_event["details"]["recommended_size"] == pytest.approx(
+        decision.details["recommended_size"],
+        rel=1e-9,
+    )


### PR DESCRIPTION
## Summary
- add an asyncio-marked integration test that runs the auto trade loop with the real RiskManagement engine and compact OHLCV data
- verify the emitted risk_guard_event matches the risk decision by checking should_trade and recommended_size

## Testing
- pytest KryptoLowca/tests/test_auto_trader.py

------
https://chatgpt.com/codex/tasks/task_e_68d6db97361c832ab9d5143932dec538