### PR TITLE
Refactor strategy foundation into modular services

### DIFF
--- a/KryptoLowca/core/services/__init__.py
+++ b/KryptoLowca/core/services/__init__.py
@@ -1,0 +1,15 @@
+"""Szkielet usług core wykorzystywany przez trading engine."""
+
+from .error_policy import exception_guard, guard_exceptions
+from .execution_service import ExecutionService
+from .risk_service import RiskAssessment, RiskService
+from .signal_service import SignalService
+
+__all__ = [
+    "exception_guard",
+    "guard_exceptions",
+    "ExecutionService",
+    "RiskAssessment",
+    "RiskService",
+    "SignalService",
+]

--- a/KryptoLowca/core/services/error_policy.py
+++ b/KryptoLowca/core/services/error_policy.py
@@ -1,0 +1,59 @@
+"""Polityka wyjątków dla usług core."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from functools import wraps
+from typing import Any, Callable, Generator, TypeVar
+
+from KryptoLowca.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+@contextmanager
+def exception_guard(component: str, *, re_raise: bool = False) -> Generator[None, None, None]:
+    """Chroni bloki kodu przed nieobsłużonymi wyjątkami."""
+
+    try:
+        yield
+    except Exception as exc:  # pragma: no cover - defensywna warstwa
+        logger.exception("Błąd w komponencie %s", component)
+        if re_raise:
+            raise
+
+
+def guard_exceptions(component: str, *, re_raise: bool = False) -> Callable[[F], F]:
+    """Dekorator obsługujący wyjątki dla funkcji synchronicznych i asynchronicznych."""
+
+    def decorator(func: F) -> F:
+        if asyncio.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    return await func(*args, **kwargs)
+                except Exception as exc:  # pragma: no cover
+                    logger.exception("Błąd w komponencie %s", component)
+                    if re_raise:
+                        raise
+                    return None
+
+            return async_wrapper  # type: ignore[return-value]
+
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # pragma: no cover
+                logger.exception("Błąd w komponencie %s", component)
+                if re_raise:
+                    raise
+                return None
+
+        return sync_wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+__all__ = ["exception_guard", "guard_exceptions"]

--- a/KryptoLowca/core/services/execution_service.py
+++ b/KryptoLowca/core/services/execution_service.py
@@ -1,0 +1,44 @@
+"""Serwis wykonania zleceń – abstrakcja nad adapterami giełdowymi."""
+from __future__ import annotations
+
+from typing import Any, Mapping, Protocol
+
+from KryptoLowca.logging_utils import get_logger
+from KryptoLowca.strategies.base import StrategyContext, StrategySignal
+
+from .error_policy import guard_exceptions
+
+logger = get_logger(__name__)
+
+
+class ExchangeAdapter(Protocol):
+    async def submit_order(self, *, symbol: str, side: str, size: float, **kwargs: Any) -> Mapping[str, Any]:
+        ...
+
+
+class ExecutionService:
+    def __init__(self, adapter: ExchangeAdapter) -> None:
+        self._adapter = adapter
+        self._logger = get_logger(__name__)
+
+    @guard_exceptions("ExecutionService")
+    async def execute(self, signal: StrategySignal, context: StrategyContext) -> Mapping[str, Any] | None:
+        if signal.action == "HOLD":
+            self._logger.info("Sygnał HOLD – nie wysyłamy zlecenia")
+            return None
+        if signal.size is None:
+            self._logger.warning("Brak wielkości pozycji w sygnale")
+            return None
+        side = "buy" if signal.action.upper() == "BUY" else "sell"
+        payload = await self._adapter.submit_order(
+            symbol=context.symbol,
+            side=side,
+            size=signal.size,
+            stop_loss=signal.stop_loss,
+            take_profit=signal.take_profit,
+        )
+        self._logger.info("Zlecenie wysłane: %s", payload)
+        return payload
+
+
+__all__ = ["ExecutionService", "ExchangeAdapter"]

--- a/KryptoLowca/core/services/risk_service.py
+++ b/KryptoLowca/core/services/risk_service.py
@@ -1,0 +1,60 @@
+"""Moduł zarządzania ryzykiem – walidacja sygnałów przed wykonaniem."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+from KryptoLowca.logging_utils import get_logger
+from KryptoLowca.strategies.base import StrategyContext, StrategySignal
+
+logger = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class RiskAssessment:
+    allow: bool
+    reason: str
+    size: Optional[float] = None
+    stop_loss: Optional[float] = None
+    take_profit: Optional[float] = None
+
+
+class RiskService:
+    """Lekka warstwa logiki biznesowej."""
+
+    def __init__(self, *, max_position_notional_pct: float = 0.02, max_daily_loss_pct: float = 0.05) -> None:
+        self.max_position_notional_pct = max_position_notional_pct
+        self.max_daily_loss_pct = max_daily_loss_pct
+
+    def assess(self, signal: StrategySignal, context: StrategyContext, market_state: Mapping[str, float]) -> RiskAssessment:
+        if signal is None:
+            return RiskAssessment(allow=False, reason="Brak sygnału")
+
+        notional_limit = context.portfolio_value * self.max_position_notional_pct
+        proposed_size = signal.size or notional_limit
+        if proposed_size > notional_limit:
+            logger.warning(
+                "Rozmiar pozycji %s przekracza limit %.2f (portfolio %.2f)",
+                proposed_size,
+                notional_limit,
+                context.portfolio_value,
+            )
+            return RiskAssessment(allow=False, reason="Przekroczony limit pozycji")
+
+        if signal.action == "HOLD":
+            return RiskAssessment(allow=False, reason="Brak działania")
+
+        last_loss_pct = float(market_state.get("daily_loss_pct", 0.0))
+        if last_loss_pct <= -abs(self.max_daily_loss_pct):
+            return RiskAssessment(allow=False, reason="Przekroczony dzienny limit strat")
+
+        return RiskAssessment(
+            allow=True,
+            reason="OK",
+            size=proposed_size,
+            stop_loss=signal.stop_loss,
+            take_profit=signal.take_profit,
+        )
+
+
+__all__ = ["RiskService", "RiskAssessment"]

