### PR TITLE
Fix fee handling for backtest and paper fills

### DIFF
--- a/KryptoLowca/backtest/simulation.py
+++ b/KryptoLowca/backtest/simulation.py
@@ -477,7 +477,7 @@ class BacktestEngine:
             position_before = position
             equity_before = cash + position_before * bar_close
             cash -= direction * fill.price * fill.size
-            cash -= fill.fee if fill.side == "buy" else -fill.fee
+            cash -= fill.fee
             position = position_before + direction * fill.size
             if abs(position) < 1e-9:
                 position = 0.0

--- a/KryptoLowca/core/services/paper_adapter.py
+++ b/KryptoLowca/core/services/paper_adapter.py
@@ -75,7 +75,7 @@ class PaperTradingAdapter:
     def _apply_fill(self, state: _PortfolioState, fill: BacktestFill) -> None:
         direction = 1 if fill.side == "buy" else -1
         state.cash -= direction * fill.price * fill.size
-        state.cash -= fill.fee if fill.side == "buy" else -fill.fee
+        state.cash -= fill.fee
         state.position += direction * fill.size
         if state.position:
             state.avg_price = (


### PR DESCRIPTION
## Summary
- subtract trade fees from cash for both buy and sell fills in the backtest engine and paper trading adapter
- extend backtest and paper trading tests to validate fee aggregation, cash balances, and equity snapshots

## Testing
- python - <<'PY'
import pytest
_orig = pytest.importorskip

def _patched_importorskip(modname, minversion=None, reason=None, **kwargs):
    return _orig(modname, minversion=minversion, reason=reason)

pytest.importorskip = _patched_importorskip
raise SystemExit(pytest.main(["KryptoLowca/tests/test_backtest_simulation.py"]))
PY


------
https://chatgpt.com/codex/tasks/task_e_68d7ae670508832a9aada6030c2101c7