### PR TITLE
Fix mypy typing issues for marketplace and execution services

### DIFF
--- a/KryptoLowca/config_manager.py
+++ b/KryptoLowca/config_manager.py
@@ -180,7 +180,20 @@ class ExchangeConfig:
 
         # rzutowania
         self.retry_attempts = int(self.retry_attempts)
-        self.retry_delay = float(self.retry_delay)
+
+        retry_delay_raw = self.retry_delay
+        if retry_delay_raw is None:
+            retry_delay_value = 0.0
+        elif isinstance(retry_delay_raw, (int, float)):
+            retry_delay_value = float(retry_delay_raw)
+        elif isinstance(retry_delay_raw, str):
+            try:
+                retry_delay_value = float(retry_delay_raw.strip())
+            except ValueError as exc:
+                raise ValidationError("retry_delay musi być liczbą") from exc
+        else:
+            raise ValidationError("retry_delay musi być liczbą lub None")
+        self.retry_delay = retry_delay_value
         self.require_demo_mode = bool(self.require_demo_mode)
         self.telemetry_log_interval_s = float(self.telemetry_log_interval_s)
         self.telemetry_schema_version = int(self.telemetry_schema_version)

--- a/KryptoLowca/core/services/execution_service.py
+++ b/KryptoLowca/core/services/execution_service.py
@@ -29,7 +29,12 @@ class ExecutionService:
     def portfolio_snapshot(self, symbol: str) -> Mapping[str, object] | None:
         getter = getattr(self._adapter, "portfolio_snapshot", None)
         if callable(getter):
-            return getter(symbol)
+            result = getter(symbol)
+            if result is None or isinstance(result, Mapping):
+                return result
+            raise TypeError(
+                "portfolio_snapshot must return Mapping[str, object] or None"
+            )
         return None
 
     @guard_exceptions("ExecutionService")


### PR DESCRIPTION
## Summary
- implement a typed `StrategyPreset` dataclass plus marketplace loader helpers and export them from the marketplace module
- harden portfolio snapshot and paper adapter data conversions to respect declared typing contracts
- normalize `retry_delay` handling in configuration validation to accept optional inputs safely

## Testing
- `poetry run mypy KryptoLowca/core/services/execution_service.py KryptoLowca/strategies/marketplace.py KryptoLowca/config_manager.py KryptoLowca/core/services/paper_adapter.py` *(fails: poetry configuration is invalid in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e5a8007c832a88f3bb393649a34d