--- a/KryptoLowca/core/services/signal_service.py
+++ b/KryptoLowca/core/services/signal_service.py
@@ -1,0 +1,65 @@
+"""Serwis sygnałów łączący strategie z silnikiem wykonawczym."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping
+
+from KryptoLowca.logging_utils import get_logger
+from KryptoLowca.strategies.base import (
+    BaseStrategy,
+    DataProvider,
+    StrategyContext,
+    StrategyMetadata,
+    StrategySignal,
+    registry as global_registry,
+)
+
+from .error_policy import guard_exceptions
+
+
+class SignalService:
+    """Centralizuje uruchamianie strategii i walidację wyników."""
+
+    def __init__(self, *, strategy_registry=global_registry) -> None:
+        self._registry = strategy_registry
+        self._logger = get_logger(__name__)
+
+    @guard_exceptions("SignalService")
+    async def run_strategy(
+        self,
+        strategy_name: str,
+        context: StrategyContext,
+        market_payload: Mapping[str, object],
+        data_provider: DataProvider,
+    ) -> StrategySignal | None:
+        strategy_cls = self._registry.get(strategy_name)
+        strategy: BaseStrategy = strategy_cls()
+        await strategy.prepare(context, data_provider)
+        signal = await strategy.handle_market_data(context, market_payload)
+        self._logger.debug(
+            "Sygnał %s: action=%s confidence=%.2f", strategy_name, signal.action, signal.confidence
+        )
+        return signal
+
+    def build_context(
+        self,
+        *,
+        symbol: str,
+        timeframe: str,
+        portfolio_value: float,
+        position: float,
+        metadata: StrategyMetadata,
+        mode: str = "demo",
+    ) -> StrategyContext:
+        return StrategyContext(
+            symbol=symbol,
+            timeframe=timeframe,
+            portfolio_value=portfolio_value,
+            position=position,
+            timestamp=datetime.utcnow(),
+            metadata=metadata,
+            extra={"mode": mode},
+        )
+
+
+__all__ = ["SignalService"]

--- a/KryptoLowca/interfaces/__init__.py
+++ b/KryptoLowca/interfaces/__init__.py
@@ -1,0 +1,6 @@
+"""Warstwa interfejsów użytkownika (API i aplikacja desktopowa)."""
+
+from .api import TradingAPI
+from .desktop import DesktopInterface
+
+__all__ = ["TradingAPI", "DesktopInterface"]

--- a/KryptoLowca/interfaces/api.py
+++ b/KryptoLowca/interfaces/api.py
@@ -1,0 +1,25 @@
+"""Szkielet API (np. FastAPI) do zarządzania botem."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from KryptoLowca.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class TradingAPI:
+    """Minimalny kontroler API – do rozbudowy w kolejnych iteracjach."""
+
+    def __init__(self) -> None:
+        self._routes: Dict[str, Any] = {}
+
+    def add_route(self, path: str, handler: Any) -> None:
+        logger.debug("Rejestruję endpoint %s", path)
+        self._routes[path] = handler
+
+    def routes(self) -> Dict[str, Any]:
+        return dict(self._routes)
+
+
+__all__ = ["TradingAPI"]

