### PR TITLE
Add risk audit persistence and tests

### DIFF
--- a/KryptoLowca/auto_trader.py
+++ b/KryptoLowca/auto_trader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 import time
 import statistics
+import asyncio
 from typing import Optional, List, Dict, Any, Callable, Tuple
 import inspect
 from dataclasses import dataclass, field
@@ -949,6 +950,67 @@ class AutoTrader:
             self.emitter.emit("risk_guard_event", **payload)
         except Exception:  # pragma: no cover - audyt nie może zatrzymać bota
             logger.exception("Failed to emit risk_guard_event")
+
+        db_manager = self._resolve_db()
+        if db_manager is not None:
+            limit_events: Optional[List[str]] = None
+            if isinstance(decision.details, dict):
+                candidate = decision.details.get("limit_events")
+                if isinstance(candidate, (list, tuple)):
+                    limit_events = [str(item) for item in candidate]
+            db_payload = {
+                "symbol": symbol,
+                "state": decision.state,
+                "fraction": float(decision.fraction),
+                "side": side,
+                "reason": decision.reason,
+                "price": float(price),
+                "mode": decision.mode,
+                "limit_events": limit_events,
+                "details": decision.details,
+                "stop_loss_pct": decision.stop_loss_pct,
+                "take_profit_pct": decision.take_profit_pct,
+                "should_trade": decision.should_trade,
+            }
+            try:
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    loop = None
+
+                if loop is not None:
+                    async_method = getattr(db_manager, "log_risk_audit", None)
+                    if callable(async_method):
+                        result = async_method(db_payload)
+                        if inspect.isawaitable(result):
+                            task = loop.create_task(result)
+
+                            def _handle_task(t: asyncio.Task[Any]) -> None:
+                                try:
+                                    t.result()
+                                except Exception:  # pragma: no cover - logowanie awarii w tle
+                                    logger.exception("Async risk audit log failed")
+
+                            task.add_done_callback(_handle_task)
+                        else:
+                            logger.debug("Async log_risk_audit returned non-awaitable result")
+                    else:
+                        logger.debug("No async log_risk_audit available on db manager")
+                else:
+                    sync = getattr(db_manager, "sync", None)
+                    log_method = None
+                    if sync is not None:
+                        log_method = getattr(sync, "log_risk_audit", None)
+                    if log_method is None:
+                        log_method = getattr(db_manager, "log_risk_audit", None)
+                    if callable(log_method):
+                        result = log_method(db_payload)
+                        if inspect.isawaitable(result):
+                            asyncio.run(result)
+                    else:
+                        logger.debug("No log_risk_audit method available on db manager")
+            except Exception:  # pragma: no cover - logowanie awarii
+                logger.exception("Failed to persist risk audit log")
 
         msg = (
             f"Risk state={decision.state} reason={decision.reason} symbol={symbol} side={side} fraction={decision.fraction:.4f}"


### PR DESCRIPTION
## Summary
- persist AutoTrader risk audits through the database manager when available
- extend the database schema with risk audit log support and an async/sync logging helper
- cover the new flow with a database integration test that asserts the audit entry is written

## Testing
- pytest KryptoLowca/tests/test_database_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d6db989f0c832a9326a6f162d41bad