### PR TITLE
Add robust Zonda status normalization and tests

### DIFF
--- a/KryptoLowca/config_manager.py
+++ b/KryptoLowca/config_manager.py
@@ -784,7 +784,7 @@ class ConfigManager:
             key: ("" if key in self.ENCRYPTED_FIELDS.get("exchange", set()) else value)
             for key, value in template["exchange"].items()
         }
-        with self.config_path.open("w", encoding="utf-8") as fh):
+        with self.config_path.open("w", encoding="utf-8") as fh:
             yaml.safe_dump(template, fh, sort_keys=True)
         return self.config_path
 


### PR DESCRIPTION
## Summary
- normalize multiple Zonda API order status variants inside the exchange adapter
- add contract tests covering signature assertions and status normalization cases
- fix config manager template writer syntax so the module imports during tests

## Testing
- pytest KryptoLowca/tests/test_exchange_protocols.py

------
https://chatgpt.com/codex/tasks/task_e_68d7d8eb81f8832ab089944a53345fc4