--- a/KryptoLowca/interfaces/desktop.py
+++ b/KryptoLowca/interfaces/desktop.py
@@ -1,0 +1,37 @@
+"""Szkielet interfejsu desktopowego (.exe) – do rozbudowy."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+from KryptoLowca.logging_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class DesktopMenuEntry:
+    label: str
+    action: Callable[[], None]
+
+
+class DesktopInterface:
+    def __init__(self) -> None:
+        self._entries: Dict[str, DesktopMenuEntry] = {}
+
+    def register_entry(self, name: str, entry: DesktopMenuEntry) -> None:
+        logger.debug("Rejestruję akcję GUI %s", name)
+        self._entries[name] = entry
+
+    def trigger(self, name: str) -> None:
+        entry = self._entries.get(name)
+        if not entry:
+            raise KeyError(f"Brak akcji GUI '{name}'")
+        logger.info("Uruchamiam akcję GUI %s", name)
+        entry.action()
+
+    def available_entries(self) -> Dict[str, DesktopMenuEntry]:
+        return dict(self._entries)
+
+
+__all__ = ["DesktopInterface", "DesktopMenuEntry"]

--- a/KryptoLowca/strategies/base/__init__.py
+++ b/KryptoLowca/strategies/base/__init__.py
@@ -1,0 +1,16 @@
+"""Warstwa bazowa strategii – interfejs oraz rejestr."""
+
+from .engine import BaseStrategy, DataProvider, StrategyContext, StrategyError, StrategyMetadata, StrategySignal
+from .registry import StrategyRegistry, registry, strategy
+
+__all__ = [
+    "BaseStrategy",
+    "DataProvider",
+    "StrategyContext",
+    "StrategyError",
+    "StrategyMetadata",
+    "StrategySignal",
+    "StrategyRegistry",
+    "registry",
+    "strategy",
+]

--- a/KryptoLowca/strategies/base/engine.py
+++ b/KryptoLowca/strategies/base/engine.py
@@ -1,0 +1,175 @@
+"""Fundamenty silnika strategii w architekturze modułowej.
+
+Moduł dostarcza bazowe klasy danych oraz abstrakcyjny interfejs strategii,
+który będzie współdzielony przez marketplace presetów, moduł backtestingu oraz
+silnik autotradingu. Zależymy jedynie od ``logging_utils`` (centralny logger)
+i standardowych bibliotek, aby zapewnić możliwość wykorzystania w lekkich
+testach jednostkowych.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Protocol
+
+from KryptoLowca.logging_utils import get_logger
+
+__all__ = [
+    "StrategyError",
+    "StrategyMetadata",
+    "StrategyContext",
+    "StrategySignal",
+    "DataProvider",
+    "BaseStrategy",
+]
+
+
+logger = get_logger(__name__)
+
+
+class StrategyError(RuntimeError):
+    """Wspólny typ wyjątków rzucanych przez strategie."""
+
+
+@dataclass(slots=True)
+class StrategyMetadata:
+    """Opis strategii wyświetlany w marketplace i GUI."""
+
+    name: str
+    description: str
+    author: str = "internal"
+    version: str = "0.1.0"
+    tags: tuple[str, ...] = ()
+    exchanges: tuple[str, ...] = ("binance",)
+    timeframes: tuple[str, ...] = ("1h",)
+    risk_level: str = "balanced"
+
+
+@dataclass(slots=True)
+class StrategyContext:
+    """Kontekst wywołania strategii przekazywany na każdym kroku."""
+
+    symbol: str
+    timeframe: str
+    portfolio_value: float
+    position: float
+    timestamp: datetime
+    metadata: StrategyMetadata
+    extra: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def require_demo_mode(self) -> None:
+        """Prosta walidacja – blokada live tradingu przed audytem."""
+
+        if self.extra.get("mode", "demo") != "demo":
+            raise StrategyError(
+                "Strategia nie została jeszcze certyfikowana do trybu LIVE. "
+                "Uruchom ją w środowisku paper trading przed przełączeniem."
+            )
+
+
+@dataclass(slots=True)
+class StrategySignal:
+    """Struktura sygnału zwracanego przez strategie."""
+
+    symbol: str
+    action: str  # BUY, SELL, HOLD
+    confidence: float = 0.0
+    size: Optional[float] = None
+    stop_loss: Optional[float] = None
+    take_profit: Optional[float] = None
+    reason: Optional[str] = None
+    payload: Dict[str, Any] = field(default_factory=dict)
+    generated_at: datetime = field(default_factory=datetime.utcnow)
+
+    def ensure_bounds(self) -> "StrategySignal":
+        if not 0.0 <= self.confidence <= 1.0:
+            raise StrategyError("confidence musi być w zakresie 0-1")
+        if self.size is not None and self.size < 0:
+            raise StrategyError("size nie może być ujemne")
+        return self
+
+
+class DataProvider(Protocol):
+    """Minimalny interfejs wymagany do pobierania danych przez strategie."""
+
+    async def get_ohlcv(self, symbol: str, timeframe: str, *, limit: int = 500) -> Mapping[str, Any]:
+        ...
+
+    async def get_ticker(self, symbol: str) -> Mapping[str, Any]:  # pragma: no cover - interfejs
+        ...
+
+
+class BaseStrategy(ABC):
+    """Abstrakcyjna strategia – punkty rozszerzeń dla konkretnych presetów."""
+
+    metadata: StrategyMetadata
+
+    def __init__(self, metadata: StrategyMetadata | None = None) -> None:
+        self.metadata = metadata or StrategyMetadata(
+            name=self.__class__.__name__,
+            description="Brak opisu",
+        )
+        self._logger = get_logger(f"{__name__}.{self.metadata.name}")
+        self._prepared = False
+
+    async def prepare(self, context: StrategyContext, data_provider: DataProvider) -> None:
+        """Hook inicjalizacyjny uruchamiany przez silnik przed tradingiem."""
+
+        if self._prepared:
+            return
+        context.require_demo_mode()
+        await self._warmup(context, data_provider)
+        self._prepared = True
+        self._logger.info(
+            "Strategia %s przygotowana (symbol=%s, timeframe=%s)",
+            self.metadata.name,
+            context.symbol,
+            context.timeframe,
+        )
+
+    async def _warmup(self, context: StrategyContext, data_provider: DataProvider) -> None:
+        """Domyślna implementacja pobiera historię do cache'u."""
+
+        try:
+            await data_provider.get_ohlcv(context.symbol, context.timeframe, limit=200)
+        except Exception as exc:  # pragma: no cover - zależne od providerów
+            self._logger.warning("Błąd pobierania danych podczas warm-up", exc_info=exc)
+            raise StrategyError("Nie udało się pobrać danych historycznych") from exc
+
+    async def handle_market_data(
+        self,
+        context: StrategyContext,
+        market_payload: Mapping[str, Any],
+    ) -> StrategySignal:
+        """Główny punkt wejścia – deleguje generowanie sygnału."""
+
+        if not self._prepared:
+            raise StrategyError("Strategia nie została przygotowana – wywołaj prepare()")
+        try:
+            signal = await self.generate_signal(context, market_payload)
+            return signal.ensure_bounds()
+        except StrategyError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensywna warstwa
+            self._logger.exception("Nieoczekiwany błąd strategii")
+            raise StrategyError("Strategia zgłosiła nieobsługiwany wyjątek") from exc
+
+    @abstractmethod
+    async def generate_signal(
+        self,
+        context: StrategyContext,
+        market_payload: Mapping[str, Any],
+    ) -> StrategySignal:
+        """Metoda implementowana przez konkretne strategie."""
+
+    async def notify_fill(self, context: StrategyContext, fill_data: Mapping[str, Any]) -> None:
+        """Hook pozwalający zareagować na wykonane zlecenie."""
+
+        self._logger.debug("Fill data: %s", dict(fill_data))
+
+    async def shutdown(self) -> None:
+        """Umożliwia zwolnienie zasobów (np. sesji HTTP)."""
+
+        self._prepared = False
+        self._logger.info("Strategia %s zamknięta", self.metadata.name)

