### PR TITLE
Document architecture and add lint/type CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master", "develop"]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r KryptoLowca/requirements.txt
+          pip install pytest ruff mypy
+
+      - name: Ruff lint
+        run: >-
+          ruff check
+          KryptoLowca/core/services
+          KryptoLowca/strategies/base
+          KryptoLowca/config_manager.py
+          KryptoLowca/strategies/marketplace.py
+
+      - name: Mypy type check
+        run: mypy
+
+      - name: Pytest
+        run: pytest KryptoLowca/tests/strategies/test_registry.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Wkład w projekt KryptoLowca
+
+Dziękujemy za chęć współtworzenia KryptoLowca! Poniżej znajdziesz minimalny
+proces kontrybucji obowiązujący w repozytorium.
+
+## Proces review
+
+1. Utwórz branch funkcjonalny i utrzymuj zmiany w małych, dobrze opisanych
+   commitach.
+2. Przed złożeniem PR uzupełnij opis o zakres zmian, wpływ na bezpieczeństwo oraz
+   informację o scenariuszach testowych (wszystkie muszą działać w trybie demo).
+3. PR wymagają minimum **dwóch** niezależnych review – jednego technicznego i
+   jednego z zespołu bezpieczeństwa/compliance.
+4. Reviewerzy sprawdzają zgodność z dokumentacją architektury, wymaganiami KYC/AML
+   oraz checklistą bezpieczeństwa. Zmiany są mergowane dopiero po zatwierdzeniu
+   przez oba zespoły.
+
+## Checklista bezpieczeństwa przed PR
+
+- [ ] Potwierdziłem uruchomienie pipeline'u wyłącznie w trybie demo/testnet.
+- [ ] Zweryfikowałem, że nie są używane produkcyjne klucze API ani dane klientów.
+- [ ] Oceniłem wpływ zmian na zarządzanie ryzykiem i dodałem brakujące alerty/logi.
+- [ ] Sprawdziłem, czy konfiguracja wymusza flagi `require_demo_mode` oraz
+      odpowiednie limity pozycji.
+- [ ] Zgłosiłem potencjalne incydenty bezpieczeństwa zespołowi `#sec-alerts`.
+
+## Testy lokalne (obowiązkowe)
+
+Przed otwarciem PR uruchom wszystkie poniższe polecenia:
+
+```bash
+ruff check \
+  KryptoLowca/core/services \
+  KryptoLowca/strategies/base \
+  KryptoLowca/config_manager.py \
+  KryptoLowca/strategies/marketplace.py
+mypy
+pytest KryptoLowca/tests/strategies/test_registry.py
+```
+
+Jeżeli dodajesz dodatkowe testy jednostkowe/integracyjne, dopisz je do sekcji
+"Test Plan" w opisie PR. Pamiętaj, aby **nie** przełączać środowiska na live
+bez pisemnego zatwierdzenia zespołu compliance po zakończeniu testów demo.

--- a/KryptoLowca/config_manager.py
+++ b/KryptoLowca/config_manager.py
@@ -278,7 +278,12 @@ class StrategyConfig:
             from KryptoLowca.strategies.presets import load_builtin_presets
 
             for preset in load_builtin_presets():
-                strategy_section = dict(preset.config.get("strategy", {}))
+                raw_section = preset.config.get("strategy", {})
+                strategy_section: Dict[str, Any]
+                if isinstance(raw_section, dict):
+                    strategy_section = dict(raw_section)
+                else:
+                    strategy_section = {}
                 if not strategy_section:
                     continue
                 name = preset.preset_id.upper()

--- a/KryptoLowca/strategies/marketplace.py
+++ b/KryptoLowca/strategies/marketplace.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 try:  # pragma: no cover - moduł opcjonalny w starszych środowiskach
     from .presets import load_builtin_presets
@@ -29,11 +29,26 @@ class StrategyPreset:
     exchanges: List[str]
     tags: List[str]
     config: Dict[str, object]
-
-
 def _load_json(path: Path) -> Dict[str, object]:
     with path.open("r", encoding="utf-8") as handle:
