### PR TITLE
Add unified exchange abstraction with demo adapters and key management

### DIFF
--- a/KryptoLowca/config_manager.py
+++ b/KryptoLowca/config_manager.py
@@ -14,6 +14,8 @@ import yaml
 from cryptography.fernet import Fernet, InvalidToken
 import pandas as pd
 
+from KryptoLowca.security.api_key_manager import APIKeyManager
+
 if TYPE_CHECKING:  # pragma: no cover - tylko dla typowania
     from KryptoLowca.backtest.simulation import BacktestReport, MatchingConfig
     from KryptoLowca.data.market_data import MarketDataProvider, MarketDataRequest
@@ -440,6 +442,11 @@ class ConfigManager:
         self._current_config: Dict[str, Any] = self._default_config()
         self._marketplace_dir: Optional[Path] = None
         self._versions_dir: Path = self.config_path.parent / "versions"
+        self.api_key_manager = APIKeyManager(
+            self.config_path.parent / "api_keys_store.json",
+            encryptor=self._encrypt_section,
+            decryptor=self._decrypt_section,
+        )
 
     @classmethod
     async def create(

--- a/KryptoLowca/core/services/execution_service.py
+++ b/KryptoLowca/core/services/execution_service.py
@@ -1,19 +1,16 @@
 """Serwis wykonania zleceń – abstrakcja nad adapterami giełdowymi."""
 from __future__ import annotations
 
-from typing import Any, Mapping, Protocol
+import inspect
+from typing import Any, Mapping
 
+from KryptoLowca.exchanges.interfaces import ExchangeAdapter, OrderRequest, OrderStatus
 from KryptoLowca.logging_utils import get_logger
 from KryptoLowca.strategies.base import StrategyContext, StrategySignal
 
 from .error_policy import guard_exceptions
 
 logger = get_logger(__name__)
-
-
-class ExchangeAdapter(Protocol):
-    async def submit_order(self, *, symbol: str, side: str, size: float, **kwargs: Any) -> Mapping[str, Any]:
-        ...
 
 
 class ExecutionService:
@@ -44,15 +41,31 @@ class ExecutionService:
             self._logger.warning("Brak wielkości pozycji w sygnale")
             return None
         side = "buy" if signal.action.upper() == "BUY" else "sell"
-        payload = await self._adapter.submit_order(
+        order = OrderRequest(
             symbol=context.symbol,
             side=side,
-            size=signal.size,
-            stop_loss=signal.stop_loss,
-            take_profit=signal.take_profit,
+            quantity=signal.size,
+            order_type="MARKET" if signal.action.upper() in {"BUY", "SELL"} else "LIMIT",
+            extra_params={
+                "stop_loss": signal.stop_loss,
+                "take_profit": signal.take_profit,
+            },
         )
+        submit = getattr(self._adapter, "submit_order")
+        try:
+            result = submit(order)
+        except TypeError:
+            result = submit(
+                symbol=context.symbol,
+                side=side,
+                size=signal.size,
+                stop_loss=signal.stop_loss,
+                take_profit=signal.take_profit,
+            )
+
+        payload = await result if inspect.isawaitable(result) else result
         self._logger.info("Zlecenie wysłane: %s", payload)
-        return payload
+        return payload.raw if isinstance(payload, OrderStatus) else payload
 
 
 __all__ = ["ExecutionService", "ExchangeAdapter"]

--- a/KryptoLowca/exchanges/__init__.py
+++ b/KryptoLowca/exchanges/__init__.py
@@ -8,6 +8,18 @@ from .adapters import (
     ExchangeAdapterFactory,
     create_exchange_adapter,
 )
+from .binance import BinanceTestnetAdapter
+from .interfaces import (
+    ExchangeAdapter,
+    ExchangeCredentials,
+    MarketSubscription,
+    OrderRequest,
+    OrderStatus,
+    RateLimitRule,
+    RESTWebSocketAdapter,
+    WebSocketSubscription,
+)
+from .kraken import KrakenDemoAdapter
 
 __all__ = [
     "AdapterError",
@@ -15,4 +27,14 @@ __all__ = [
     "CCXTExchangeAdapter",
     "ExchangeAdapterFactory",
     "create_exchange_adapter",
+    "BinanceTestnetAdapter",
+    "KrakenDemoAdapter",
+    "ExchangeAdapter",
+    "ExchangeCredentials",
+    "MarketSubscription",
+    "OrderRequest",
+    "OrderStatus",
+    "RateLimitRule",
+    "RESTWebSocketAdapter",
+    "WebSocketSubscription",
 ]

--- a/KryptoLowca/exchanges/binance.py
+++ b/KryptoLowca/exchanges/binance.py
@@ -1,0 +1,173 @@
+"""Adapter Binance Testnet zgodny z RESTWebSocketAdapter."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+import urllib.parse
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, Dict, Optional
+
+from .interfaces import (
+    ExchangeCredentials,
+    MarketPayload,
+    MarketSubscription,
+    OrderRequest,
+    OrderStatus,
+    RESTWebSocketAdapter,
+    WebSocketSubscription,
+)
+
+
+class _DummySubscription:
+    """Prosta implementacja kontekstu WebSocket dla testów."""
+
+    def __init__(self, callback: Callable[[], None] | None = None) -> None:
+        self._callback = callback
+
+    async def __aenter__(self) -> "_DummySubscription":
+        if self._callback:
+            self._callback()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> Optional[bool]:  # type: ignore[override]
+        return None
+
+
+class BinanceTestnetAdapter(RESTWebSocketAdapter):
+    """Adapter obsługujący podstawowe operacje dla Binance Testnet."""
+
+    def __init__(
+        self,
+        *,
+        demo_mode: bool = True,
+        http_client=None,
+        ws_factory: Optional[
+            Callable[[Iterable[MarketSubscription], Callable[[MarketPayload], Awaitable[None]]], WebSocketSubscription]
+        ] = None,
+        compliance_ack: bool = False,
+    ) -> None:
+        super().__init__(
+            name="binance-testnet",
+            base_url="https://testnet.binance.vision",
+            demo_mode=demo_mode,
+            http_client=http_client,
+            compliance_ack=compliance_ack,
+        )
+        self._ws_factory = ws_factory or self._default_ws_factory
+
+    async def authenticate(self, credentials: ExchangeCredentials) -> None:
+        if not credentials.api_key or not credentials.api_secret:
+            raise ValueError("Wymagane są klucze API dla Binance")
+        await super().authenticate(credentials)
+
+    def _signed_params(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._credentials:
+            raise RuntimeError("Brak poświadczeń – wywołaj authenticate()")
+        payload = dict(params)
+        payload.setdefault("recvWindow", 5_000)
+        payload["timestamp"] = int(time.time() * 1000)
+        query = urllib.parse.urlencode(payload, doseq=True)
+        signature = hmac.new(
+            self._credentials.api_secret.encode(), query.encode(), hashlib.sha256
+        ).hexdigest()
+        payload["signature"] = signature
+        return payload
+
+    def _auth_headers(self) -> Dict[str, str]:
+        if not self._credentials:
+            raise RuntimeError("Brak poświadczeń – wywołaj authenticate()")
+        return {"X-MBX-APIKEY": self._credentials.api_key}
+
+    async def fetch_market_data(self, symbol: str) -> MarketPayload:
+        response = await self._request("GET", "/api/v3/ticker/bookTicker", params={"symbol": symbol})
+        return response
+
+    async def stream_market_data(
+        self, subscriptions: Iterable[MarketSubscription], callback: Callable[[MarketPayload], Awaitable[None]]
+    ) -> WebSocketSubscription:
+        return self._ws_factory(subscriptions, callback)
+
+    async def submit_order(self, order: OrderRequest) -> OrderStatus:
+        params: Dict[str, Any] = {
+            "symbol": order.symbol,
+            "side": order.side.upper(),
+            "type": order.order_type,
+            "quantity": order.quantity,
+        }
+        if order.price is not None:
+            params["price"] = order.price
+        if order.time_in_force:
+            params["timeInForce"] = order.time_in_force
+        if order.client_order_id:
+            params["newClientOrderId"] = order.client_order_id
+        params.update(order.extra_params)
+        signed = self._signed_params(params)
+        response = await self._request(
+            "POST",
+            "/api/v3/order",
+            params=signed,
+            headers=self._auth_headers(),
+        )
+        return OrderStatus(
+            order_id=response.get("orderId", ""),
+            status=response.get("status", "UNKNOWN"),
+            filled_quantity=float(response.get("executedQty", 0.0)),
+            remaining_quantity=float(response.get("origQty", 0.0))
+            - float(response.get("executedQty", 0.0)),
+            average_price=float(response.get("price", 0.0)) if response.get("price") else None,
+            raw=response,
+        )
+
+    async def fetch_order_status(self, order_id: str, *, symbol: Optional[str] = None) -> OrderStatus:
+        params = {"orderId": order_id}
+        if symbol:
+            params["symbol"] = symbol
+        signed = self._signed_params(params)
+        response = await self._request(
+            "GET",
+            "/api/v3/order",
+            params=signed,
+            headers=self._auth_headers(),
+        )
+        return OrderStatus(
+            order_id=str(response.get("orderId", order_id)),
+            status=response.get("status", "UNKNOWN"),
+            filled_quantity=float(response.get("executedQty", 0.0)),
+            remaining_quantity=float(response.get("origQty", 0.0))
+            - float(response.get("executedQty", 0.0)),
+            average_price=float(response.get("price", 0.0)) if response.get("price") else None,
+            raw=response,
+        )
+
+    async def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> OrderStatus:
+        params = {"orderId": order_id}
+        if symbol:
+            params["symbol"] = symbol
+        signed = self._signed_params(params)
+        response = await self._request(
+            "DELETE",
+            "/api/v3/order",
+            params=signed,
+            headers=self._auth_headers(),
+        )
+        return OrderStatus(
+            order_id=str(response.get("orderId", order_id)),
+            status=response.get("status", "CANCELED"),
+            filled_quantity=float(response.get("executedQty", 0.0)),
+            remaining_quantity=float(response.get("origQty", 0.0))
+            - float(response.get("executedQty", 0.0)),
+            average_price=float(response.get("price", 0.0)) if response.get("price") else None,
+            raw=response,
+        )
+
+    def _default_ws_factory(
+        self,
+        subscriptions: Iterable[MarketSubscription],
+        callback: Callable[[MarketPayload], Awaitable[None]],
+    ) -> WebSocketSubscription:
+        # Domyślnie zwracamy atrapę – umożliwia wstrzyknięcie mocków w testach.
+        return _DummySubscription()
+
+
+__all__ = ["BinanceTestnetAdapter"]

--- a/KryptoLowca/exchanges/interfaces.py
+++ b/KryptoLowca/exchanges/interfaces.py
@@ -1,0 +1,322 @@
+"""Abstrakcje adapterów giełdowych dla REST + WebSocket."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Protocol, Sequence
+
+try:  # pragma: no cover - biblioteka opcjonalna w runtime
+    import httpx
+except Exception:  # pragma: no cover - środowisko testowe
+    httpx = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ExchangeCredentials:
+    """Parametry autoryzacji konta giełdowego."""
+
+    api_key: str
+    api_secret: str
+    passphrase: Optional[str] = None
+    is_read_only: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class RateLimitRule:
+    """Konfiguracja limitu: ``rate`` żądań na ``per`` sekund."""
+
+    rate: int
+    per: float
+    weight: int = 1
+
+    def __post_init__(self) -> None:
+        if self.rate <= 0 or self.per <= 0:
+            raise ValueError("RateLimitRule musi mieć dodatnie wartości")
+        if self.weight <= 0:
+            raise ValueError("Waga limitu musi być dodatnia")
+
+
+class RateLimiter:
+    """Asynchroniczny licznik tokenów obsługujący wagę zapytań."""
+
+    def __init__(self, rule: RateLimitRule) -> None:
+        self._rule = rule
+        self._tokens = float(rule.rate)
+        self._updated = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, weight: int | None = None) -> None:
+        weight = weight or self._rule.weight
+        async with self._lock:
+            while True:
+                now = time.monotonic()
+                elapsed = now - self._updated
+                if elapsed > 0:
+                    refill = elapsed * self._rule.rate / self._rule.per
+                    if refill > 0:
+                        self._tokens = min(self._rule.rate, self._tokens + refill)
+                        self._updated = now
+                if self._tokens >= weight:
+                    self._tokens -= weight
+                    return
+                missing = weight - self._tokens
+                wait_for = max(missing * self._rule.per / self._rule.rate, 0.01)
+                logger.debug("RateLimiter waiting %.3fs (missing %.2f tokens)", wait_for, missing)
+                await asyncio.sleep(wait_for)
+
+
+@dataclass(slots=True)
+class MarketSubscription:
+    channel: str
+    symbols: Sequence[str]
+    params: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class OrderRequest:
+    symbol: str
+    side: str
+    quantity: float
+    order_type: str = "LIMIT"
+    price: Optional[float] = None
+    time_in_force: Optional[str] = None
+    client_order_id: Optional[str] = None
+    extra_params: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class OrderStatus:
+    order_id: str
+    status: str
+    filled_quantity: float
+    remaining_quantity: float
+    average_price: Optional[float]
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+class WebSocketSubscription(Protocol):
+    async def __aenter__(self) -> "WebSocketSubscription":
+        ...
+
+    async def __aexit__(self, exc_type, exc, tb) -> Optional[bool]:  # type: ignore[override]
+        ...
+
+
+MarketPayload = Dict[str, Any]
+CallbackT = Callable[[MarketPayload], Awaitable[None]]
+OrderCallbackT = Callable[[OrderStatus], Awaitable[None]]
+
+
+class ExchangeAdapter(Protocol):
+    """Wspólny kontrakt wykorzystywany przez ExecutionService."""
+
+    name: str
+    demo_mode: bool
+
+    async def connect(self) -> None:
+        ...
+
+    async def close(self) -> None:
+        ...
+
+    async def authenticate(self, credentials: ExchangeCredentials) -> None:
+        ...
+
+    async def fetch_market_data(self, symbol: str) -> MarketPayload:
+        ...
+
+    async def stream_market_data(
+        self, subscriptions: Iterable[MarketSubscription], callback: CallbackT
+    ) -> WebSocketSubscription:
+        ...
+
+    async def submit_order(self, order: OrderRequest) -> OrderStatus:
+        ...
+
+    async def fetch_order_status(self, order_id: str, *, symbol: Optional[str] = None) -> OrderStatus:
+        ...
+
+    async def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> OrderStatus:
+        ...
+
+    async def monitor_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float = 1.0,
+        symbol: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> OrderStatus:
+        ...
+
+
+class RESTClient(Protocol):
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        timeout: Optional[float] = None,
+    ) -> Any:
+        ...
+
+
+class RESTWebSocketAdapter(ABC):
+    """Bazowa implementacja adaptera REST + WebSocket z retry/backoff."""
+
+    http_client: RESTClient
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        base_url: str,
+        demo_mode: bool = True,
+        rate_limit_rule: Optional[RateLimitRule] = None,
+        http_client: Optional[RESTClient] = None,
+        compliance_ack: bool = False,
+    ) -> None:
+        if not demo_mode and not compliance_ack:
+            raise ValueError("Live trading wymaga potwierdzenia compliance")
+        self.name = name
+        self.base_url = base_url.rstrip("/")
+        self.demo_mode = demo_mode
+        self._rate_limiter = RateLimiter(rate_limit_rule or RateLimitRule(rate=1200, per=60.0))
+        if http_client is not None:
+            self.http_client = http_client
+        else:
+            if httpx is None:
+                raise RuntimeError("httpx nie jest dostępny – wstrzyknij klienta REST")
+            self.http_client = httpx.AsyncClient(base_url=self.base_url)  # type: ignore[assignment]
+        self._credentials: Optional[ExchangeCredentials] = None
+        self._closed = False
+
+    async def connect(self) -> None:
+        self._closed = False
+
+    async def close(self) -> None:
+        self._closed = True
+        client_close = getattr(self.http_client, "aclose", None)
+        if callable(client_close):
+            try:
+                result = client_close()
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as exc:  # pragma: no cover - logujemy
+                logger.debug("Błąd podczas zamykania klienta HTTP %s: %s", self.name, exc)
+
+    async def authenticate(self, credentials: ExchangeCredentials) -> None:
+        if credentials.is_read_only:
+            logger.info("%s: uwierzytelnianie w trybie read-only", self.name)
+        self._credentials = credentials
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        weight: int = 1,
+        retries: int = 3,
+        backoff: float = 0.5,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        if self._closed:
+            raise RuntimeError("Adapter jest zamknięty")
+        await self._rate_limiter.acquire(weight)
+        url = f"{self.base_url}{path}"
+        attempt = 0
+        last_exc: Optional[Exception] = None
+        while attempt <= retries:
+            try:
+                response = await self.http_client.request(
+                    method,
+                    url,
+                    params=params,
+                    data=data,
+                    headers=headers,
+                    timeout=timeout,
+                )
+                status = getattr(response, "status_code", None)
+                if status and status >= 400:
+                    if status in {429, 418}:
+                        await asyncio.sleep(backoff * (attempt + 1))
+                        attempt += 1
+                        continue
+                    raise RuntimeError(f"{self.name} HTTP {status}: {getattr(response, 'text', '')}")
+                if hasattr(response, "json"):
+                    return await response.json() if asyncio.iscoroutinefunction(response.json) else response.json()
+                if hasattr(response, "data"):
+                    return response.data  # type: ignore[return-value]
+                raise RuntimeError("Nieznany typ odpowiedzi HTTP")
+            except Exception as exc:  # pragma: no cover - fallback retry
+                last_exc = exc
+                logger.debug("%s request attempt %s failed: %s", self.name, attempt, exc)
+                await asyncio.sleep(backoff * (attempt + 1))
+                attempt += 1
+        raise RuntimeError(f"{self.name} request failed: {last_exc}")
+
+    @abstractmethod
+    async def fetch_market_data(self, symbol: str) -> MarketPayload:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def stream_market_data(
+        self, subscriptions: Iterable[MarketSubscription], callback: CallbackT
+    ) -> WebSocketSubscription:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def submit_order(self, order: OrderRequest) -> OrderStatus:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def fetch_order_status(self, order_id: str, *, symbol: Optional[str] = None) -> OrderStatus:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> OrderStatus:
+        raise NotImplementedError
+
+    async def monitor_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float = 1.0,
+        symbol: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> OrderStatus:
+        deadline = time.monotonic() + timeout
+        while True:
+            status = await self.fetch_order_status(order_id, symbol=symbol)
+            if status.status.upper() in {"FILLED", "CANCELED", "REJECTED"}:
+                return status
+            if time.monotonic() >= deadline:
+                return status
+            await asyncio.sleep(poll_interval)
+
+
+__all__ = [
+    "ExchangeCredentials",
+    "RateLimitRule",
+    "RateLimiter",
+    "MarketSubscription",
+    "OrderRequest",
+    "OrderStatus",
+    "ExchangeAdapter",
+    "RESTWebSocketAdapter",
+    "WebSocketSubscription",
+]