--- a/KryptoLowca/strategies/base/registry.py
+++ b/KryptoLowca/strategies/base/registry.py
@@ -1,0 +1,56 @@
+"""Rejestr strategii wykorzystywany przez marketplace oraz silnik autotradingu."""
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Dict, Iterable, Iterator, MutableMapping, Type
+
+from .engine import BaseStrategy, StrategyMetadata
+
+__all__ = ["StrategyRegistry", "registry", "strategy"]
+
+
+class StrategyRegistry:
+    """Łatwy w testach rejestr strategii."""
+
+    def __init__(self) -> None:
+        self._strategies: MutableMapping[str, Type[BaseStrategy]] = OrderedDict()
+
+    def register(self, strategy_cls: Type[BaseStrategy]) -> Type[BaseStrategy]:
+        key = strategy_cls.__name__.lower()
+        self._strategies[key] = strategy_cls
+        return strategy_cls
+
+    def get(self, name: str) -> Type[BaseStrategy]:
+        key = (name or "").strip().lower()
+        try:
+            return self._strategies[key]
+        except KeyError as exc:  # pragma: no cover - defensywne logowanie
+            raise KeyError(f"Strategia '{name}' nie jest zarejestrowana") from exc
+
+    def __contains__(self, item: object) -> bool:
+        if isinstance(item, str):
+            return item.strip().lower() in self._strategies
+        if isinstance(item, type) and issubclass(item, BaseStrategy):
+            return item.__name__.lower() in self._strategies
+        return False
+
+    def __iter__(self) -> Iterator[Type[BaseStrategy]]:
+        return iter(self._strategies.values())
+
+    def items(self) -> Iterable[tuple[str, Type[BaseStrategy]]]:
+        return self._strategies.items()
+
+    def metadata(self) -> Dict[str, StrategyMetadata]:
+        return {
+            name: getattr(cls, "metadata", StrategyMetadata(name=cls.__name__, description=""))
+            for name, cls in self._strategies.items()
+        }
+
+
+def strategy(strategy_cls: Type[BaseStrategy]) -> Type[BaseStrategy]:
+    """Dekorator ułatwiający rejestrację."""
+
+    return registry.register(strategy_cls)
+
+
+registry = StrategyRegistry()