-        return json.load(handle)
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"Plik presetów {path} nie zawiera obiektu JSON")
+    return {str(key): value for key, value in data.items()}
+
+
+def _as_str_list(value: object) -> List[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, tuple):
+        return [str(item) for item in value]
+    return []
+
+
+def _as_mapping(value: object) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return {str(key): val for key, val in value.items()}
+    return {}
 
 
 def load_marketplace_presets(base_path: Optional[Path] = None) -> List[StrategyPreset]:
@@ -45,19 +60,25 @@ def load_marketplace_presets(base_path: Optional[Path] = None) -> List[StrategyP
     if directory.exists():
         for file in sorted(directory.glob("*.json")):
             data = _load_json(file)
-            config = data.get("config", {})
+            config = _as_mapping(data.get("config", {}))
+            recommended_raw = data.get("recommended_min_balance", 0.0)
+            try:
+                recommended_min_balance = float(recommended_raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                recommended_min_balance = 0.0
             preset = StrategyPreset(
-                preset_id=data["id"],
-                name=data["name"],
-                description=data.get("description", ""),
-                risk_level=data.get("risk_level", "unknown"),
-                recommended_min_balance=float(data.get("recommended_min_balance", 0.0)),
-                timeframe=data.get("timeframe", ""),
-                exchanges=list(data.get("exchanges", [])),
-                tags=list(data.get("tags", [])),
-                config=dict(config),
+                preset_id=str(data.get("id", "")),
+                name=str(data.get("name", "")),
+                description=str(data.get("description", "")),
+                risk_level=str(data.get("risk_level", "unknown")),
+                recommended_min_balance=recommended_min_balance,
+                timeframe=str(data.get("timeframe", "")),
+                exchanges=_as_str_list(data.get("exchanges", [])),
+                tags=_as_str_list(data.get("tags", [])),
+                config=config,
             )
-            presets[preset.preset_id] = preset
+            if preset.preset_id:
+                presets[preset.preset_id] = preset
 
     return list(presets.values())
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# Architektura KryptoLowca
+
+## Przegląd systemu
+
+KryptoLowca jest modularnym środowiskiem do tworzenia i uruchamiania strategii
+handlowych na giełdach krypto. Cały pipeline operacyjny działa **obowiązkowo w
+trybie demo/testnet** do momentu zakończenia audytu bezpieczeństwa i zgodności.
+Przed włączeniem trybu LIVE wymagane jest udokumentowane przejście scenariuszy
+papier trading oraz zatwierdzenie przez dział compliance.
+
+Centralny przepływ danych wygląda następująco:
+
+1. **Serwis sygnałów** (`KryptoLowca/core/services/signal_service.py`) ładuje
+   strategię z rejestru, buduje kontekst (wymuszając tryb demo) i deleguje
+   przygotowanie oraz generowanie sygnałów.
+2. **Serwis ryzyka** (`KryptoLowca/core/services/risk_service.py`) wykonuje
+   kontrolę limitów ekspozycji, ostatnich strat i wymusza blokady ochronne.
+3. **Serwis egzekucji** (`KryptoLowca/core/services/execution_service.py`) zamienia
+   zatwierdzone sygnały na zlecenia API giełdy poprzez adaptery.
+
+Każda warstwa jest odseparowana kontraktami bazowymi, a komunikacja przebiega w
+układzie sygnał → ocena ryzyka → wykonanie. Poniższe sekcje opisują moduły,
+które wchodzą w skład tej architektury.
+
+## Strategie bazowe (`KryptoLowca/strategies/base/`)
+
+- `engine.py` zawiera klasę `BaseStrategy`, struktury danych (`StrategyContext`,
+  `StrategySignal`) oraz `DataProvider`. Kontekst posiada metodę
+  `require_demo_mode`, która blokuje handel LIVE bez formalnego audytu.
+  Strategia ma lifecycle: `prepare()` (z wymuszeniem trybu demo),
+  `generate_signal()` (zaimplementowana w presetach) oraz hooki na fill/shutdown.
+- `registry.py` implementuje prosty rejestr (`StrategyRegistry`) oraz dekorator
+  `@strategy` do automatycznej rejestracji presetów. Rejestr jest wykorzystywany
+  zarówno przez marketplace jak i silnik auto-tradingu/tests.
+
+## Usługi rdzeniowe (`KryptoLowca/core/services/`)
+
+- `signal_service.py` odpowiada za odszukanie strategii w rejestrze, zbudowanie
+  `StrategyContext` z wymuszonym trybem demo oraz wywołanie lifecycle'u
+  `prepare()`/`handle_market_data()`.
+- `risk_service.py` przeprowadza politykę zarządzania ryzykiem – limity
+  notional, kontrolę strat dziennych, odrzucanie sygnałów `HOLD`.
+- `execution_service.py` izoluje logikę wysyłania zleceń. Wymaga adaptera giełdy
+  implementującego `submit_order` i respektuje ograniczenia (np. brak rozmiaru).
+
+## Konfiguracja (`KryptoLowca/config_manager.py`)
+
+`ConfigManager` spina konfigurację aplikacji i integruje się z marketplace
+strategii. Obsługuje szyfrowanie kluczy API, waliduje sekcje (AI, bazy danych,
+parametry handlu, giełdy, strategii) oraz pilnuje flag związanych z compliance
+(m.in. `require_demo_mode`, `compliance_confirmed`). Każda zmiana konfiguracji
+musi uwzględniać zasady KYC/AML i przejść walidację `validate()`.
+
+## Marketplace presetów (`KryptoLowca/strategies/marketplace.py`, `presets/`)
+
+Marketplace udostępnia gotowe presety strategii wraz z metadanymi marketingowymi.
+Moduł `marketplace.py` ładuje builtin presety oraz JSON-y z katalogu
+`KryptoLowca/strategies/presets/`. Preset (`StrategyPreset`) zawiera parametry do
+konfiguracji strategii, rekomendowany balans i tagi. Rejestr strategii oraz
+manager konfiguracji korzystają z presetów, aby publikować strategie w GUI i
+uruchamiać pipeline demo.
+
+## Bezpieczeństwo, compliance i zgłaszanie incydentów
+
+- **Tryb demo/testnet** jest obowiązkowy aż do przejścia pełnego procesu KYC/AML,
+  audytu kodu oraz podpisania akceptacji ryzyka. Wszystkie testy i review muszą
+  wykonywać zlecenia na kontach paper-trading.
+- KYC/AML: każdy adapter giełdowy musi być skonfigurowany z kontem spełniającym
+  wymagania regulacyjne. Zmiany kluczy API wymagają zatwierdzenia przez dział
+  compliance i aktualizacji metadanych w `ConfigManager`.
+- Zgłaszanie incydentów: incydenty bezpieczeństwa i anomalie handlowe należy
+  natychmiast zgłosić do zespołu bezpieczeństwa poprzez kanał `#sec-alerts` oraz
+  wypełnić formularz post-incident w ciągu 24h. Logi z usług rdzeniowych i
+  dashboardów muszą zostać zabezpieczone na potrzeby analizy.
+
+## Kolejne kroki
+
+- Rozbudowa dokumentacji o szczegółowe diagramy przepływu danych.
+- Dodanie testów integracyjnych pipeline'u (sygnał → ryzyko → egzekucja).
+- Przygotowanie checklisty audytu LIVE (compliance + ryzyko technologiczne).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+extend-exclude = [
+  "KryptoLowca/2.8",
+  "KryptoLowca/backups",
+  "KryptoLowca/KryptoLowca.zip",
+]
+
+[tool.ruff.lint]
+select = ["E9", "F63", "F7", "F82"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+strict_optional = true
+show_error_codes = true
+namespace_packages = true
+follow_imports = "silent"
+files = [
+  "KryptoLowca/core/services",
+  "KryptoLowca/strategies/base",
+  "KryptoLowca/config_manager.py",
+  "KryptoLowca/strategies/marketplace.py",
+]
+
+[[tool.mypy.overrides]]
+module = ["yaml"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["KryptoLowca/tests"]
+filterwarnings = [
+  "ignore::DeprecationWarning",
+]


### PR DESCRIPTION
## Summary
- document the current module layout, compliance requirements, and demo restrictions in docs/ARCHITECTURE.md
- add a CONTRIBUTING guide with review workflow, safety checklist, and mandatory demo testing reminders
- configure ruff and mypy via pyproject.toml and run them with pytest in a new CI workflow

## Testing
- ruff check KryptoLowca/core/services KryptoLowca/strategies/base KryptoLowca/config_manager.py KryptoLowca/strategies/marketplace.py
- mypy
- pytest KryptoLowca/tests/strategies/test_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68d705458500832a9e1cd2aa1ad57962