### PR TITLE
Require fresh backtest confirmation before live trading

### DIFF
--- a/KryptoLowca/auto_trader.py
+++ b/KryptoLowca/auto_trader.py
@@ -1066,14 +1066,28 @@ class AutoTrader:
                 cfg = StrategyConfig(**value).validate()
             else:
                 raise TypeError("Nieobsługiwany format konfiguracji strategii")
-            if cfg.mode == "live" and not getattr(cfg, "backtest_passed_at", None):
-                message = (
-                    "Odrzucono przełączenie strategii w tryb LIVE – brak potwierdzonego "
-                    "backtestu. Uruchom backtest i ponów próbę."
-                )
-                self.emitter.log(message, level="WARNING", component="AutoTrader")
-                logger.warning("%s", message)
-                return
+            if cfg.mode == "live":
+                backtest_ts = getattr(cfg, "backtest_passed_at", None)
+                freshness_window = getattr(cfg, "BACKTEST_VALIDITY_WINDOW_S", 0.0)
+                reason: Optional[str] = None
+                if not backtest_ts:
+                    reason = "brak potwierdzonego backtestu"
+                else:
+                    age = time.time() - float(backtest_ts)
+                    if freshness_window and age > float(freshness_window):
+                        hours = max(1, int(freshness_window // 3600))
+                        reason = (
+                            "wynik backtestu jest przeterminowany (starszy niż "
+                            f"{hours}h)"
+                        )
+                if reason:
+                    message = (
+                        "Odrzucono przełączenie strategii w tryb LIVE – "
+                        f"{reason}. Uruchom backtest i ponów próbę."
+                    )
+                    self.emitter.log(message, level="WARNING", component="AutoTrader")
+                    logger.warning("%s", message)
+                    return
         except Exception as exc:  # pragma: no cover - logujemy i utrzymujemy stare ustawienia
             self.emitter.log(
                 f"Nieprawidłowa konfiguracja strategii: {exc!r}",

--- a/KryptoLowca/tests/test_auto_trader.py
+++ b/KryptoLowca/tests/test_auto_trader.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 import pytest
 
 from KryptoLowca.auto_trader import AutoTrader
-from KryptoLowca.config_manager import StrategyConfig
+from KryptoLowca.config_manager import BACKTEST_VALIDITY_WINDOW_S, StrategyConfig
 from KryptoLowca.core.services import ExecutionService, PaperTradingAdapter, RiskAssessment, SignalService
 from KryptoLowca.core.services.data_provider import ExchangeDataProvider  # noqa: F401 - ensures module importable
 from KryptoLowca.core.services.risk_service import RiskService
@@ -232,6 +232,45 @@ def test_live_mode_requires_backtest_confirmation(strategy_harness: StrategyHarn
     assert trader._strategy_config.mode == "demo"
     assert any(
         level == "WARNING" and "backtest" in message.lower()
+        for level, _, message in emitter.logs
+    )
+
+
+def test_live_mode_rejects_stale_backtest(strategy_harness: StrategyHarness) -> None:
+    provider = StubDataProvider(price=102.0)
+    adapter = RecordingExecutionAdapter()
+    trader, emitter, _ = _configured_trader(
+        symbol_source=lambda: [("BTC/USDT", "1m")],
+        data_provider=provider,
+        signal_service=strategy_harness.signal_service,
+        risk_service=AcceptAllRiskService(size=50.0),
+        execution_adapter=adapter,
+    )
+
+    assert trader._strategy_config.mode == "demo"
+
+    stale_ts = time.time() - (BACKTEST_VALIDITY_WINDOW_S + 10)
+    live_cfg = StrategyConfig(
+        preset="DummyStrategy",
+        mode="live",
+        max_leverage=1.0,
+        max_position_notional_pct=0.5,
+        trade_risk_pct=0.1,
+        default_sl=0.01,
+        default_tp=0.02,
+        violation_cooldown_s=1,
+        reduce_only_after_violation=False,
+        compliance_confirmed=True,
+        api_keys_configured=True,
+        acknowledged_risk_disclaimer=True,
+        backtest_passed_at=stale_ts,
+    )
+
+    trader.configure(strategy=live_cfg)
+
+    assert trader._strategy_config.mode == "demo"
+    assert any(
+        level == "WARNING" and "przeterminowany" in message.lower()
         for level, _, message in emitter.logs
     )
 


### PR DESCRIPTION
## Summary
- require AutoTrader live-mode updates to verify a recent backtest confirmation before applying
- persist and validate backtest timestamps in StrategyConfig/ConfigManager, including a fallback for missing marketplace presets
- add regression tests covering live-mode rejection when no or stale backtest confirmation is present

## Testing
- pytest KryptoLowca/tests/test_auto_trader.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b40def14832ab3ce55914e825ad1