--- a/KryptoLowca/strategies/presets/__init__.py
+++ b/KryptoLowca/strategies/presets/__init__.py
@@ -1,0 +1,37 @@
+"""Wbudowane presety strategii udostępniane bezpośrednio w repozytorium."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from KryptoLowca.strategies.marketplace import StrategyPreset
+
+from .daily_trend import DAILY_TREND_PRESET
+from .trend_following import INTRADAY_TREND_PRESET
+
+
+_BUILTIN_PRESETS: Dict[str, StrategyPreset] = {
+    DAILY_TREND_PRESET.preset_id: DAILY_TREND_PRESET,
+    INTRADAY_TREND_PRESET.preset_id: INTRADAY_TREND_PRESET,
+}
+
+
+def load_builtin_presets() -> Iterable[StrategyPreset]:
+    """Zwraca iterowalny zbiór presetów (łatwe do rozszerzenia w przyszłości)."""
+
+    return _BUILTIN_PRESETS.values()
+
+
+def get_builtin_preset(preset_id: str) -> StrategyPreset:
+    try:
+        return _BUILTIN_PRESETS[preset_id]
+    except KeyError as exc:  # pragma: no cover - defensywne
+        raise KeyError(f"Brak wbudowanego presetu '{preset_id}'") from exc
+
+
+__all__ = [
+    "StrategyPreset",
+    "load_builtin_presets",
+    "get_builtin_preset",
+    "DAILY_TREND_PRESET",
+    "INTRADAY_TREND_PRESET",
+]

--- a/KryptoLowca/strategies/presets/daily_trend.py
+++ b/KryptoLowca/strategies/presets/daily_trend.py
@@ -1,0 +1,48 @@
+"""Wbudowany preset dziennego trend following dla kont demo."""
+from __future__ import annotations
+
+from KryptoLowca.strategies.marketplace import StrategyPreset
+
+DAILY_TREND_PRESET = StrategyPreset(
+    preset_id="DAILY_TREND",
+    name="Daily Trend Guard",
+    description=(
+        "Konserwatywna strategia podążania za trendem dziennym. Wymusza demo "
+        "mode oraz ogranicza rozmiar pozycji do 1.5% kapitału, co jest "
+        "zgodne z dobrymi praktykami dla konta o wartości 5 000 USD."
+    ),
+    risk_level="balanced",
+    recommended_min_balance=5_000.0,
+    timeframe="1d",
+    exchanges=["binance", "kraken", "zonda"],
+    tags=["trend", "spot", "daily"],
+    config={
+        "strategy": {
+            "preset": "DAILY_TREND",
+            "mode": "demo",
+            "max_leverage": 1.0,
+            "max_position_notional_pct": 0.015,
+            "trade_risk_pct": 0.0075,
+            "default_sl": 0.02,
+            "default_tp": 0.045,
+            "violation_cooldown_s": 600,
+            "reduce_only_after_violation": True,
+        },
+        "trade": {
+            "risk_per_trade": 0.0075,
+            "max_leverage": 1.0,
+            "stop_loss_pct": 0.02,
+            "take_profit_pct": 0.05,
+            "max_open_positions": 3,
+        },
+        "exchange": {
+            "exchange_name": "binance",
+            "testnet": True,
+            "require_demo_mode": True,
+            "rate_limit_per_minute": 1200,
+            "rate_limit_alert_threshold": 0.75,
+        },
+    },
+)
+
+__all__ = ["DAILY_TREND_PRESET"]

--- a/KryptoLowca/strategies/presets/trend_following.py
+++ b/KryptoLowca/strategies/presets/trend_following.py
@@ -1,0 +1,48 @@
+"""Wbudowany preset intraday trend following dla Binance/Kraken."""
+from __future__ import annotations
+
+from KryptoLowca.strategies.marketplace import StrategyPreset
+
+INTRADAY_TREND_PRESET = StrategyPreset(
+    preset_id="INTRADAY_TREND",
+    name="Intraday Momentum Scout",
+    description=(
+        "Agresywniejsza wersja trend following na interwale 1h. Została "
+        "przygotowana do pracy z kontem demo Binance Testnet i Kraken Demo, "
+        "z dodatkowymi limitami bezpieczeństwa (cooldown po naruszeniu ryzyka)."
+    ),
+    risk_level="assertive",
+    recommended_min_balance=10_000.0,
+    timeframe="1h",
+    exchanges=["binance", "kraken"],
+    tags=["trend", "momentum", "intraday"],
+    config={
+        "strategy": {
+            "preset": "INTRADAY_TREND",
+            "mode": "demo",
+            "max_leverage": 1.0,
+            "max_position_notional_pct": 0.025,
+            "trade_risk_pct": 0.0125,
+            "default_sl": 0.018,
+            "default_tp": 0.055,
+            "violation_cooldown_s": 900,
+            "reduce_only_after_violation": True,
+        },
+        "trade": {
+            "risk_per_trade": 0.0125,
+            "max_leverage": 1.0,
+            "stop_loss_pct": 0.018,
+            "take_profit_pct": 0.055,
+            "max_open_positions": 4,
+        },
+        "exchange": {
+            "exchange_name": "kraken",
+            "testnet": True,
+            "require_demo_mode": True,
+            "rate_limit_per_minute": 900,
+            "rate_limit_alert_threshold": 0.8,
+        },
+    },
+)
+
+__all__ = ["INTRADAY_TREND_PRESET"]

--- a/KryptoLowca/tests/strategies/test_registry.py
+++ b/KryptoLowca/tests/strategies/test_registry.py
@@ -1,0 +1,104 @@
+"""Testy jednostkowe dla nowej warstwy bazowej strategii."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping
+
+import pytest
+
+from KryptoLowca.strategies.base import (
+    BaseStrategy,
+    StrategyContext,
+    StrategyError,
+    StrategyMetadata,
+    StrategySignal,
+)
+from KryptoLowca.strategies.base.registry import StrategyRegistry
+from KryptoLowca.strategies.presets import get_builtin_preset, load_builtin_presets
+
+
+@dataclass
+class _StubProvider:
+    payload: Mapping[str, Any]
+
+    async def get_ohlcv(self, symbol: str, timeframe: str, *, limit: int = 500) -> Mapping[str, Any]:
+        return {"symbol": symbol, "timeframe": timeframe, "limit": limit}
+
+    async def get_ticker(self, symbol: str) -> Mapping[str, Any]:  # pragma: no cover - nieużyte
+        return {"symbol": symbol, "price": self.payload.get("price", 0.0)}
+
+
+class _DemoStrategy(BaseStrategy):
+    metadata = StrategyMetadata(
+        name="DemoStrategy",
+        description="Strategia do testów jednostkowych",
+        risk_level="balanced",
+        exchanges=("binance",),
+        timeframes=("1h",),
+    )
+
+    async def generate_signal(
+        self,
+        context: StrategyContext,
+        market_payload: Mapping[str, Any],
+    ) -> StrategySignal:
+        price = float(market_payload.get("close", 0.0))
+        action = "BUY" if price > 0 else "HOLD"
+        return StrategySignal(symbol=context.symbol, action=action, confidence=0.8)
+
+
+@pytest.mark.asyncio
+async def test_strategy_prepare_requires_demo_mode() -> None:
+    provider = _StubProvider({"close": 100.0})
+    ctx = StrategyContext(
+        symbol="BTC/USDT",
+        timeframe="1h",
+        portfolio_value=10_000.0,
+        position=0.0,
+        timestamp=datetime.utcnow(),
+        metadata=_DemoStrategy.metadata,
+        extra={"mode": "demo"},
+    )
+    strategy = _DemoStrategy()
+    await strategy.prepare(ctx, provider)
+    signal = await strategy.handle_market_data(ctx, {"close": 100.0})
+    assert signal.action == "BUY"
+
+
+@pytest.mark.asyncio
+async def test_strategy_prepare_blocks_live_mode() -> None:
+    provider = _StubProvider({"close": -1.0})
+    ctx = StrategyContext(
+        symbol="ETH/USDT",
+        timeframe="1h",
+        portfolio_value=5_000.0,
+        position=0.0,
+        timestamp=datetime.utcnow(),
+        metadata=_DemoStrategy.metadata,
+        extra={"mode": "live"},
+    )
+    strategy = _DemoStrategy()
+    with pytest.raises(StrategyError):
+        await strategy.prepare(ctx, provider)
+
+
+def test_registry_registration() -> None:
+    local_registry = StrategyRegistry()
+
+    @local_registry.register
+    class AnotherStrategy(_DemoStrategy):
+        pass
+
+    assert "anotherstrategy" in local_registry
+    assert local_registry.get("AnotherStrategy") is AnotherStrategy
+
+
+def test_builtin_presets_available() -> None:
+    presets = list(load_builtin_presets())
+    assert presets, "Spodziewamy się co najmniej jednego wbudowanego presetu"
+    preset_ids = {preset.preset_id for preset in presets}
+    for expected in {"DAILY_TREND", "INTRADAY_TREND"}:
+        assert expected in preset_ids
+        preset = get_builtin_preset(expected)
+        assert preset.config["strategy"]["mode"] == "demo"


### PR DESCRIPTION
## Summary
- introduce modular strategy base package with registry and async-safe error handling
- add built-in demo presets and surface them through the marketplace/config manager
- scaffold core services (signal, risk, execution) plus API/desktop interfaces and new unit tests

## Testing
- pytest KryptoLowca/tests/strategies/test_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68d6fd71a630832a8daffb176bd592d7