### PR TITLE
Add marketplace preset versioning, audit history, and CLI editor

### DIFF
--- a/KryptoLowca/strategies/marketplace/mean_reversion_safe.json
+++ b/KryptoLowca/strategies/marketplace/mean_reversion_safe.json
@@ -7,6 +7,19 @@
   "timeframe": "15m",
   "exchanges": ["binance", "zonda"],
   "tags": ["mean-reversion", "paper", "low-volatility"],
+  "version": "1.4.5",
+  "last_updated": "2024-05-20T15:00:00+00:00",
+  "compatibility": {
+    "app": ">=2.8.0",
+    "schema": "1.1"
+  },
+  "compliance": {
+    "required_flags": [
+      "compliance_confirmed",
+      "acknowledged_risk_disclaimer"
+    ],
+    "allow_live": false
+  },
   "config": {
     "strategy": {
       "preset": "SAFE",

--- a/KryptoLowca/strategies/marketplace/trend_following_balanced.json
+++ b/KryptoLowca/strategies/marketplace/trend_following_balanced.json
@@ -7,6 +7,20 @@
   "timeframe": "1h",
   "exchanges": ["binance", "okx"],
   "tags": ["trend", "spot", "ai-assisted"],
+  "version": "3.2.0",
+  "last_updated": "2024-06-10T08:30:00+00:00",
+  "compatibility": {
+    "app": ">=2.9.0",
+    "schema": "1.2"
+  },
+  "compliance": {
+    "required_flags": [
+      "compliance_confirmed",
+      "api_keys_configured",
+      "acknowledged_risk_disclaimer"
+    ],
+    "allow_live": true
+  },
   "config": {
     "strategy": {
       "preset": "BALANCED",

--- a/KryptoLowca/strategies/presets/daily_trend.py
+++ b/KryptoLowca/strategies/presets/daily_trend.py
@@ -1,6 +1,8 @@
 """Wbudowany preset dziennego trend following dla kont demo."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from KryptoLowca.strategies.marketplace import StrategyPreset
 
 DAILY_TREND_PRESET = StrategyPreset(
@@ -42,6 +44,16 @@ DAILY_TREND_PRESET = StrategyPreset(
             "rate_limit_per_minute": 1200,
             "rate_limit_alert_threshold": 0.75,
         },
+    },
+    version="1.1.0",
+    last_updated=datetime(2024, 3, 1, 12, 0, tzinfo=timezone.utc),
+    compatibility={"app": ">=2.8.0", "schema": "1.0"},
+    compliance={
+        "required_flags": [
+            "compliance_confirmed",
+            "acknowledged_risk_disclaimer",
+        ],
+        "allow_live": False,
     },
 )
 

--- a/KryptoLowca/strategies/presets/trend_following.py
+++ b/KryptoLowca/strategies/presets/trend_following.py
@@ -1,6 +1,8 @@
 """Wbudowany preset intraday trend following dla Binance/Kraken."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from KryptoLowca.strategies.marketplace import StrategyPreset
 
 INTRADAY_TREND_PRESET = StrategyPreset(
@@ -42,6 +44,17 @@ INTRADAY_TREND_PRESET = StrategyPreset(
             "rate_limit_per_minute": 900,
             "rate_limit_alert_threshold": 0.8,
         },
+    },
+    version="2.0.0",
+    last_updated=datetime(2024, 5, 15, 9, 30, tzinfo=timezone.utc),
+    compatibility={"app": ">=2.9.0", "schema": "1.1"},
+    compliance={
+        "required_flags": [
+            "compliance_confirmed",
+            "api_keys_configured",
+            "acknowledged_risk_disclaimer",
+        ],
+        "allow_live": False,
     },
 )
 

--- a/KryptoLowca/tests/test_config_manager_versions.py
+++ b/KryptoLowca/tests/test_config_manager_versions.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+from KryptoLowca.config_manager import ConfigManager, ValidationError
+
+
+@pytest.mark.asyncio
+async def test_apply_preset_creates_history(tmp_path: Path) -> None:
+    marketplace_dir = tmp_path / "marketplace"
+    marketplace_dir.mkdir()
+    preset_payload = {
+        "id": "demo",
+        "name": "Demo",
+        "description": "Preset testowy",
+        "risk_level": "balanced",
+        "recommended_min_balance": 1000,
+        "timeframe": "1h",
+        "exchanges": ["binance"],
+        "tags": ["demo"],
+        "version": "1.0.1",
+        "last_updated": "2024-06-01T12:00:00+00:00",
+        "compatibility": {"app": ">=2.9.0"},
+        "compliance": {"required_flags": ["compliance_confirmed"]},
+        "config": {
+            "strategy": {
+                "preset": "DEMO",
+                "mode": "demo",
+            },
+            "exchange": {
+                "exchange_name": "binance",
+                "api_key": "demo-key",
+                "api_secret": "demo-secret",
+            },
+        },
+    }
+    (marketplace_dir / "demo.json").write_text(
+        json.dumps(preset_payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    key = Fernet.generate_key()
+    manager = ConfigManager(tmp_path / "config.yaml", encryption_key=key)
+    manager.set_marketplace_directory(marketplace_dir)
+    await manager.load_config()
+
+    config = manager.apply_marketplace_preset(
+        "demo",
+        actor="user@example.com",
+        note="initial import",
+    )
+    assert config["exchange"]["exchange_name"] == "binance"
+
+    history = manager.get_preset_history("demo")
+    assert len(history) == 1
+    version_id = history[0]["version_id"]
+
+    snapshot_path = tmp_path / "versions" / "demo" / f"{version_id}.json"
+    stored = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    assert stored["config"]["exchange"]["api_key"] != "demo-key"
+
+    config["trade"]["max_open_positions"] = 7
+    await manager.save_config(
+        config,
+        actor="user@example.com",
+        preset_id="demo",
+        note="manual tuning",
+        source="editor",
+    )
+
+    history = manager.get_preset_history("demo")
+    assert len(history) == 2
+
+    rolled_back = manager.rollback_preset(
+        "demo",
+        version_id,
+        actor="auditor@example.com",
+        note="rollback test",
+    )
+    assert rolled_back["trade"]["max_open_positions"] == manager._default_config()["trade"]["max_open_positions"]
+
+
+@pytest.mark.asyncio
+async def test_live_mode_requires_confirmation(tmp_path: Path) -> None:
+    marketplace_dir = tmp_path / "marketplace"
+    marketplace_dir.mkdir()
+    payload = {
+        "id": "live_demo",
+        "name": "Live Demo",
+        "description": "Preset wymagający trybu live",
+        "risk_level": "balanced",
+        "recommended_min_balance": 2500,
+        "timeframe": "4h",
+        "exchanges": ["binance"],
+        "tags": ["live"],
+        "version": "0.2.0",
+        "last_updated": "2024-06-05T09:00:00+00:00",
+        "compatibility": {"app": ">=2.9.0"},
+        "compliance": {
+            "required_flags": [
+                "compliance_confirmed",
+                "api_keys_configured",
+                "acknowledged_risk_disclaimer",
+            ]
+        },
+        "config": {
+            "strategy": {
+                "preset": "LIVE_TEST",
+                "mode": "live",
+                "compliance_confirmed": True,
+                "api_keys_configured": True,
+                "acknowledged_risk_disclaimer": True,
+            },
+            "exchange": {"exchange_name": "binance", "testnet": False},
+        },
+    }
+    (marketplace_dir / "live_demo.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    key = Fernet.generate_key()
+    manager = ConfigManager(tmp_path / "config.yaml", encryption_key=key)
+    manager.set_marketplace_directory(marketplace_dir)
+    await manager.load_config()
+
+    with pytest.raises(ValidationError):
+        manager.apply_marketplace_preset("live_demo", actor="user@example.com")
+
+    config = manager.apply_marketplace_preset(
+        "live_demo",
+        actor="user@example.com",
+        user_confirmed=True,
+        note="enable live",
+    )
+    assert config["strategy"]["mode"] == "live"

--- a/KryptoLowca/tests/test_marketplace_loader.py
+++ b/KryptoLowca/tests/test_marketplace_loader.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from pathlib import Path
+
+from KryptoLowca.strategies.marketplace import (
+    StrategyPreset,
+    load_marketplace_presets,
+    load_preset,
+)
+
+
+def test_load_marketplace_presets_with_metadata(tmp_path: Path) -> None:
+    marketplace_dir = tmp_path
+    payload = {
+        "id": "demo_strategy",
+        "name": "Demo Strategy",
+        "description": "Testowa strategia do sprawdzenia metadanych.",
+        "risk_level": "balanced",
+        "recommended_min_balance": 1234.5,
+        "timeframe": "1h",
+        "exchanges": ["binance"],
+        "tags": ["demo"],
+        "version": "0.1.0",
+        "last_updated": "2024-05-05T10:15:00+00:00",
+        "compatibility": {"app": ">=2.7.0"},
+        "compliance": {"required_flags": ["compliance_confirmed"]},
+        "config": {"strategy": {"preset": "SAFE", "mode": "demo"}},
+    }
+    (marketplace_dir / "demo_strategy.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    presets = load_marketplace_presets(base_path=marketplace_dir)
+    assert any(p.preset_id == "demo_strategy" for p in presets)
+
+    preset = load_preset("demo_strategy", base_path=marketplace_dir)
+    assert isinstance(preset, StrategyPreset)
+    assert preset.version == "0.1.0"
+    assert preset.compatibility["app"] == ">=2.7.0"
+    assert preset.compliance["required_flags"] == ["compliance_confirmed"]
+    assert preset.last_updated == datetime(2024, 5, 5, 10, 15, tzinfo=timezone.utc)

--- a/KryptoLowca/tests/test_preset_editor_cli.py
+++ b/KryptoLowca/tests/test_preset_editor_cli.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+from KryptoLowca.config_manager import ConfigManager
+from KryptoLowca.scripts import preset_editor_cli
+
+
+def test_cli_editor_applies_preset(tmp_path: Path, capsys) -> None:
+    marketplace_dir = tmp_path / "marketplace"
+    marketplace_dir.mkdir()
+    preset_payload = {
+        "id": "cli_demo",
+        "name": "CLI Demo",
+        "description": "Preset do testów CLI",
+        "risk_level": "safe",
+        "recommended_min_balance": 500,
+        "timeframe": "1h",
+        "exchanges": ["binance"],
+        "tags": ["cli"],
+        "version": "0.0.1",
+        "last_updated": "2024-06-10T12:00:00+00:00",
+        "compatibility": {"app": ">=2.8.0"},
+        "compliance": {"required_flags": ["compliance_confirmed"]},
+        "config": {
+            "strategy": {
+                "preset": "CLI",
+                "mode": "demo",
+            },
+            "trade": {"max_open_positions": 3},
+        },
+    }
+    (marketplace_dir / "cli_demo.json").write_text(
+        json.dumps(preset_payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "config.yaml"
+    key = Fernet.generate_key().decode()
+
+    exit_code = preset_editor_cli.main(
+        [
+            "--config-path",
+            str(config_path),
+            "--marketplace-dir",
+            str(marketplace_dir),
+            "--preset-id",
+            "cli_demo",
+            "--encryption-key",
+            key,
+            "--actor",
+            "cli@example.com",
+            "--set",
+            "trade.max_open_positions=5",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "cli_demo" in output
+
+    manager = ConfigManager(config_path, encryption_key=key.encode())
+    asyncio.run(manager.load_config())
+    assert manager._current_config["trade"]["max_open_positions"] == 5
+
+    history = manager.get_preset_history("cli_demo")
+    assert len(history) >= 2


### PR DESCRIPTION
## Summary
- extend marketplace presets with version, compatibility, and compliance metadata and propagate parsing to builtin/JSON sources
- add ConfigManager snapshot history with audit logging, rollback support, and stricter live-mode confirmation handling
- provide a CLI preset editor stub that applies presets with overrides and persists encrypted configs alongside new unit tests

## Testing
- pytest KryptoLowca/tests/test_marketplace_loader.py KryptoLowca/tests/test_config_manager_versions.py KryptoLowca/tests/test_preset_editor_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d70f4373cc832a9ba430493b708610