### PR TITLE
Require backtest confirmation before enabling live mode

### DIFF
--- a/KryptoLowca/auto_trader.py
+++ b/KryptoLowca/auto_trader.py
@@ -1066,6 +1066,14 @@ class AutoTrader:
                 cfg = StrategyConfig(**value).validate()
             else:
                 raise TypeError("Nieobsługiwany format konfiguracji strategii")
+            if cfg.mode == "live" and not getattr(cfg, "backtest_passed_at", None):
+                message = (
+                    "Odrzucono przełączenie strategii w tryb LIVE – brak potwierdzonego "
+                    "backtestu. Uruchom backtest i ponów próbę."
+                )
+                self.emitter.log(message, level="WARNING", component="AutoTrader")
+                logger.warning("%s", message)
+                return
         except Exception as exc:  # pragma: no cover - logujemy i utrzymujemy stare ustawienia
             self.emitter.log(
                 f"Nieprawidłowa konfiguracja strategii: {exc!r}",


### PR DESCRIPTION
## Summary
- store the timestamp of a successful guard_backtest call on StrategyConfig and persist it through ConfigManager
- prevent AutoTrader from switching into live mode when no confirmed backtest timestamp is present and log an operator warning
- add a regression test ensuring live mode cannot be enabled without a successful backtest

## Testing
- pytest KryptoLowca/tests/test_auto_trader.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ae67ef48832aa6e810827603266d