### PR TITLE
Implement websocket streaming for Binance and Kraken demo adapters

### DIFF
--- a/KryptoLowca/exchanges/kraken.py
+++ b/KryptoLowca/exchanges/kraken.py
@@ -1,12 +1,16 @@
 """Adapter demo dla Kraken API."""
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import base64
 import hashlib
 import hmac
+import json
+import logging
 import time
 import urllib.parse
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from typing import Any, Dict, Optional
 
 from .interfaces import (
@@ -20,12 +24,148 @@ from .interfaces import (
 )
 
 
-class _DummySubscription(WebSocketSubscription):
-    async def __aenter__(self) -> "_DummySubscription":
+try:  # pragma: no cover - zależność opcjonalna
+    import websockets
+    from websockets.protocol import State as _WSState
+except Exception:  # pragma: no cover - środowisko bez websocketów
+    websockets = None  # type: ignore[assignment]
+    _WSState = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+
+_KRAKEN_WS_ENDPOINT = "wss://beta-ws.kraken.com/"
+_KRAKEN_WS_INITIAL_BACKOFF = 1.0
+_KRAKEN_WS_MAX_BACKOFF = 30.0
+
+
+class _KrakenWebSocketSubscription(WebSocketSubscription):
+    """Obsługa websocketów Kraken Demo z reconnect/backoff."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        subscriptions: Sequence[tuple[Dict[str, Any], Dict[str, Any]]],
+        callback: Callable[[MarketPayload], Awaitable[None]],
+        initial_backoff: float = _KRAKEN_WS_INITIAL_BACKOFF,
+        max_backoff: float = _KRAKEN_WS_MAX_BACKOFF,
+    ) -> None:
+        if not subscriptions:
+            raise ValueError("Wymagana jest co najmniej jedna subskrypcja Kraken")
+        if websockets is None:  # pragma: no cover - brak zależności
+            raise RuntimeError("Pakiet 'websockets' jest wymagany do streamingu Kraken")
+        self._endpoint = endpoint
+        self._subscriptions = list(subscriptions)
+        self._callback = callback
+        self._initial_backoff = max(0.1, initial_backoff)
+        self._max_backoff = max(self._initial_backoff, max_backoff)
+        self._task: Optional[asyncio.Task[None]] = None
+        self._ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._closed = False
+
+    async def __aenter__(self) -> "_KrakenWebSocketSubscription":
+        self._task = asyncio.create_task(self._runner(), name="kraken-ws-runner")
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> Optional[bool]:  # type: ignore[override]
+        self._closed = True
+        if self._ws:
+            with contextlib.suppress(Exception):
+                await self._send_unsubscribe()
+            with contextlib.suppress(Exception):
+                await self._ws.close()
+            self._ws = None
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
         return None
+
+    async def _runner(self) -> None:
+        attempt = 0
+        while not self._closed:
+            try:
+                self._ws = await websockets.connect(self._endpoint, ping_interval=20)
+                try:
+                    await self._send_subscribe()
+                    attempt = 0
+                    async for message in self._ws:
+                        await self._handle_message(message)
+                finally:
+                    if self._ws:
+                        with contextlib.suppress(Exception):
+                            await self._ws.close()
+                    self._ws = None
+            except asyncio.CancelledError:  # pragma: no cover - zamykanie kontekstu
+                raise
+            except Exception as exc:
+                if self._closed:
+                    break
+                attempt += 1
+                wait_for = min(self._initial_backoff * (2 ** (attempt - 1)), self._max_backoff)
+                logger.debug("Kraken WS reconnect in %.2fs after error: %s", wait_for, exc)
+                await asyncio.sleep(wait_for)
+            else:
+                if not self._closed:
+                    attempt += 1
+                    wait_for = min(self._initial_backoff * (2 ** (attempt - 1)), self._max_backoff)
+                    logger.debug("Kraken WS reconnect in %.2fs after close", wait_for)
+                    await asyncio.sleep(wait_for)
+
+    async def _send_subscribe(self) -> None:
+        if not self._ws:
+            return
+        for subscribe_payload, _ in self._subscriptions:
+            await self._ws.send(json.dumps(subscribe_payload))
+
+    async def _send_unsubscribe(self) -> None:
+        if not self._ws:
+            return
+        state = getattr(self._ws, "state", None)
+        name = getattr(state, "name", None)
+        if name == "CLOSED" or (state is not None and _WSState is not None and state == getattr(_WSState, "CLOSED", None)):
+            return
+        for _, unsubscribe_payload in self._subscriptions:
+            await self._ws.send(json.dumps(unsubscribe_payload))
+
+    async def _handle_message(self, message: str | bytes) -> None:
+        if isinstance(message, bytes):
+            message = message.decode("utf-8", "ignore")
+        try:
+            payload: MarketPayload = json.loads(message)
+        except json.JSONDecodeError:
+            logger.debug("Kraken WS otrzymał nieprawidłowy JSON: %s", message)
+            return
+        try:
+            await self._callback(payload)
+        except Exception as exc:  # pragma: no cover - callback użytkownika
+            logger.exception("Błąd callbacka Kraken WS: %s", exc)
+
+
+def _prepare_kraken_payloads(subscriptions: Iterable[MarketSubscription]) -> list[tuple[Dict[str, Any], Dict[str, Any]]]:
+    payloads: list[tuple[Dict[str, Any], Dict[str, Any]]] = []
+    for subscription in subscriptions:
+        subscribe: Dict[str, Any] = {"event": "subscribe"}
+        unsubscribe: Dict[str, Any] = {"event": "unsubscribe"}
+
+        pairs = list(subscription.symbols)
+        if pairs:
+            subscribe["pair"] = pairs
+            unsubscribe["pair"] = pairs
+
+        base_subscription = dict(subscription.params.get("subscription", {}))
+        base_subscription.setdefault("name", subscription.channel)
+        subscribe["subscription"] = dict(base_subscription)
+        unsubscribe["subscription"] = dict(base_subscription)
+
+        extra_fields = {k: v for k, v in subscription.params.items() if k != "subscription"}
+        subscribe.update(extra_fields)
+        unsubscribe.update(extra_fields)
+
+        payloads.append((subscribe, unsubscribe))
+    return payloads
 
 
 class KrakenDemoAdapter(RESTWebSocketAdapter):
@@ -158,7 +298,14 @@ class KrakenDemoAdapter(RESTWebSocketAdapter):
         subscriptions: Iterable[MarketSubscription],
         callback: Callable[[MarketPayload], Awaitable[None]],
     ) -> WebSocketSubscription:
-        return _DummySubscription()
+        payloads = _prepare_kraken_payloads(subscriptions)
+        return _KrakenWebSocketSubscription(
+            endpoint=_KRAKEN_WS_ENDPOINT,
+            subscriptions=payloads,
+            callback=callback,
+            initial_backoff=_KRAKEN_WS_INITIAL_BACKOFF,
+            max_backoff=_KRAKEN_WS_MAX_BACKOFF,
+        )
 
 
 __all__ = ["KrakenDemoAdapter"]


### PR DESCRIPTION
## Summary
- add websocket factories for the Binance testnet and Kraken demo adapters using official demo endpoints, including reconnect/backoff handling
- forward market/order websocket events to the provided callback and manage subscription formatting helpers
- extend exchange protocol tests with mocked websocket servers that verify subscription messages, event parsing, and reconnection behavior

## Testing
- pytest KryptoLowca/tests/test_exchange_protocols.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d7cf2b5d94832aad13b3a9f010c708