--- a/KryptoLowca/exchanges/kraken.py
+++ b/KryptoLowca/exchanges/kraken.py
@@ -1,0 +1,164 @@
+"""Adapter demo dla Kraken API."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import time
+import urllib.parse
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, Dict, Optional
+
+from .interfaces import (
+    ExchangeCredentials,
+    MarketPayload,
+    MarketSubscription,
+    OrderRequest,
+    OrderStatus,
+    RESTWebSocketAdapter,
+    WebSocketSubscription,
+)
+
+
+class _DummySubscription(WebSocketSubscription):
+    async def __aenter__(self) -> "_DummySubscription":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> Optional[bool]:  # type: ignore[override]
+        return None
+
+
+class KrakenDemoAdapter(RESTWebSocketAdapter):
+    """Implementacja podstawowych operacji Kraken Demo."""
+
+    def __init__(
+        self,
+        *,
+        demo_mode: bool = True,
+        http_client=None,
+        ws_factory: Optional[
+            Callable[[Iterable[MarketSubscription], Callable[[MarketPayload], Awaitable[None]]], WebSocketSubscription]
+        ] = None,
+        compliance_ack: bool = False,
+    ) -> None:
+        base_url = "https://api.demo.kraken.com"
+        super().__init__(
+            name="kraken-demo",
+            base_url=base_url,
+            demo_mode=demo_mode,
+            http_client=http_client,
+            compliance_ack=compliance_ack,
+        )
+        self._ws_factory = ws_factory or self._default_ws_factory
+
+    async def authenticate(self, credentials: ExchangeCredentials) -> None:
+        if not credentials.api_key or not credentials.api_secret:
+            raise ValueError("Kraken wymaga kluczy API")
+        await super().authenticate(credentials)
+
+    async def fetch_market_data(self, symbol: str) -> MarketPayload:
+        response = await self._request("GET", "/0/public/Ticker", params={"pair": symbol})
+        return response
+
+    async def stream_market_data(
+        self, subscriptions: Iterable[MarketSubscription], callback: Callable[[MarketPayload], Awaitable[None]]
+    ) -> WebSocketSubscription:
+        return self._ws_factory(subscriptions, callback)
+
+    def _private_headers(self, path: str, data: Dict[str, Any]) -> Dict[str, str]:
+        if not self._credentials:
+            raise RuntimeError("Brak poświadczeń")
+        nonce = str(int(time.time() * 1000))
+        data["nonce"] = nonce
+        postdata = urllib.parse.urlencode(data)
+        message = (nonce + postdata).encode()
+        sha256 = hashlib.sha256(message).digest()
+        try:
+            secret = base64.b64decode(self._credentials.api_secret)
+        except Exception:  # pragma: no cover - fallback dla kluczy w formacie plain
+            secret = self._credentials.api_secret.encode()
+        mac = hmac.new(secret, path.encode() + sha256, hashlib.sha512)
+        signature = base64.b64encode(mac.digest()).decode()
+        return {"API-Key": self._credentials.api_key, "API-Sign": signature}
+
+    async def submit_order(self, order: OrderRequest) -> OrderStatus:
+        data = {
+            "ordertype": order.order_type.lower(),
+            "pair": order.symbol,
+            "type": order.side.lower(),
+            "volume": str(order.quantity),
+        }
+        if order.price is not None:
+            data["price"] = str(order.price)
+        data.update({k: str(v) for k, v in order.extra_params.items()})
+        headers = self._private_headers("/0/private/AddOrder", data)
+        response = await self._request(
+            "POST",
+            "/0/private/AddOrder",
+            data=data,
+            headers=headers,
+        )
+        txid = "".join(response.get("result", {}).get("txid", []))
+        descr = response.get("result", {}).get("descr", {})
+        return OrderStatus(
+            order_id=txid,
+            status="OPEN",
+            filled_quantity=0.0,
+            remaining_quantity=order.quantity,
+            average_price=float(descr.get("price", 0.0)) if descr.get("price") else None,
+            raw=response,
+        )
+
+    async def fetch_order_status(self, order_id: str, *, symbol: Optional[str] = None) -> OrderStatus:
+        data = {"txid": order_id}
+        headers = self._private_headers("/0/private/QueryOrders", data)
+        response = await self._request(
+            "POST",
+            "/0/private/QueryOrders",
+            data=data,
+            headers=headers,
+        )
+        order_info = response.get("result", {}).get(order_id, {})
+        status = order_info.get("status", "unknown").upper()
+        filled = float(order_info.get("vol_exec", 0.0))
+        total = float(order_info.get("vol", filled))
+        price = order_info.get("price") or order_info.get("pricec")
+        avg_price = float(price) if price else None
+        return OrderStatus(
+            order_id=order_id,
+            status=status,
+            filled_quantity=filled,
+            remaining_quantity=max(total - filled, 0.0),
+            average_price=avg_price,
+            raw=response,
+        )
+
+    async def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> OrderStatus:
+        data = {"txid": order_id}
+        headers = self._private_headers("/0/private/CancelOrder", data)
+        response = await self._request(
+            "POST",
+            "/0/private/CancelOrder",
+            data=data,
+            headers=headers,
+        )
+        result = response.get("result", {})
+        status = "CANCELED" if result.get("count", 0) else "UNKNOWN"
+        return OrderStatus(
+            order_id=order_id,
+            status=status,
+            filled_quantity=0.0,
+            remaining_quantity=0.0,
+            average_price=None,
+            raw=response,
+        )
+
+    def _default_ws_factory(
+        self,
+        subscriptions: Iterable[MarketSubscription],
+        callback: Callable[[MarketPayload], Awaitable[None]],
+    ) -> WebSocketSubscription:
+        return _DummySubscription()
+
+
+__all__ = ["KrakenDemoAdapter"]

--- a/KryptoLowca/managers/__init__.py
+++ b/KryptoLowca/managers/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "DatabaseManager", "DBOptions",
     "AIManager", "ConfigManager", "ExchangeManager",
     "ReportManager", "RiskManagerAdapter", "SecurityManager",
+    "MultiExchangeAccountManager",
 ]
 
 # Importy opcjonalne z ochroną na brak zależności środowiskowych
@@ -44,3 +45,8 @@ try:
     from .security_manager import SecurityManager  # type: ignore
 except Exception:  # pragma: no cover
     SecurityManager = None  # type: ignore
+
+try:
+    from .multi_account_manager import MultiExchangeAccountManager  # type: ignore
+except Exception:  # pragma: no cover
+    MultiExchangeAccountManager = None  # type: ignore

--- a/KryptoLowca/managers/multi_account_manager.py
+++ b/KryptoLowca/managers/multi_account_manager.py
@@ -1,0 +1,131 @@
+"""Manager rozdzielający zlecenia pomiędzy wiele giełd."""
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Deque, Dict, Iterable, List, Optional, Tuple
+
+from KryptoLowca.exchanges.interfaces import (
+    ExchangeAdapter,
+    ExchangeCredentials,
+    MarketPayload,
+    MarketSubscription,
+    OrderRequest,
+    OrderStatus,
+    WebSocketSubscription,
+)
+
+
+@dataclass(slots=True)
+class ManagedAccount:
+    exchange: str
+    account: str
+    adapter: ExchangeAdapter
+    weight: int = 1
+    tags: set[str] = field(default_factory=set)
+
+
+class MultiExchangeAccountManager:
+    """Zarządza wieloma kontami, balansując obciążenie i monitorując zlecenia."""
+
+    def __init__(self) -> None:
+        self._accounts: Dict[Tuple[str, str], ManagedAccount] = {}
+        self._round_robin: Deque[Tuple[str, str]] = deque()
+        self._order_index: Dict[str, Tuple[str, str]] = {}
+        self._lock = asyncio.Lock()
+
+    def register_account(
+        self,
+        *,
+        exchange: str,
+        account: str,
+        adapter: ExchangeAdapter,
+        weight: int = 1,
+        tags: Optional[Iterable[str]] = None,
+    ) -> None:
+        key = (exchange, account)
+        self._accounts[key] = ManagedAccount(
+            exchange=exchange,
+            account=account,
+            adapter=adapter,
+            weight=max(1, weight),
+            tags=set(tags or []),
+        )
+        for _ in range(max(1, weight)):
+            self._round_robin.append(key)
+
+    async def connect_all(self, credentials: Dict[Tuple[str, str], ExchangeCredentials]) -> None:
+        for key, account in self._accounts.items():
+            await account.adapter.connect()
+            creds = credentials.get(key)
+            if creds:
+                await account.adapter.authenticate(creds)
+
+    async def stream_market_data(
+        self,
+        subscriptions: Iterable[MarketSubscription],
+        callback: Callable[[str, str, MarketPayload], Awaitable[None]],
+    ) -> List[WebSocketSubscription]:
+        tasks: List[WebSocketSubscription] = []
+        for (exchange, account), managed in self._accounts.items():
+            async def _wrap(event: MarketPayload, ex=exchange, acc=account) -> None:
+                await callback(ex, acc, event)
+
+            tasks.append(managed.adapter.stream_market_data(subscriptions, _wrap))
+        return tasks
+
+    async def dispatch_order(self, order: OrderRequest) -> OrderStatus:
+        async with self._lock:
+            if not self._round_robin:
+                raise RuntimeError("Brak zarejestrowanych kont giełdowych")
+            key = self._round_robin[0]
+            self._round_robin.rotate(-1)
+            managed = self._accounts[key]
+        status = await managed.adapter.submit_order(order)
+        self._order_index[status.order_id] = key
+        return status
+
+    async def fetch_order_status(self, order_id: str) -> OrderStatus:
+        key = self._order_index.get(order_id)
+        if not key:
+            raise KeyError(f"Nieznane zlecenie {order_id}")
+        managed = self._accounts[key]
+        return await managed.adapter.fetch_order_status(order_id)
+
+    async def cancel_order(self, order_id: str) -> OrderStatus:
+        key = self._order_index.get(order_id)
+        if not key:
+            raise KeyError(f"Nieznane zlecenie {order_id}")
+        managed = self._accounts[key]
+        status = await managed.adapter.cancel_order(order_id)
+        self._order_index.pop(order_id, None)
+        return status
+
+    async def monitor_open_orders(
+        self,
+        *,
+        poll_interval: float = 1.0,
+        timeout: float = 60.0,
+    ) -> Dict[str, OrderStatus]:
+        results: Dict[str, OrderStatus] = {}
+        tasks = []
+        for order_id, key in list(self._order_index.items()):
+            adapter = self._accounts[key].adapter
+            tasks.append(
+                asyncio.create_task(
+                    adapter.monitor_order(order_id, poll_interval=poll_interval, timeout=timeout)
+                )
+            )
+        for task in asyncio.as_completed(tasks):
+            status = await task
+            results[status.order_id] = status
+            if status.status.upper() in {"FILLED", "CANCELED", "REJECTED"}:
+                self._order_index.pop(status.order_id, None)
+        return results
+
+    def list_accounts(self) -> List[ManagedAccount]:
+        return list(self._accounts.values())
+
+
+__all__ = ["MultiExchangeAccountManager", "ManagedAccount"]

--- a/KryptoLowca/security/api_key_manager.py
+++ b/KryptoLowca/security/api_key_manager.py
@@ -1,0 +1,199 @@
+"""Zarządzanie kluczami API z szyfrowaniem i rotacją."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from KryptoLowca.exchanges.interfaces import ExchangeCredentials
+
+Encryptor = Callable[[str, Dict[str, Any]], Dict[str, Any]]
+Decryptor = Callable[[str, Dict[str, Any]], Dict[str, Any]]
+
+
+@dataclass(slots=True)
+class APIKeyRecord:
+    exchange: str
+    account: str
+    version: int
+    created_at: datetime
+    expires_at: Optional[datetime]
+    credentials: ExchangeCredentials
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_payload(self, encryptor: Encryptor) -> Dict[str, Any]:
+        payload = {
+            "exchange": self.exchange,
+            "account": self.account,
+            "version": self.version,
+            "created_at": self.created_at.isoformat(),
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "metadata": self.metadata,
+        }
+        encrypted = encryptor(
+            "exchange",
+            {
+                "api_key": self.credentials.api_key,
+                "api_secret": self.credentials.api_secret,
+                "passphrase": self.credentials.passphrase or "",
+                "is_read_only": self.credentials.is_read_only,
+            },
+        )
+        payload["data"] = encrypted
+        return payload
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any], decryptor: Decryptor) -> "APIKeyRecord":
+        decrypted = decryptor("exchange", payload.get("data", {}))
+        metadata = payload.get("metadata", {}) or {}
+        return cls(
+            exchange=payload["exchange"],
+            account=payload["account"],
+            version=int(payload.get("version", 1)),
+            created_at=datetime.fromisoformat(payload["created_at"]),
+            expires_at=(
+                datetime.fromisoformat(payload["expires_at"])
+                if payload.get("expires_at")
+                else None
+            ),
+            credentials=ExchangeCredentials(
+                api_key=decrypted.get("api_key", ""),
+                api_secret=decrypted.get("api_secret", ""),
+                passphrase=decrypted.get("passphrase") or None,
+                is_read_only=bool(decrypted.get("is_read_only", False)),
+                metadata=metadata,
+            ),
+            metadata=metadata,
+        )
+
+
+class APIKeyManager:
+    """Magazyn kluczy API korzystający z szyfrowania ConfigManagera."""
+
+    def __init__(
+        self,
+        storage_path: Path,
+        *,
+        encryptor: Encryptor,
+        decryptor: Decryptor,
+        default_ttl: timedelta | None = timedelta(days=180),
+    ) -> None:
+        self._path = Path(storage_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._encryptor = encryptor
+        self._decryptor = decryptor
+        self._default_ttl = default_ttl
+
+    def _load_records(self) -> List[APIKeyRecord]:
+        if not self._path.exists():
+            return []
+        raw = json.loads(self._path.read_text())
+        records = []
+        for payload in raw.get("records", []):
+            try:
+                records.append(APIKeyRecord.from_payload(payload, self._decryptor))
+            except Exception:
+                continue
+        return records
+
+    def _write_records(self, records: Iterable[APIKeyRecord]) -> None:
+        payload = {"records": [record.to_payload(self._encryptor) for record in records]}
+        self._path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+    def save_credentials(
+        self,
+        exchange: str,
+        account: str,
+        credentials: ExchangeCredentials,
+        *,
+        compliance_ack: bool = False,
+        expires_at: Optional[datetime] = None,
+        rotate: bool = False,
+    ) -> APIKeyRecord:
+        env = str(credentials.metadata.get("environment", "demo")).lower()
+        if env not in {"demo", "test", "paper"} and not compliance_ack:
+            raise ValueError("Zapis kluczy live wymaga potwierdzenia compliance")
+        records = self._load_records()
+        existing = [
+            record for record in records if record.exchange == exchange and record.account == account
+        ]
+        next_version = max([r.version for r in existing], default=0) + 1
+        expires = expires_at or (
+            datetime.now(timezone.utc) + self._default_ttl if self._default_ttl else None
+        )
+        record = APIKeyRecord(
+            exchange=exchange,
+            account=account,
+            version=next_version,
+            created_at=datetime.now(timezone.utc),
+            expires_at=expires,
+            credentials=credentials,
+            metadata=dict(credentials.metadata),
+        )
+        remaining = [r for r in records if r.exchange != exchange or r.account != account]
+        if rotate:
+            remaining.extend(existing)
+        remaining.append(record)
+        self._write_records(remaining)
+        return record
+
+    def rotate_credentials(
+        self,
+        exchange: str,
+        account: str,
+        credentials: ExchangeCredentials,
+        *,
+        compliance_ack: bool = False,
+        expires_at: Optional[datetime] = None,
+    ) -> APIKeyRecord:
+        return self.save_credentials(
+            exchange,
+            account,
+            credentials,
+            compliance_ack=compliance_ack,
+            expires_at=expires_at,
+            rotate=True,
+        )
+
+    def load_credentials(self, exchange: str, account: str) -> ExchangeCredentials:
+        records = sorted(
+            (
+                record
+                for record in self._load_records()
+                if record.exchange == exchange and record.account == account
+            ),
+            key=lambda r: (r.version, r.created_at),
+        )
+        if not records:
+            raise KeyError(f"Brak kluczy dla konta {exchange}:{account}")
+        return records[-1].credentials
+
+    def list_accounts(self) -> List[Dict[str, Any]]:
+        summary: Dict[tuple[str, str], APIKeyRecord] = {}
+        for record in self._load_records():
+            key = (record.exchange, record.account)
+            if key not in summary or summary[key].version < record.version:
+                summary[key] = record
+        return [
+            {
+                "exchange": exchange,
+                "account": account,
+                "version": record.version,
+                "expires_at": record.expires_at.isoformat() if record.expires_at else None,
+                "metadata": record.metadata,
+            }
+            for (exchange, account), record in sorted(summary.items())
+        ]
+
+    def purge_expired(self) -> int:
+        now = datetime.now(timezone.utc)
+        before = self._load_records()
+        records = [record for record in before if not record.expires_at or record.expires_at > now]
+        removed = len(before) - len(records)
+        self._write_records(records)
+        return removed
+
+
+__all__ = ["APIKeyManager", "APIKeyRecord"]

--- a/KryptoLowca/tests/test_exchange_protocols.py
+++ b/KryptoLowca/tests/test_exchange_protocols.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.fernet import Fernet
+
+from KryptoLowca.config_manager import ConfigManager
+from KryptoLowca.exchanges import (
+    BinanceTestnetAdapter,
+    ExchangeCredentials,
+    KrakenDemoAdapter,
+    OrderRequest,
+    OrderStatus,
+)
+from KryptoLowca.managers.multi_account_manager import MultiExchangeAccountManager
+
+
+class StubResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.text = json.dumps(payload)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class RecordingHTTPClient:
+    def __init__(self, responses: list[StubResponse]) -> None:
+        self.responses = responses
+        self.requests: list[dict] = []
+
+    async def request(self, method, url, *, params=None, data=None, headers=None, timeout=None):
+        self.requests.append(
+            {
+                "method": method,
+                "url": url,
+                "params": params,
+                "data": data,
+                "headers": headers,
+            }
+        )
+        if not self.responses:
+            raise RuntimeError("No more responses configured")
+        return self.responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_binance_adapter_signed_requests():
+    response = StubResponse(
+        {"orderId": 1, "status": "NEW", "executedQty": "0", "origQty": "1", "price": "0"}
+    )
+    http = RecordingHTTPClient([response])
+    adapter = BinanceTestnetAdapter(http_client=http)
+    await adapter.connect()
+    await adapter.authenticate(ExchangeCredentials(api_key="k", api_secret="s"))
+
+    order = OrderRequest(symbol="BTCUSDT", side="BUY", quantity=1.0, order_type="MARKET")
+    status = await adapter.submit_order(order)
+
+    call = http.requests[0]
+    assert call["headers"]["X-MBX-APIKEY"] == "k"
+    assert "signature" in call["params"]
+    assert status.order_id == 1
+    assert status.status == "NEW"
+
+
+@pytest.mark.asyncio
+async def test_binance_rate_limit_retry(monkeypatch):
+    success = StubResponse(
+        {
+            "orderId": 1,
+            "status": "FILLED",
+            "executedQty": "1",
+            "origQty": "1",
+            "price": "20000",
+        }
+    )
+    http = RecordingHTTPClient([StubResponse({"error": "429"}, status_code=429), success])
+
+    async def fast_sleep(delay: float) -> None:  # pragma: no cover - test helper
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    adapter = BinanceTestnetAdapter(http_client=http)
+    await adapter.connect()
+    await adapter.authenticate(ExchangeCredentials(api_key="k", api_secret="s"))
+
+    status = await adapter.fetch_order_status("1", symbol="BTCUSDT")
+    assert status.status == "FILLED"
+    assert len(http.requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_kraken_headers_signed():
+    http = RecordingHTTPClient(
+        [
+            StubResponse({"result": {"txid": ["ABC"], "descr": {"price": "10"}}}),
+            StubResponse({"result": {"ABC": {"status": "closed", "vol": "1", "vol_exec": "1"}}}),
+        ]
+    )
+    adapter = KrakenDemoAdapter(http_client=http)
+    await adapter.connect()
+    secret = base64.b64encode(b"topsecret").decode()
+    await adapter.authenticate(ExchangeCredentials(api_key="key", api_secret=secret))
+
+    order = OrderRequest(symbol="XBTUSD", side="buy", quantity=1.0, order_type="limit", price=10)
+    status = await adapter.submit_order(order)
+    assert status.order_id == "ABC"
+    call = http.requests[0]
+    assert call["headers"]["API-Key"] == "key"
+    assert "API-Sign" in call["headers"]
+
+    detail = await adapter.fetch_order_status("ABC")
+    assert detail.status == "CLOSED"
+    assert len(http.requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_api_key_manager_rotation(tmp_path):
+    encryption_key = Fernet.generate_key()
+    cfg = await ConfigManager.create(config_path=str(tmp_path / "config.json"), encryption_key=encryption_key)
+    manager = cfg.api_key_manager
+
+    creds = ExchangeCredentials(api_key="demo", api_secret="secret", metadata={"environment": "demo"})
+    record = manager.save_credentials("binance", "acct", creds)
+    stored = json.loads((tmp_path / "api_keys_store.json").read_text())
+    assert stored["records"][0]["data"]["api_key"] != "demo"
+
+    rotated = manager.rotate_credentials(
+        "binance",
+        "acct",
+        ExchangeCredentials(api_key="demo2", api_secret="secret2", metadata={"environment": "demo"}),
+    )
+    assert rotated.version == 2
+    latest = manager.load_credentials("binance", "acct")
+    assert latest.api_key == "demo2"
+
+    with pytest.raises(ValueError):
+        manager.save_credentials(
+            "binance",
+            "live",
+            ExchangeCredentials(api_key="live", api_secret="live", metadata={"environment": "live"}),
+        )
+
+    manager.save_credentials(
+        "binance",
+        "live",
+        ExchangeCredentials(api_key="live", api_secret="live", metadata={"environment": "live"}),
+        compliance_ack=True,
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    removed = manager.purge_expired()
+    assert removed >= 1
+
+
+class StubAdapter:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.demo_mode = True
+        self._orders: dict[str, OrderStatus] = {}
+
+    async def connect(self) -> None:
+        return None
+
+    async def close(self) -> None:  # pragma: no cover - not used in tests
+        return None
+
+    async def authenticate(self, credentials: ExchangeCredentials) -> None:
+        self.credentials = credentials
+
+    async def fetch_market_data(self, symbol: str) -> dict[str, str]:  # pragma: no cover - not used
+        return {"symbol": symbol}
+
+    async def stream_market_data(self, subscriptions, callback):  # pragma: no cover - not used
+        class _Dummy:
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                return None
+
+        return _Dummy()
+
+    async def submit_order(self, order: OrderRequest) -> OrderStatus:
+        order_id = f"{self.name}-{len(self._orders) + 1}"
+        status = OrderStatus(
+            order_id=order_id,
+            status="NEW",
+            filled_quantity=0.0,
+            remaining_quantity=order.quantity,
+            average_price=None,
+            raw={"exchange": self.name},
+        )
+        self._orders[order_id] = status
+        return status
+
+    async def fetch_order_status(self, order_id: str, *, symbol: str | None = None) -> OrderStatus:
+        return self._orders[order_id]
+
+    async def cancel_order(self, order_id: str, *, symbol: str | None = None) -> OrderStatus:
+        status = OrderStatus(
+            order_id=order_id,
+            status="CANCELED",
+            filled_quantity=0.0,
+            remaining_quantity=0.0,
+            average_price=None,
+            raw={"exchange": self.name},
+        )
+        self._orders[order_id] = status
+        return status
+
+    async def monitor_order(
+        self,
+        order_id: str,
+        *,
+        poll_interval: float = 0.0,
+        symbol: str | None = None,
+        timeout: float = 0.0,
+    ) -> OrderStatus:
+        status = self._orders[order_id]
+        filled = OrderStatus(
+            order_id=order_id,
+            status="FILLED",
+            filled_quantity=status.remaining_quantity,
+            remaining_quantity=0.0,
+            average_price=status.average_price,
+            raw=status.raw,
+        )
+        self._orders[order_id] = filled
+        return filled
+
+
+@pytest.mark.asyncio
+async def test_multi_account_round_robin():
+    manager = MultiExchangeAccountManager()
+    adapter_a = StubAdapter("binance")
+    adapter_b = StubAdapter("kraken")
+    manager.register_account(exchange="binance", account="a", adapter=adapter_a)
+    manager.register_account(exchange="kraken", account="b", adapter=adapter_b)
+
+    creds = {
+        ("binance", "a"): ExchangeCredentials(api_key="a", api_secret="a"),
+        ("kraken", "b"): ExchangeCredentials(api_key="b", api_secret="b"),
+    }
+    await manager.connect_all(creds)
+
+    order = OrderRequest(symbol="BTCUSDT", side="buy", quantity=1.0)
+    first = await manager.dispatch_order(order)
+    second = await manager.dispatch_order(order)
+
+    assert first.order_id.startswith("binance")
+    assert second.order_id.startswith("kraken")
+
+    status = await manager.fetch_order_status(first.order_id)
+    assert status.status == "NEW"
+
+    cancel_status = await manager.cancel_order(second.order_id)
+    assert cancel_status.status == "CANCELED"
+
+    summary = await manager.monitor_open_orders()
+    assert summary[first.order_id].status == "FILLED"
+
+
+@pytest.mark.asyncio
+async def test_live_mode_requires_ack(monkeypatch):
+    http = RecordingHTTPClient([])
+    with pytest.raises(ValueError):
+        BinanceTestnetAdapter(demo_mode=False, http_client=http)
+
+    adapter = BinanceTestnetAdapter(demo_mode=False, http_client=http, compliance_ack=True)
+    await adapter.connect()
+


### PR DESCRIPTION
## Summary
- introduce a shared REST/WebSocket exchange adapter interface with rate limiting and monitoring helpers
- add Binance Testnet and Kraken Demo adapters plus a multi-account order dispatcher using the new abstraction
- implement encrypted API key manager tied into ConfigManager and provide contract/integration tests for adapters and key rotation

## Testing
- `pytest KryptoLowca/tests/test_exchange_protocols.py`
- `pytest` *(fails: legacy marketplace modules raise circular import errors; existing issue unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c9f1f140832ab322d1b2ee0c1cb9