### PR TITLE
Add Zonda exchange streaming adapter and tests

### DIFF
--- a/KryptoLowca/managers/multi_account_manager.py
+++ b/KryptoLowca/managers/multi_account_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Deque, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, ClassVar, Deque, Dict, FrozenSet, Iterable, List, Optional, Tuple
 
 from KryptoLowca.exchanges.interfaces import (
     ExchangeAdapter,
@@ -27,7 +27,13 @@ class ManagedAccount:
 
 
 class MultiExchangeAccountManager:
-    """Zarządza wieloma kontami, balansując obciążenie i monitorując zlecenia."""
+    """Zarządza wieloma kontami, balansując obciążenie i monitorując zlecenia.
+
+    Domyślnie obsługujemy identyfikatory ``binance``, ``kraken`` oraz ``zonda``
+    wykorzystywane w adapterach REST/WebSocket.
+    """
+
+    SUPPORTED_EXCHANGES: ClassVar[FrozenSet[str]] = frozenset({"binance", "kraken", "zonda"})
 
     def __init__(self) -> None:
         self._accounts: Dict[Tuple[str, str], ManagedAccount] = {}
@@ -54,6 +60,12 @@ class MultiExchangeAccountManager:
         )
         for _ in range(max(1, weight)):
             self._round_robin.append(key)
+
+    @classmethod
+    def is_supported_exchange(cls, exchange: str) -> bool:
+        """Sprawdza, czy identyfikator giełdy znajduje się na liście wspieranych."""
+
+        return exchange in cls.SUPPORTED_EXCHANGES
 
     async def connect_all(self, credentials: Dict[Tuple[str, str], ExchangeCredentials]) -> None:
         for key, account in self._accounts.items():

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,6 +43,17 @@ które wchodzą w skład tej architektury.
 - `execution_service.py` izoluje logikę wysyłania zleceń. Wymaga adaptera giełdy
   implementującego `submit_order` i respektuje ograniczenia (np. brak rozmiaru).
 
+## Adaptery giełdowe i zarządzanie kontami
+
+- `KryptoLowca/exchanges/binance.py`, `kraken.py` oraz `zonda.py` implementują
+  adaptery REST/WebSocket dla środowisk demo/testnet. Każdy adapter wspiera
+  podpisy specyficzne dla giełdy (np. HMAC SHA512 na Zondzie) oraz streaming
+  danych rynkowych poprzez kanały WebSocket.
+- `MultiExchangeAccountManager` (`KryptoLowca/managers/multi_account_manager.py`)
+  potrafi równoważyć zlecenia pomiędzy kontami na giełdach `binance`, `kraken`
+  i `zonda`, pamiętając kontekst zamówień oraz zarządzając subskrypcjami danych
+  rynkowych.
+
 ## Konfiguracja (`KryptoLowca/config_manager.py`)
 
 `ConfigManager` spina konfigurację aplikacji i integruje się z marketplace


### PR DESCRIPTION
## Summary
- implement a production-ready Zonda REST/WebSocket adapter with API signing and resilient streaming
- extend the multi-exchange account manager and documentation to recognize the `zonda` identifier
- cover the adapter with contract-style HTTP/WS tests and keep documentation aligned

## Testing
- pytest KryptoLowca/tests/test_exchange_protocols.py

------
https://chatgpt.com/codex/tasks/task_e_68d7d2d0a8f4832a8a487b5c428d27e9