### PR TITLE
Add websocket subscription tests for Binance and Kraken adapters

### DIFF
--- a/KryptoLowca/config_manager.py
+++ b/KryptoLowca/config_manager.py
@@ -784,7 +784,7 @@ class ConfigManager:
             key: ("" if key in self.ENCRYPTED_FIELDS.get("exchange", set()) else value)
             for key, value in template["exchange"].items()
         }
-        with self.config_path.open("w", encoding="utf-8") as fh):
+        with self.config_path.open("w", encoding="utf-8") as fh:
             yaml.safe_dump(template, fh, sort_keys=True)
         return self.config_path
 


### PR DESCRIPTION
## Summary
- add websocket subscription integration tests for Binance and Kraken adapters using mocked websocket clients
- ensure config template writing helper opens files without syntax errors to allow test imports

## Testing
- pytest KryptoLowca/tests/test_exchange_protocols.py -k websocket -q

------
https://chatgpt.com/codex/tasks/task_e_68d7d8edd448832abfaf12e9591946ab