### PR TITLE
Add runtime bootstrap and alert channel configuration

### DIFF
--- a/bot_core/__init__.py
+++ b/bot_core/__init__.py
@@ -1,0 +1,34 @@
+"""Nowa modularna architektura bota handlowego."""
+
+from bot_core.alerts import (
+    AlertChannel,
+    AlertMessage,
+    DEFAULT_SMS_PROVIDERS,
+    SmsProviderConfig,
+    get_sms_provider,
+)
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import CoreConfig
+from bot_core.exchanges.base import ExchangeAdapter
+from bot_core.security import (
+    KeyringSecretStorage,
+    SecretManager,
+    SecretStorageError,
+)
+from bot_core.runtime import BootstrapContext, bootstrap_environment
+
+__all__ = [
+    "AlertChannel",
+    "AlertMessage",
+    "DEFAULT_SMS_PROVIDERS",
+    "SmsProviderConfig",
+    "get_sms_provider",
+    "CoreConfig",
+    "ExchangeAdapter",
+    "KeyringSecretStorage",
+    "SecretManager",
+    "SecretStorageError",
+    "BootstrapContext",
+    "bootstrap_environment",
+    "load_core_config",
+]

--- a/bot_core/alerts/__init__.py
+++ b/bot_core/alerts/__init__.py
@@ -1,0 +1,36 @@
+"""Pakiet kanałów alertów i routera."""
+
+from bot_core.alerts.audit import AlertAuditEntry, InMemoryAlertAuditLog
+from bot_core.alerts.base import (
+    AlertAuditLog,
+    AlertChannel,
+    AlertDeliveryError,
+    AlertMessage,
+    AlertRouter,
+)
+from bot_core.alerts.channels import (
+    DEFAULT_SMS_PROVIDERS,
+    EmailChannel,
+    SMSChannel,
+    SmsProviderConfig,
+    TelegramChannel,
+    get_sms_provider,
+)
+from bot_core.alerts.router import DefaultAlertRouter
+
+__all__ = [
+    "AlertAuditEntry",
+    "AlertAuditLog",
+    "AlertChannel",
+    "AlertDeliveryError",
+    "AlertMessage",
+    "AlertRouter",
+    "DefaultAlertRouter",
+    "EmailChannel",
+    "SMSChannel",
+    "SmsProviderConfig",
+    "TelegramChannel",
+    "DEFAULT_SMS_PROVIDERS",
+    "get_sms_provider",
+    "InMemoryAlertAuditLog",
+]

--- a/bot_core/alerts/audit.py
+++ b/bot_core/alerts/audit.py
@@ -1,0 +1,52 @@
+"""Repozytoria audytu wykorzystywane przez system alertów."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Mapping
+
+from bot_core.alerts.base import AlertAuditLog, AlertMessage
+
+
+@dataclass(slots=True)
+class AlertAuditEntry:
+    """Pojedynczy zapis audytowy odpowiadający wysłanemu komunikatowi."""
+
+    channel: str
+    message: AlertMessage
+    created_at: datetime
+
+    def as_dict(self) -> Mapping[str, str]:
+        """Eksportuje wpis w formacie przyjaznym serializacji."""
+
+        payload: dict[str, str] = {
+            "channel": self.channel,
+            "category": self.message.category,
+            "title": self.message.title,
+            "severity": self.message.severity,
+            "timestamp": self.message.timestamp.isoformat(),
+            "created_at": self.created_at.isoformat(),
+        }
+        payload.update({f"ctx_{k}": v for k, v in self.message.context.items()})
+        payload["body"] = self.message.body
+        return payload
+
+
+class InMemoryAlertAuditLog(AlertAuditLog):
+    """Prosta implementacja audytu na potrzeby środowisk deweloperskich."""
+
+    __slots__ = ("_entries",)
+
+    def __init__(self) -> None:
+        self._entries: List[AlertAuditEntry] = []
+
+    def append(self, message: AlertMessage, *, channel: str) -> None:
+        entry = AlertAuditEntry(channel=channel, message=message, created_at=message.timestamp)
+        self._entries.append(entry)
+
+    def export(self) -> Iterable[Mapping[str, str]]:
+        return tuple(entry.as_dict() for entry in self._entries)
+
+
+__all__ = ["AlertAuditEntry", "InMemoryAlertAuditLog"]
+

--- a/bot_core/alerts/base.py
+++ b/bot_core/alerts/base.py
@@ -1,0 +1,61 @@
+"""Interfejsy kanałów alertów oraz audytu."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableSequence, Protocol
+
+
+class AlertDeliveryError(RuntimeError):
+    """Sygnalizuje niepowodzenie podczas wysyłki alertu na kanał."""
+
+
+@dataclass(slots=True)
+class AlertMessage:
+    """Reprezentuje sformatowaną treść alertu wraz z metadanymi."""
+
+    category: str
+    title: str
+    body: str
+    severity: str
+    context: Mapping[str, str]
+    timestamp: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+
+class AlertChannel(abc.ABC):
+    """Każdy kanał powiadomień musi implementować ten interfejs."""
+
+    name: str
+
+    @abc.abstractmethod
+    def send(self, message: AlertMessage) -> None:
+        """Publikuje alert na danym kanale."""
+
+    @abc.abstractmethod
+    def health_check(self) -> Mapping[str, str]:
+        """Zwraca stan kanału wykorzystywany w raportach SLO."""
+
+
+class AlertAuditLog(Protocol):
+    """Minimalny kontrakt repozytorium audytowego."""
+
+    def append(self, message: AlertMessage, *, channel: str) -> None:
+        ...
+
+    def export(self) -> Iterable[Mapping[str, str]]:
+        ...
+
+
+class AlertRouter(abc.ABC):
+    """Centralna szyna, która będzie sterować dostarczaniem alertów."""
+
+    channels: MutableSequence[AlertChannel]
+
+    @abc.abstractmethod
+    def register(self, channel: AlertChannel) -> None:
+        ...
+
+    @abc.abstractmethod
+    def dispatch(self, message: AlertMessage) -> None:
+        ...

--- a/bot_core/alerts/channels/__init__.py
+++ b/bot_core/alerts/channels/__init__.py
@@ -1,0 +1,19 @@
+"""Adaptery kanałów powiadomień."""
+
+from bot_core.alerts.channels.email import EmailChannel
+from bot_core.alerts.channels.providers import (
+    DEFAULT_SMS_PROVIDERS,
+    SmsProviderConfig,
+    get_sms_provider,
+)
+from bot_core.alerts.channels.sms import SMSChannel
+from bot_core.alerts.channels.telegram import TelegramChannel
+
+__all__ = [
+    "EmailChannel",
+    "SMSChannel",
+    "TelegramChannel",
+    "SmsProviderConfig",
+    "DEFAULT_SMS_PROVIDERS",
+    "get_sms_provider",
+]

--- a/bot_core/alerts/channels/email.py
+++ b/bot_core/alerts/channels/email.py
@@ -1,0 +1,78 @@
+"""Adapter kanału e-mail bazujący na SMTP."""
+from __future__ import annotations
+
+import logging
+import smtplib
+from dataclasses import dataclass, field
+from email.message import EmailMessage
+from typing import Callable, Sequence
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+
+
+@dataclass(slots=True)
+class EmailChannel(AlertChannel):
+    """Wysyła powiadomienia korzystając z serwera SMTP."""
+
+    host: str
+    port: int
+    from_address: str
+    recipients: Sequence[str]
+    username: str | None = None
+    password: str | None = None
+    use_tls: bool = True
+    timeout: float = 10.0
+    name: str = "email"
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.email"))
+    _smtp_factory: Callable[[str, int, float], smtplib.SMTP] = field(default=smtplib.SMTP, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+    _last_success: str | None = field(default=None, init=False, repr=False)
+
+    def send(self, message: AlertMessage) -> None:
+        email = self._build_email(message)
+        try:
+            with self._smtp_factory(self.host, self.port, timeout=self.timeout) as client:
+                client.ehlo()
+                if self.use_tls:
+                    client.starttls()
+                    client.ehlo()
+                if self.username and self.password:
+                    client.login(self.username, self.password)
+                client.send_message(email)
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki e-maila")
+            raise AlertDeliveryError(f"Nie udało się wysłać e-maila: {exc}") from exc
+
+        self._last_error = None
+        self._last_success = message.timestamp.isoformat()
+
+    def health_check(self) -> dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: dict[str, str] = {"status": status}
+        if self._last_success:
+            data["last_success"] = self._last_success
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _build_email(self, message: AlertMessage) -> EmailMessage:
+        email = EmailMessage()
+        email["From"] = self.from_address
+        email["To"] = ", ".join(self.recipients)
+        email["Subject"] = f"[{message.severity.upper()}] {message.title}"
+        body_lines = [
+            message.body,
+            "",
+            "Kontekst:",
+            *[f"- {key}: {value}" for key, value in sorted(message.context.items())],
+            "",
+            f"Kategoria: {message.category}",
+            f"Znacznik czasu: {message.timestamp.isoformat()}",
+        ]
+        email.set_content("\n".join(body_lines))
+        return email
+
+
+__all__ = ["EmailChannel"]
+

--- a/bot_core/alerts/channels/providers.py
+++ b/bot_core/alerts/channels/providers.py
@@ -1,0 +1,75 @@
+"""Predefiniowane konfiguracje lokalnych dostawców SMS."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True, slots=True)
+class SmsProviderConfig:
+    """Opisuje parametry integracji z dostawcą SMS."""
+
+    provider_id: str
+    display_name: str
+    api_base_url: str
+    iso_country_code: str
+    supports_alphanumeric_sender: bool
+    notes: str | None = None
+    max_sender_length: int = 11
+
+
+#: Zestaw standardowych konfiguracji dla operatorów wymaganych w pierwszym etapie.
+DEFAULT_SMS_PROVIDERS: Dict[str, SmsProviderConfig] = {
+    "orange_pl": SmsProviderConfig(
+        provider_id="orange_pl",
+        display_name="Orange Polska",
+        api_base_url="https://api.orange.pl/sms/v1",
+        iso_country_code="PL",
+        supports_alphanumeric_sender=True,
+        notes="Wymaga whitelisting IP i zgłoszenia alfanumerycznego nadawcy do Orange.",
+    ),
+    "tmobile_pl": SmsProviderConfig(
+        provider_id="tmobile_pl",
+        display_name="T-Mobile Polska",
+        api_base_url="https://api.t-mobile.pl/sms/v1",
+        iso_country_code="PL",
+        supports_alphanumeric_sender=True,
+        notes="Obsługa w trybie REST, dostęp po podpisaniu umowy A2P.",
+    ),
+    "plus_pl": SmsProviderConfig(
+        provider_id="plus_pl",
+        display_name="Plus Polska",
+        api_base_url="https://api.plus.pl/messaging/v1",
+        iso_country_code="PL",
+        supports_alphanumeric_sender=False,
+        notes="Domyślnie preferuje numeryczny nadpis nadawcy, alfanumeryczny wymaga dodatkowej zgody.",
+    ),
+    "play_pl": SmsProviderConfig(
+        provider_id="play_pl",
+        display_name="Play Polska",
+        api_base_url="https://api.play.pl/sms/v1",
+        iso_country_code="PL",
+        supports_alphanumeric_sender=True,
+        notes="Wymaga wcześniejszego zgłoszenia puli IP oraz rejestracji brandu.",
+    ),
+    "nova_is": SmsProviderConfig(
+        provider_id="nova_is",
+        display_name="Nova Islandia",
+        api_base_url="https://api.nova.is/sms/v1",
+        iso_country_code="IS",
+        supports_alphanumeric_sender=True,
+        notes="Islandzki operator z obsługą webhooków statusowych i fallbackiem numerowym.",
+    ),
+}
+
+
+def get_sms_provider(provider_key: str) -> SmsProviderConfig:
+    """Zwraca konfigurację dostawcy na podstawie klucza."""
+
+    try:
+        return DEFAULT_SMS_PROVIDERS[provider_key]
+    except KeyError as exc:  # pragma: no cover - błąd sygnalizujemy w miejscu użycia
+        raise KeyError(f"Nieznany dostawca SMS: {provider_key}") from exc
+
+
+__all__ = ["SmsProviderConfig", "DEFAULT_SMS_PROVIDERS", "get_sms_provider"]

--- a/bot_core/alerts/channels/sms.py
+++ b/bot_core/alerts/channels/sms.py
@@ -1,0 +1,121 @@
+"""Adapter SMS obsługujący dostawców z API HTTP (np. Twilio i operatorów lokalnych)."""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Protocol, Sequence
+from urllib import parse, request
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+from bot_core.alerts.channels.providers import SmsProviderConfig
+
+
+class _SmsHttpOpener(Protocol):
+    def __call__(self, req: request.Request, *, timeout: float) -> request.addinfourl:
+        ...
+
+
+def _default_sms_opener(req: request.Request, *, timeout: float) -> request.addinfourl:
+    return request.urlopen(req, timeout=timeout)  # noqa: S310 - kontrolujemy docelowe API
+
+
+@dataclass(slots=True)
+class SMSChannel(AlertChannel):
+    """Wysyła wiadomości SMS poprzez API kompatybilne z modelem Twilio."""
+
+    account_sid: str
+    auth_token: str
+    from_number: str
+    recipients: Sequence[str]
+    provider: SmsProviderConfig | None = None
+    provider_base_url: str = "https://api.twilio.com"
+    name: str = "sms"
+    timeout: float = 10.0
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.sms"))
+    _opener: _SmsHttpOpener = field(default=_default_sms_opener, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+    _last_success: datetime | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.provider is not None:
+            # Normalizujemy bazowy adres do postaci bez końcowego slasha.
+            base = self.provider.api_base_url.rstrip("/")
+            self.provider_base_url = base
+            self.logger.debug(
+                "SMSChannel skonfigurowany dla dostawcy", extra={"provider": self.provider.provider_id}
+            )
+
+    def send(self, message: AlertMessage) -> None:
+        for recipient in self.recipients:
+            self._send_single(recipient, message)
+        self._last_success = datetime.now(tz=timezone.utc)
+        self._last_error = None
+
+    def _send_single(self, recipient: str, message: AlertMessage) -> None:
+        url = f"{self.provider_base_url}/2010-04-01/Accounts/{self.account_sid}/Messages.json"
+        payload = parse.urlencode({
+            "To": recipient,
+            "From": self.from_number,
+            "Body": self._build_body(message),
+        }).encode("utf-8")
+        req = request.Request(url, data=payload, method="POST")
+        auth_header = base64.b64encode(f"{self.account_sid}:{self.auth_token}".encode("utf-8")).decode("ascii")
+        req.add_header("Authorization", f"Basic {auth_header}")
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+        try:
+            with self._opener(req, timeout=self.timeout) as response:
+                status = getattr(response, "status", response.getcode())
+                raw_body = response.read()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki SMS", extra={"recipient": recipient})
+            raise AlertDeliveryError(f"Błąd wysyłki SMS do {recipient}: {exc}") from exc
+
+        if status >= 400:
+            detail = raw_body.decode("utf-8", errors="ignore") if raw_body else ""
+            self._last_error = detail or str(status)
+            self.logger.error(
+                "Dostawca SMS zwrócił kod %s: %s",
+                status,
+                detail,
+                extra={"recipient": recipient, "provider": self.provider.provider_id if self.provider else None},
+            )
+            raise AlertDeliveryError(f"Dostawca SMS zwrócił kod {status}: {detail}")
+
+        if raw_body:
+            try:
+                decoded: Dict[str, object] = json.loads(raw_body)
+            except json.JSONDecodeError:  # pragma: no cover - brak body JSON nie jest błędem krytycznym
+                decoded = {"status": "unknown"}
+            error_msg = decoded.get("message") if isinstance(decoded, dict) else None
+            if error_msg:
+                self._last_error = str(error_msg)
+                self.logger.error(
+                    "Dostawca SMS zgłosił błąd: %s",
+                    error_msg,
+                    extra={"recipient": recipient, "provider": self.provider.provider_id if self.provider else None},
+                )
+                raise AlertDeliveryError(f"Dostawca SMS zgłosił błąd: {error_msg}")
+
+    def health_check(self) -> Dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: Dict[str, str] = {"status": status}
+        if self.provider is not None:
+            data["provider"] = self.provider.provider_id
+            data["country"] = self.provider.iso_country_code
+        if self._last_success:
+            data["last_success"] = self._last_success.isoformat()
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _build_body(self, message: AlertMessage) -> str:
+        context = "; ".join(f"{key}={value}" for key, value in sorted(message.context.items()))
+        return f"{message.title}: {message.body} [{context}]"
+
+
+__all__ = ["SMSChannel"]

--- a/bot_core/alerts/channels/telegram.py
+++ b/bot_core/alerts/channels/telegram.py
@@ -1,0 +1,99 @@
+"""Adapter kanału powiadomień dla Telegrama."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Protocol
+from urllib import request
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+
+
+class _HttpOpener(Protocol):
+    def __call__(self, req: request.Request, *, timeout: float) -> request.addinfourl:
+        ...
+
+
+def _default_opener(req: request.Request, *, timeout: float) -> request.addinfourl:
+    return request.urlopen(req, timeout=timeout)  # noqa: S310 - docelowo wywołujemy zaufane API
+
+
+@dataclass(slots=True)
+class TelegramChannel(AlertChannel):
+    """Publikuje alerty wykorzystując oficjalne API Telegram Bot."""
+
+    bot_token: str
+    chat_id: str
+    parse_mode: str = "MarkdownV2"
+    name: str = "telegram"
+    timeout: float = 10.0
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.telegram"))
+    _opener: _HttpOpener = field(default=_default_opener, repr=False)
+    _last_success: datetime | None = field(default=None, init=False, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+
+    def send(self, message: AlertMessage) -> None:
+        payload = {
+            "chat_id": self.chat_id,
+            "text": self._format_message(message),
+            "disable_web_page_preview": True,
+        }
+        if self.parse_mode:
+            payload["parse_mode"] = self.parse_mode
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
+        req = request.Request(url, data=json.dumps(payload).encode("utf-8"), headers={"Content-Type": "application/json"})
+
+        try:
+            with self._opener(req, timeout=self.timeout) as response:
+                status = getattr(response, "status", response.getcode())
+                data = response.read()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki do Telegrama")
+            raise AlertDeliveryError(f"Błąd wysyłki do Telegrama: {exc}") from exc
+
+        if status >= 400:
+            body = data.decode("utf-8", errors="ignore") if data else ""
+            self._last_error = body or str(status)
+            self.logger.error("Telegram zwrócił błąd HTTP %s: %s", status, body)
+            raise AlertDeliveryError(f"Telegram zwrócił błąd HTTP {status}: {body}")
+
+        try:
+            parsed: Dict[str, object] = json.loads(data) if data else {"ok": True}
+        except json.JSONDecodeError as exc:  # pragma: no cover - powinno się udać dla poprawnych odpowiedzi
+            self._last_error = str(exc)
+            raise AlertDeliveryError("Niepoprawna odpowiedź Telegrama") from exc
+
+        if not bool(parsed.get("ok", True)):
+            description = str(parsed.get("description", "Nieznany błąd"))
+            self._last_error = description
+            self.logger.error("Telegram odrzucił wiadomość: %s", description)
+            raise AlertDeliveryError(f"Telegram odrzucił wiadomość: {description}")
+
+        self._last_success = datetime.now(tz=timezone.utc)
+        self._last_error = None
+
+    def health_check(self) -> Dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: Dict[str, str] = {"status": status}
+        if self._last_success:
+            data["last_success"] = self._last_success.isoformat()
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _format_message(self, message: AlertMessage) -> str:
+        header = f"*{message.title}*" if self.parse_mode == "MarkdownV2" else message.title
+        context_lines = "\n".join(f"• {key}: {value}" for key, value in sorted(message.context.items()))
+        parts = [header, message.body]
+        if context_lines:
+            parts.append(context_lines)
+        parts.append(f"Kategoria: {message.category} | Poziom: {message.severity}")
+        return "\n\n".join(part for part in parts if part)
+
+
+__all__ = ["TelegramChannel"]
+

--- a/bot_core/alerts/router.py
+++ b/bot_core/alerts/router.py
@@ -1,0 +1,64 @@
+"""Domyślna implementacja routera alertów."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, MutableSequence
+
+from bot_core.alerts.base import AlertChannel, AlertMessage, AlertRouter, AlertAuditLog, AlertDeliveryError
+
+
+@dataclass(slots=True)
+class DefaultAlertRouter(AlertRouter):
+    """Zarządza kanałami powiadomień i rejestruje zdarzenia w audycie."""
+
+    audit_log: AlertAuditLog
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts"))
+    stop_on_error: bool = False
+    channels: MutableSequence[AlertChannel] = field(default_factory=list)
+
+    def register(self, channel: AlertChannel) -> None:
+        if any(existing.name == channel.name for existing in self.channels):
+            raise ValueError(f"Kanał o nazwie '{channel.name}' został już zarejestrowany")
+        self.channels.append(channel)
+
+    def dispatch(self, message: AlertMessage) -> None:
+        failures: Dict[str, str] = {}
+        for channel in list(self.channels):
+            try:
+                channel.send(message)
+            except AlertDeliveryError as exc:  # pragma: no cover - defensive guard
+                self.logger.error("Nie udało się wysłać alertu", extra={"channel": channel.name, "error": str(exc)})
+                failures[channel.name] = str(exc)
+                if self.stop_on_error:
+                    raise
+            except Exception as exc:  # noqa: BLE001
+                error_msg = f"Nieznany błąd kanału {channel.name}: {exc}"
+                self.logger.exception(error_msg)
+                failures[channel.name] = str(exc)
+                if self.stop_on_error:
+                    raise AlertDeliveryError(error_msg) from exc
+            else:
+                self.audit_log.append(message, channel=channel.name)
+
+        if failures and not self.stop_on_error:
+            summary = ", ".join(f"{name}: {reason}" for name, reason in failures.items())
+            self.logger.warning("Część kanałów zgłosiła błędy: %s", summary)
+
+    def health_snapshot(self) -> Dict[str, Dict[str, str]]:
+        snapshot: Dict[str, Dict[str, str]] = {}
+        now = datetime.now(timezone.utc).isoformat()
+        for channel in self.channels:
+            data = {"checked_at": now}
+            try:
+                data.update(channel.health_check())
+            except Exception as exc:  # noqa: BLE001
+                self.logger.exception("Błąd podczas health-check kanału %s", channel.name)
+                data.update({"status": "error", "detail": str(exc)})
+            snapshot[channel.name] = data
+        return snapshot
+
+
+__all__ = ["DefaultAlertRouter"]
+

--- a/bot_core/config/__init__.py
+++ b/bot_core/config/__init__.py
@@ -1,0 +1,17 @@
+"""Warstwa konfiguracji aplikacji."""
+
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import (
+    CoreConfig,
+    EnvironmentConfig,
+    RiskProfileConfig,
+    SMSProviderSettings,
+)
+
+__all__ = [
+    "CoreConfig",
+    "EnvironmentConfig",
+    "RiskProfileConfig",
+    "SMSProviderSettings",
+    "load_core_config",
+]

--- a/bot_core/config/loader.py
+++ b/bot_core/config/loader.py
@@ -1,0 +1,106 @@
+"""Ładowanie konfiguracji z plików YAML."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from bot_core.config.models import (
+    CoreConfig,
+    EmailChannelSettings,
+    EnvironmentConfig,
+    RiskProfileConfig,
+    SMSProviderSettings,
+    TelegramChannelSettings,
+)
+from bot_core.exchanges.base import Environment
+
+
+def _load_sms_providers(raw_alerts: Mapping[str, Any]) -> Mapping[str, SMSProviderSettings]:
+    providers: dict[str, SMSProviderSettings] = {}
+    for name, entry in raw_alerts.get("sms_providers", {}).items():
+        providers[name] = SMSProviderSettings(
+            name=name,
+            provider_key=str(entry["provider"]),
+            api_base_url=str(entry["api_base_url"]),
+            from_number=str(entry["from_number"]),
+            recipients=tuple(entry.get("recipients", ())),
+            allow_alphanumeric_sender=bool(entry.get("allow_alphanumeric_sender", False)),
+            sender_id=entry.get("sender_id"),
+            credential_key=entry.get("credential_key"),
+        )
+    return providers
+
+
+def load_core_config(path: str | Path) -> CoreConfig:
+    """Wczytuje plik YAML i mapuje go na dataclasses."""
+
+    with Path(path).open("r", encoding="utf-8") as handle:
+        raw: dict[str, Any] = yaml.safe_load(handle) or {}
+
+    environments = {
+        name: EnvironmentConfig(
+            name=name,
+            exchange=entry["exchange"],
+            environment=Environment(entry["environment"]),
+            keychain_key=entry["keychain_key"],
+            data_cache_path=entry["data_cache_path"],
+            risk_profile=entry["risk_profile"],
+            alert_channels=tuple(entry.get("alert_channels", ())),
+            ip_allowlist=tuple(entry.get("ip_allowlist", ())),
+            credential_purpose=str(entry.get("credential_purpose", "trading")),
+        )
+        for name, entry in raw.get("environments", {}).items()
+    }
+
+    risk_profiles = {
+        name: RiskProfileConfig(
+            name=name,
+            max_daily_loss_pct=float(entry["max_daily_loss_pct"]),
+            max_position_pct=float(entry["max_position_pct"]),
+            target_volatility=float(entry["target_volatility"]),
+            max_leverage=float(entry["max_leverage"]),
+            stop_loss_atr_multiple=float(entry["stop_loss_atr_multiple"]),
+            max_open_positions=int(entry["max_open_positions"]),
+            hard_drawdown_pct=float(entry["hard_drawdown_pct"]),
+        )
+        for name, entry in raw.get("risk_profiles", {}).items()
+    }
+
+    reporting = raw.get("reporting", {})
+    alerts = raw.get("alerts", {})
+    sms_providers = _load_sms_providers(alerts)
+    telegram_channels = {
+        name: TelegramChannelSettings(
+            name=name,
+            chat_id=str(entry["chat_id"]),
+            token_secret=str(entry["token_secret"]),
+            parse_mode=str(entry.get("parse_mode", "MarkdownV2")),
+        )
+        for name, entry in alerts.get("telegram_channels", {}).items()
+    }
+    email_channels = {
+        name: EmailChannelSettings(
+            name=name,
+            host=str(entry["host"]),
+            port=int(entry.get("port", 587)),
+            from_address=str(entry["from_address"]),
+            recipients=tuple(entry.get("recipients", ())),
+            credential_secret=entry.get("credential_secret"),
+            use_tls=bool(entry.get("use_tls", True)),
+        )
+        for name, entry in alerts.get("email_channels", {}).items()
+    }
+
+    return CoreConfig(
+        environments=environments,
+        risk_profiles=risk_profiles,
+        reporting=reporting,
+        sms_providers=sms_providers,
+        telegram_channels=telegram_channels,
+        email_channels=email_channels,
+    )
+
+
+__all__ = ["load_core_config"]

--- a/bot_core/config/models.py
+++ b/bot_core/config/models.py
@@ -1,0 +1,95 @@
+"""Modele konfiguracji dla nowej architektury."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+from bot_core.exchanges.base import Environment
+
+
+@dataclass(slots=True)
+class EnvironmentConfig:
+    """Konfiguracja środowiska (np. live, paper, testnet)."""
+
+    name: str
+    exchange: str
+    environment: Environment
+    keychain_key: str
+    data_cache_path: str
+    risk_profile: str
+    alert_channels: Sequence[str]
+    ip_allowlist: Sequence[str] = field(default_factory=tuple)
+    credential_purpose: str = "trading"
+
+
+@dataclass(slots=True)
+class RiskProfileConfig:
+    """Parametry wykorzystywane do inicjalizacji profili ryzyka."""
+
+    name: str
+    max_daily_loss_pct: float
+    max_position_pct: float
+    target_volatility: float
+    max_leverage: float
+    stop_loss_atr_multiple: float
+    max_open_positions: int
+    hard_drawdown_pct: float
+
+
+@dataclass(slots=True)
+class SMSProviderSettings:
+    """Definicja lokalnego dostawcy SMS z konfiguracji."""
+
+    name: str
+    provider_key: str
+    api_base_url: str
+    from_number: str
+    recipients: Sequence[str]
+    allow_alphanumeric_sender: bool = False
+    sender_id: str | None = None
+    credential_key: str | None = None
+
+
+@dataclass(slots=True)
+class TelegramChannelSettings:
+    """Konfiguracja kanału Telegram."""
+
+    name: str
+    chat_id: str
+    token_secret: str
+    parse_mode: str = "MarkdownV2"
+
+
+@dataclass(slots=True)
+class EmailChannelSettings:
+    """Konfiguracja kanału e-mail."""
+
+    name: str
+    host: str
+    port: int
+    from_address: str
+    recipients: Sequence[str]
+    credential_secret: str | None = None
+    use_tls: bool = True
+
+
+@dataclass(slots=True)
+class CoreConfig:
+    """Najwyższego poziomu konfiguracja aplikacji."""
+
+    environments: Mapping[str, EnvironmentConfig]
+    risk_profiles: Mapping[str, RiskProfileConfig]
+    reporting: Mapping[str, str]
+    sms_providers: Mapping[str, SMSProviderSettings]
+    telegram_channels: Mapping[str, TelegramChannelSettings]
+    email_channels: Mapping[str, EmailChannelSettings]
+
+
+__all__ = [
+    "EnvironmentConfig",
+    "RiskProfileConfig",
+    "SMSProviderSettings",
+    "TelegramChannelSettings",
+    "EmailChannelSettings",
+    "CoreConfig",
+]

--- a/bot_core/data/__init__.py
+++ b/bot_core/data/__init__.py
@@ -1,0 +1,13 @@
+"""Warstwa danych rynkowych."""
+
+from bot_core.data.base import CacheStorage, DataSource, OHLCVRequest, OHLCVResponse
+from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+
+__all__ = [
+    "CacheStorage",
+    "CachedOHLCVSource",
+    "DataSource",
+    "OHLCVRequest",
+    "OHLCVResponse",
+    "PublicAPIDataSource",
+]

--- a/bot_core/data/base.py
+++ b/bot_core/data/base.py
@@ -1,0 +1,55 @@
+"""Warstwa abstrakcji dla źródeł danych rynkowych."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Iterable, Mapping, MutableMapping, Protocol, Sequence
+
+
+@dataclass(slots=True)
+class OHLCVRequest:
+    """Parametry pobierania danych OHLCV z publicznych API."""
+
+    symbol: str
+    interval: str
+    start: int
+    end: int
+    limit: int | None = None
+
+
+@dataclass(slots=True)
+class OHLCVResponse:
+    """Ujednolicone dane świec w UTC."""
+
+    columns: Sequence[str]
+    rows: Sequence[Sequence[float]]
+
+
+class DataSource(abc.ABC):
+    """Bazowy interfejs źródeł danych."""
+
+    @abc.abstractmethod
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        """Pobiera i normalizuje dane OHLCV."""
+
+    @abc.abstractmethod
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:
+        """Pozwala na wstępne zapełnienie cache (np. przy starcie aplikacji)."""
+
+
+class CacheStorage(Protocol):
+    """Minimalny kontrakt lokalnego magazynu danych (np. Parquet/SQLite)."""
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        ...
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        ...
+
+    def metadata(self) -> MutableMapping[str, str]:
+        ...
+
+    def latest_timestamp(self, key: str) -> float | None:
+        """Zwraca znacznik czasu ostatniej świecy zapisanej w cache."""
+
+        ...

--- a/bot_core/data/ohlcv/__init__.py
+++ b/bot_core/data/ohlcv/__init__.py
@@ -1,0 +1,13 @@
+"""Moduły związane z danymi OHLCV."""
+
+from bot_core.data.ohlcv.backfill import BackfillSummary, OHLCVBackfillService
+from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+from bot_core.data.ohlcv.sqlite_storage import SQLiteCacheStorage
+
+__all__ = [
+    "BackfillSummary",
+    "CachedOHLCVSource",
+    "OHLCVBackfillService",
+    "PublicAPIDataSource",
+    "SQLiteCacheStorage",
+]

--- a/bot_core/data/ohlcv/backfill.py
+++ b/bot_core/data/ohlcv/backfill.py
@@ -1,0 +1,179 @@
+"""Proces backfillu OHLCV łączący publiczne API i lokalny cache."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+from bot_core.data.base import CacheStorage, OHLCVRequest
+from bot_core.data.ohlcv.cache import CachedOHLCVSource
+
+_LOGGER = logging.getLogger(__name__)
+
+_INTERVAL_TO_MILLISECONDS: dict[str, int] = {
+    "1m": 60_000,
+    "3m": 3 * 60_000,
+    "5m": 5 * 60_000,
+    "15m": 15 * 60_000,
+    "30m": 30 * 60_000,
+    "1h": 60 * 60_000,
+    "2h": 2 * 60 * 60_000,
+    "4h": 4 * 60 * 60_000,
+    "6h": 6 * 60 * 60_000,
+    "8h": 8 * 60 * 60_000,
+    "12h": 12 * 60 * 60_000,
+    "1d": 24 * 60 * 60_000,
+    "3d": 3 * 24 * 60 * 60_000,
+    "1w": 7 * 24 * 60 * 60_000,
+    "1M": 30 * 24 * 60 * 60_000,
+}
+
+
+@dataclass(slots=True)
+class BackfillSummary:
+    """Raport końcowy z procesu synchronizacji OHLCV."""
+
+    symbol: str
+    interval: str
+    requested_start: int
+    requested_end: int
+    fetched_candles: int
+    skipped_candles: int
+
+
+class OHLCVBackfillService:
+    """Synchronizuje lokalny cache z publicznymi danymi giełdowymi."""
+
+    def __init__(self, source: CachedOHLCVSource, *, chunk_limit: int = 1000) -> None:
+        if chunk_limit <= 0:
+            raise ValueError("chunk_limit musi być dodatni")
+        self._source = source
+        self._storage: CacheStorage = source.storage
+        self._chunk_limit = chunk_limit
+
+    def _interval_milliseconds(self, interval: str) -> int:
+        try:
+            return _INTERVAL_TO_MILLISECONDS[interval]
+        except KeyError as exc:  # pragma: no cover - walidacja w czasie runtime
+            raise ValueError(f"Nieobsługiwany interwał: {interval}") from exc
+
+    def _latest_cached_timestamp(self, symbol: str, interval: str) -> float | None:
+        key = self._source._cache_key(symbol, interval)  # pylint: disable=protected-access
+        try:
+            return self._storage.latest_timestamp(key)
+        except AttributeError:  # pragma: no cover - zabezpieczenie pod inne storage
+            try:
+                rows = self._storage.read(key)["rows"]
+            except KeyError:
+                return None
+            if not rows:
+                return None
+            return float(rows[-1][0])
+        except KeyError:
+            return None
+
+    def _count_cached_rows(self, symbol: str, interval: str) -> int:
+        key = self._source._cache_key(symbol, interval)  # pylint: disable=protected-access
+        try:
+            rows = self._storage.read(key)["rows"]
+        except KeyError:
+            return 0
+        return len(rows)
+
+    def synchronize(
+        self,
+        *,
+        symbols: Sequence[str],
+        interval: str,
+        start: int,
+        end: int,
+    ) -> list[BackfillSummary]:
+        """Aktualizuje cache dla listy symboli i zwraca raport."""
+
+        if start > end:
+            raise ValueError("Parametr start nie może być większy niż end")
+
+        interval_ms = self._interval_milliseconds(interval)
+        summaries: list[BackfillSummary] = []
+
+        for symbol in symbols:
+            existing_rows = self._count_cached_rows(symbol, interval)
+            latest_cached = self._latest_cached_timestamp(symbol, interval)
+            effective_start = start
+            if latest_cached is not None:
+                effective_start = max(start, int(latest_cached) + interval_ms)
+
+            if effective_start > end:
+                summaries.append(
+                    BackfillSummary(
+                        symbol=symbol,
+                        interval=interval,
+                        requested_start=start,
+                        requested_end=end,
+                        fetched_candles=0,
+                        skipped_candles=existing_rows,
+                    )
+                )
+                _LOGGER.info(
+                    "Symbol %s (%s) jest aktualny do %s – pomijam backfill.",
+                    symbol,
+                    interval,
+                    latest_cached,
+                )
+                continue
+
+            next_start = effective_start
+            last_progress = -1.0
+
+            while next_start <= end:
+                window_end = min(end, next_start + interval_ms * (self._chunk_limit - 1))
+                request = OHLCVRequest(
+                    symbol=symbol,
+                    interval=interval,
+                    start=next_start,
+                    end=window_end,
+                    limit=self._chunk_limit,
+                )
+                response = self._source.fetch_ohlcv(request)
+                if not response.rows:
+                    _LOGGER.warning(
+                        "Brak danych OHLCV dla %s (%s) w przedziale %s-%s.",
+                        symbol,
+                        interval,
+                        next_start,
+                        window_end,
+                    )
+                    break
+
+                newest_timestamp = float(response.rows[-1][0])
+                if newest_timestamp <= last_progress:
+                    _LOGGER.debug(
+                        "Zatrzymuję backfill %s (%s) – brak postępu (ostatni=%s).",
+                        symbol,
+                        interval,
+                        newest_timestamp,
+                    )
+                    break
+
+                last_progress = newest_timestamp
+                next_start = int(newest_timestamp) + interval_ms
+
+                if newest_timestamp >= end:
+                    break
+
+            updated_rows = self._count_cached_rows(symbol, interval)
+            summaries.append(
+                BackfillSummary(
+                    symbol=symbol,
+                    interval=interval,
+                    requested_start=start,
+                    requested_end=end,
+                    fetched_candles=max(0, updated_rows - existing_rows),
+                    skipped_candles=existing_rows,
+                )
+            )
+
+        return summaries
+
+
+__all__ = ["OHLCVBackfillService", "BackfillSummary"]

--- a/bot_core/data/ohlcv/cache.py
+++ b/bot_core/data/ohlcv/cache.py
@@ -1,0 +1,119 @@
+"""Warstwa odpowiedzialna za backfill i lokalny cache OHLCV."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from bot_core.data.base import CacheStorage, DataSource, OHLCVRequest, OHLCVResponse
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_COLUMNS: tuple[str, ...] = (
+    "open_time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+)
+
+
+@dataclass(slots=True)
+class CachedOHLCVSource(DataSource):
+    """Łączy publiczne API z lokalnym cache, zapewniając minimalne hit-rate API."""
+
+    storage: CacheStorage
+    upstream: DataSource
+
+    def _cache_key(self, symbol: str, interval: str) -> str:
+        return f"{symbol}::{interval}"
+
+    def _merge_rows(
+        self,
+        cached_rows: Sequence[Sequence[float]],
+        upstream_rows: Sequence[Sequence[float]],
+    ) -> list[Sequence[float]]:
+        combined: dict[float, Sequence[float]] = {float(row[0]): row for row in cached_rows}
+        for row in upstream_rows:
+            if not row:
+                continue
+            combined[float(row[0])] = row
+        return [combined[key] for key in sorted(combined)]
+
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        """Pobiera dane OHLCV łącząc cache oraz świeże dane z API."""
+
+        cache_key = self._cache_key(request.symbol, request.interval)
+        try:
+            cached_payload = self.storage.read(cache_key)
+        except KeyError:
+            cached_payload = {"rows": [], "columns": _DEFAULT_COLUMNS}
+        cached_rows: Sequence[Sequence[float]] = cached_payload.get("rows", [])
+        columns = tuple(cached_payload.get("columns", ()))
+
+        upstream_response = self.upstream.fetch_ohlcv(request)
+        rows = cached_rows
+        if upstream_response.rows:
+            rows = self._merge_rows(cached_rows, upstream_response.rows)
+            # Aktualizacja cache: zapisujemy całą serię, aby kolejne zapytania były szybkie.
+            selected_columns = columns or tuple(upstream_response.columns or _DEFAULT_COLUMNS)
+            self.storage.write(
+                cache_key,
+                {
+                    "columns": list(selected_columns),
+                    "rows": rows,
+                },
+            )
+            columns = selected_columns
+        if not columns:
+            columns = _DEFAULT_COLUMNS
+
+        filtered = [
+            row
+            for row in rows
+            if request.start <= float(row[0]) <= request.end
+        ]
+        if request.limit is not None:
+            filtered = filtered[: request.limit]
+
+        return OHLCVResponse(columns=columns, rows=filtered)
+
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:
+        """Aktualizuje metadane cache, ułatwiając audyt i monitoring."""
+
+        metadata = self.storage.metadata()
+        metadata["symbols"] = ",".join(sorted(set(symbols)))
+        metadata["intervals"] = ",".join(sorted(set(intervals)))
+        _LOGGER.info("Cache OHLCV gotowe dla %s symboli i %s interwałów.", len(set(symbols)), len(set(intervals)))
+
+
+@dataclass(slots=True)
+class PublicAPIDataSource(DataSource):
+    """Adapter korzystający bezpośrednio z publicznych endpointów giełdy."""
+
+    exchange_adapter: "ExchangeAdapter"
+
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        rows = self.exchange_adapter.fetch_ohlcv(
+            request.symbol,
+            request.interval,
+            start=request.start,
+            end=request.end,
+            limit=request.limit,
+        )
+        return OHLCVResponse(columns=_DEFAULT_COLUMNS, rows=rows)
+
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:
+        # Publiczne API nie wymaga przygotowania cache – metoda pozostaje dla zgodności interfejsu.
+        _LOGGER.debug(
+            "Pomijam warm_cache dla PublicAPIDataSource (symbole=%s, interwały=%s)",
+            list(symbols),
+            list(intervals),
+        )
+
+
+# Aby uniknąć cyklicznych importów, importujemy w runtime.
+from bot_core.exchanges.base import ExchangeAdapter  # noqa: E402  pylint: disable=wrong-import-position
+
+__all__ = ["CachedOHLCVSource", "PublicAPIDataSource"]

--- a/bot_core/data/ohlcv/sqlite_storage.py
+++ b/bot_core/data/ohlcv/sqlite_storage.py
@@ -1,0 +1,151 @@
+"""Implementacja magazynu OHLCV opartego o SQLite."""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import MutableMapping
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from bot_core.data.base import CacheStorage
+
+_COLUMNS = ("open_time", "open", "high", "low", "close", "volume")
+
+
+class _SQLiteMetadata(MutableMapping[str, str]):
+    """Lekki adapter słownika mapujący na tabelę metadata."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._connection = connection
+
+    def __getitem__(self, key: str) -> str:
+        cursor = self._connection.execute("SELECT value FROM metadata WHERE key = ?", (key,))
+        row = cursor.fetchone()
+        if row is None:
+            raise KeyError(key)
+        return str(row[0])
+
+    def __setitem__(self, key: str, value: str) -> None:
+        with self._connection:
+            self._connection.execute(
+                "INSERT INTO metadata(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (key, value),
+            )
+
+    def __delitem__(self, key: str) -> None:
+        with self._connection:
+            affected = self._connection.execute("DELETE FROM metadata WHERE key = ?", (key,)).rowcount
+        if affected == 0:
+            raise KeyError(key)
+
+    def __iter__(self):
+        cursor = self._connection.execute("SELECT key FROM metadata")
+        return (row[0] for row in cursor.fetchall())
+
+    def __len__(self) -> int:
+        cursor = self._connection.execute("SELECT COUNT(1) FROM metadata")
+        value = cursor.fetchone()
+        return int(value[0] if value else 0)
+
+
+class SQLiteCacheStorage(CacheStorage):
+    """Przechowuje dane OHLCV w lokalnej bazie SQLite."""
+
+    def __init__(self, database_path: str | Path) -> None:
+        path = Path(database_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(path, detect_types=sqlite3.PARSE_DECLTYPES)
+        self._connection.execute("PRAGMA journal_mode=WAL")
+        self._connection.execute("PRAGMA synchronous=NORMAL")
+        self._initialize()
+
+    def _initialize(self) -> None:
+        with self._connection:
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ohlcv (
+                    symbol TEXT NOT NULL,
+                    interval TEXT NOT NULL,
+                    open_time INTEGER NOT NULL,
+                    open REAL NOT NULL,
+                    high REAL NOT NULL,
+                    low REAL NOT NULL,
+                    close REAL NOT NULL,
+                    volume REAL NOT NULL,
+                    PRIMARY KEY(symbol, interval, open_time)
+                )
+                """
+            )
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+                """
+            )
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        symbol, interval = key.split("::", maxsplit=1)
+        cursor = self._connection.execute(
+            """
+            SELECT open_time, open, high, low, close, volume
+            FROM ohlcv
+            WHERE symbol = ? AND interval = ?
+            ORDER BY open_time
+            """,
+            (symbol, interval),
+        )
+        rows = [[float(col) for col in row] for row in cursor.fetchall()]
+        return {"columns": _COLUMNS, "rows": rows}
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        symbol, interval = key.split("::", maxsplit=1)
+        rows = payload.get("rows", [])
+        if not rows:
+            return
+        with self._connection:
+            self._connection.executemany(
+                """
+                INSERT INTO ohlcv(symbol, interval, open_time, open, high, low, close, volume)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(symbol, interval, open_time) DO UPDATE SET
+                    open = excluded.open,
+                    high = excluded.high,
+                    low = excluded.low,
+                    close = excluded.close,
+                    volume = excluded.volume
+                """,
+                [
+                    (
+                        symbol,
+                        interval,
+                        float(row[0]),
+                        float(row[1]),
+                        float(row[2]),
+                        float(row[3]),
+                        float(row[4]),
+                        float(row[5]),
+                    )
+                    for row in rows
+                ],
+            )
+
+    def metadata(self) -> MutableMapping[str, str]:
+        return _SQLiteMetadata(self._connection)
+
+    def latest_timestamp(self, key: str) -> float | None:
+        symbol, interval = key.split("::", maxsplit=1)
+        cursor = self._connection.execute(
+            """
+            SELECT MAX(open_time) FROM ohlcv
+            WHERE symbol = ? AND interval = ?
+            """,
+            (symbol, interval),
+        )
+        row = cursor.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return float(row[0])
+
+
+__all__ = ["SQLiteCacheStorage"]

--- a/bot_core/exchanges/__init__.py
+++ b/bot_core/exchanges/__init__.py
@@ -1,0 +1,23 @@
+"""Pakiet adapterów giełdowych."""
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+
+__all__ = [
+    "AccountSnapshot",
+    "BinanceFuturesAdapter",
+    "BinanceSpotAdapter",
+    "Environment",
+    "ExchangeAdapter",
+    "ExchangeCredentials",
+    "OrderRequest",
+    "OrderResult",
+]

--- a/bot_core/exchanges/base.py
+++ b/bot_core/exchanges/base.py
@@ -1,0 +1,121 @@
+"""Abstrakcyjne interfejsy adapterów giełdowych dla nowej architektury bota."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable, Mapping, Optional, Protocol, Sequence
+
+
+class Environment(str, Enum):
+    """Wspiera rozdzielenie środowisk (live, paper, testnet)."""
+
+    LIVE = "live"
+    PAPER = "paper"
+    TESTNET = "testnet"
+
+
+@dataclass(slots=True)
+class ExchangeCredentials:
+    """Przekrojowa reprezentacja kluczy API w modelu najmniejszych uprawnień."""
+
+    key_id: str
+    secret: Optional[str] = None
+    passphrase: Optional[str] = None
+    environment: Environment = Environment.LIVE
+    permissions: Sequence[str] = ()
+
+
+@dataclass(slots=True)
+class AccountSnapshot:
+    """Podstawowy model danych konta używany przez silnik ryzyka."""
+
+    balances: Mapping[str, float]
+    total_equity: float
+    available_margin: float
+    maintenance_margin: float
+
+
+@dataclass(slots=True)
+class OrderRequest:
+    """Znormalizowany model zlecenia przekazywany do modułu egzekucji."""
+
+    symbol: str
+    side: str
+    quantity: float
+    order_type: str
+    price: Optional[float] = None
+    time_in_force: Optional[str] = None
+    client_order_id: Optional[str] = None
+
+
+@dataclass(slots=True)
+class OrderResult:
+    """Standardowa odpowiedź adaptera giełdowego."""
+
+    order_id: str
+    status: str
+    filled_quantity: float
+    avg_price: Optional[float]
+    raw_response: Mapping[str, Any]
+
+
+class ExchangeAdapter(abc.ABC):
+    """Bazowy interfejs wszystkich adapterów giełdowych."""
+
+    name: str
+
+    def __init__(self, credentials: ExchangeCredentials) -> None:
+        self._credentials = credentials
+
+    @property
+    def credentials(self) -> ExchangeCredentials:
+        """Udostępnia referencję do aktualnych poświadczeń."""
+
+        return self._credentials
+
+    @abc.abstractmethod
+    def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:
+        """Ustawia specyficzne wymagania sieciowe (np. IP allowlisting)."""
+
+    @abc.abstractmethod
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        """Pobiera bieżące informacje o kapitale, marginesie i saldach."""
+
+    @abc.abstractmethod
+    def fetch_symbols(self) -> Iterable[str]:
+        """Zwraca listę obsługiwanych instrumentów w formacie wewnętrznym."""
+
+    @abc.abstractmethod
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Sequence[float]]:
+        """Pobiera świece OHLCV w UTC na potrzeby warstwy danych."""
+
+    @abc.abstractmethod
+    def place_order(self, request: OrderRequest) -> OrderResult:
+        """Składa zlecenie w imieniu strategii."""
+
+    @abc.abstractmethod
+    def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> None:
+        """Anuluje zlecenie po identyfikatorze."""
+
+    @abc.abstractmethod
+    def stream_public_data(self, *, channels: Sequence[str]) -> Protocol:
+        """Udostępnia strumień danych publicznych (websocket/REST poll)."""
+
+    @abc.abstractmethod
+    def stream_private_data(self, *, channels: Sequence[str]) -> Protocol:
+        """Udostępnia strumień zdarzeń prywatnych (zlecenia, fills)."""
+
+
+class ExchangeAdapterFactory(Protocol):
+    """Prosty kontrakt dla fabryk adapterów (używany w konfiguracji)."""
+
+    def __call__(self, credentials: ExchangeCredentials, **kwargs: Any) -> ExchangeAdapter:
+        ...

--- a/bot_core/exchanges/binance/__init__.py
+++ b/bot_core/exchanges/binance/__init__.py
@@ -1,0 +1,6 @@
+"""Adaptery Binance."""
+
+from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+
+__all__ = ["BinanceFuturesAdapter", "BinanceSpotAdapter"]

--- a/bot_core/exchanges/binance/futures.py
+++ b/bot_core/exchanges/binance/futures.py
@@ -1,0 +1,306 @@
+"""Adapter REST dla kontraktów terminowych Binance (USD-M)."""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import time
+from hashlib import sha256
+from typing import Iterable, Mapping, Optional, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_HEADERS = {"User-Agent": "bot-core/1.0 (+https://github.com/)"}
+
+
+def _determine_public_base(environment: Environment) -> str:
+    """Zwraca bazowy adres REST dla danych publicznych kontraktów USD-M."""
+
+    if environment is Environment.TESTNET or environment is Environment.PAPER:
+        return "https://testnet.binancefuture.com"
+    return "https://fapi.binance.com"
+
+
+def _determine_trading_base(environment: Environment) -> str:
+    """Zwraca bazowy adres REST dla wywołań podpisanych kontraktów USD-M."""
+
+    if environment is Environment.TESTNET or environment is Environment.PAPER:
+        return "https://testnet.binancefuture.com"
+    return "https://fapi.binance.com"
+
+
+def _stringify_params(params: Mapping[str, object]) -> list[tuple[str, str]]:
+    normalized: list[tuple[str, str]] = []
+    for key, value in params.items():
+        if isinstance(value, bool):
+            normalized.append((key, "true" if value else "false"))
+        elif value is None:
+            continue
+        else:
+            normalized.append((key, str(value)))
+    return normalized
+
+
+def _to_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+class BinanceFuturesAdapter(ExchangeAdapter):
+    """Adapter REST dla rynku terminowego Binance (USD-M)."""
+
+    name: str = "binance_futures"
+
+    def __init__(
+        self,
+        credentials: ExchangeCredentials,
+        *,
+        environment: Environment | None = None,
+    ) -> None:
+        super().__init__(credentials)
+        self._environment = environment or credentials.environment
+        self._public_base = _determine_public_base(self._environment)
+        self._trading_base = _determine_trading_base(self._environment)
+        self._permission_set = frozenset(perm.lower() for perm in self._credentials.permissions)
+        self._ip_allowlist: tuple[str, ...] = ()
+
+    def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:
+        if ip_allowlist is None:
+            self._ip_allowlist = ()
+        else:
+            self._ip_allowlist = tuple(ip_allowlist)
+        _LOGGER.info("Ustawiono allowlistę IP dla Binance Futures: %s", self._ip_allowlist)
+
+    def _public_request(
+        self,
+        path: str,
+        params: Optional[Mapping[str, object]] = None,
+        *,
+        method: str = "GET",
+    ) -> dict[str, object] | list[object]:
+        query = f"?{urlencode(_stringify_params(params or {}))}" if params else ""
+        url = f"{self._public_base}{path}{query}"
+        data = None
+        headers = dict(_DEFAULT_HEADERS)
+        if method in {"POST", "PUT"} and params:
+            data = urlencode(_stringify_params(params)).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request = Request(url, headers=headers, data=data, method=method)
+        return self._execute_request(request)
+
+    def _signed_request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        params: Optional[Mapping[str, object]] = None,
+    ) -> dict[str, object] | list[object]:
+        if not self._credentials.secret:
+            raise RuntimeError("Do podpisanych endpointów wymagany jest secret klucza API Binance.")
+
+        timestamp_ms = int(time.time() * 1000)
+        base_params = dict(params or {})
+        base_params.setdefault("timestamp", timestamp_ms)
+        payload_items = _stringify_params(base_params)
+        query_string = urlencode(payload_items)
+        signature = hmac.new(
+            self._credentials.secret.encode("utf-8"),
+            query_string.encode("utf-8"),
+            sha256,
+        ).hexdigest()
+        signed_query = f"{query_string}&signature={signature}"
+
+        url = f"{self._trading_base}{path}"
+        headers = dict(_DEFAULT_HEADERS)
+        headers["X-MBX-APIKEY"] = self._credentials.key_id
+
+        if method in {"POST", "PUT"}:
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+            data = signed_query.encode("utf-8")
+            request = Request(url, headers=headers, data=data, method=method)
+        else:
+            separator = "?" if "?" not in url else "&"
+            request = Request(f"{url}{separator}{signed_query}", headers=headers, method=method)
+        return self._execute_request(request)
+
+    @staticmethod
+    def _execute_request(request: Request) -> dict[str, object] | list[object]:
+        try:
+            with urlopen(request, timeout=15) as response:  # nosec: B310 - zaufany endpoint
+                payload = response.read()
+        except HTTPError as exc:  # pragma: no cover - zależne od API
+            _LOGGER.error("Błąd HTTP podczas komunikacji z Binance Futures: %s", exc)
+            raise RuntimeError(f"Binance Futures API zwróciło błąd HTTP: {exc}") from exc
+        except URLError as exc:  # pragma: no cover - zależne od sieci
+            _LOGGER.error("Błąd sieci podczas komunikacji z Binance Futures: %s", exc)
+            raise RuntimeError("Nie udało się połączyć z API Binance Futures") from exc
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:  # pragma: no cover - błąd po stronie API
+            _LOGGER.error("Niepoprawna odpowiedź JSON z Binance Futures: %s", exc)
+            raise RuntimeError("Niepoprawna odpowiedź JSON od API Binance Futures") from exc
+        return data
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        if not ({"read", "trade"} & self._permission_set):
+            raise PermissionError("Poświadczenia nie pozwalają na odczyt danych konta Binance Futures.")
+
+        payload = self._signed_request("/fapi/v2/account")
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("Niepoprawna odpowiedź konta z Binance Futures")
+
+        assets = payload.get("assets", [])
+        balances: dict[str, float] = {}
+        available_margin = _to_float(payload.get("totalAvailableBalance"), 0.0)
+        maintenance_margin = _to_float(payload.get("totalMaintMargin"), 0.0)
+
+        if isinstance(assets, list):
+            for entry in assets:
+                if not isinstance(entry, Mapping):
+                    continue
+                asset = entry.get("asset")
+                wallet_balance = _to_float(entry.get("walletBalance"), 0.0)
+                if isinstance(asset, str):
+                    balances[asset] = wallet_balance
+
+        total_equity = _to_float(payload.get("totalMarginBalance"), 0.0)
+        if total_equity == 0.0:
+            wallet = _to_float(payload.get("totalWalletBalance"), 0.0)
+            unrealized = _to_float(payload.get("totalUnrealizedProfit"), 0.0)
+            total_equity = wallet + unrealized
+
+        return AccountSnapshot(
+            balances=balances,
+            total_equity=total_equity,
+            available_margin=available_margin,
+            maintenance_margin=maintenance_margin,
+        )
+
+    def fetch_symbols(self) -> Iterable[str]:
+        payload = self._public_request("/fapi/v1/exchangeInfo")
+        if not isinstance(payload, Mapping) or "symbols" not in payload:
+            raise RuntimeError("Niepoprawna odpowiedź exchangeInfo z Binance Futures")
+
+        symbols_raw = payload.get("symbols")
+        if not isinstance(symbols_raw, list):
+            raise RuntimeError("Pole 'symbols' w odpowiedzi Binance Futures ma niepoprawny format")
+
+        active: list[str] = []
+        for entry in symbols_raw:
+            if not isinstance(entry, Mapping):
+                continue
+            status = entry.get("status")
+            symbol = entry.get("symbol")
+            if status != "TRADING" or not isinstance(symbol, str):
+                continue
+            active.append(symbol)
+        return active
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Sequence[float]]:
+        params: dict[str, object] = {"symbol": symbol, "interval": interval}
+        if start is not None:
+            params["startTime"] = int(start)
+        if end is not None:
+            params["endTime"] = int(end)
+        if limit is not None:
+            params["limit"] = int(limit)
+
+        payload = self._public_request("/fapi/v1/klines", params=params)
+        if not isinstance(payload, list):
+            raise RuntimeError("Odpowiedź klines z Binance Futures ma nieoczekiwany format")
+
+        candles: list[Sequence[float]] = []
+        for entry in payload:
+            if not isinstance(entry, list) or len(entry) < 6:
+                continue
+            open_time = float(entry[0])
+            open_price = float(entry[1])
+            high = float(entry[2])
+            low = float(entry[3])
+            close = float(entry[4])
+            volume = float(entry[5])
+            candles.append([open_time, open_price, high, low, close, volume])
+        return candles
+
+    def place_order(self, request: OrderRequest) -> OrderResult:
+        if "trade" not in self._permission_set:
+            raise PermissionError("Aktualne poświadczenia nie mają uprawnień tradingowych.")
+
+        params: dict[str, object] = {
+            "symbol": request.symbol,
+            "side": request.side.upper(),
+            "type": request.order_type.upper(),
+            "quantity": request.quantity,
+        }
+        if request.price is not None:
+            params["price"] = request.price
+        if request.time_in_force is not None:
+            params["timeInForce"] = request.time_in_force
+        if request.client_order_id is not None:
+            params["newClientOrderId"] = request.client_order_id
+
+        payload = self._signed_request("/fapi/v1/order", method="POST", params=params)
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("Odpowiedź z endpointu futures order ma niepoprawny format")
+
+        payload_dict = dict(payload)
+        order_id = str(payload_dict.get("orderId"))
+        status = str(payload_dict.get("status", "UNKNOWN"))
+        filled_qty = _to_float(payload_dict.get("executedQty", 0.0))
+        avg_price_field = payload_dict.get("avgPrice", payload_dict.get("price"))
+        avg_price = _to_float(avg_price_field) if avg_price_field not in (None, "0", 0, 0.0) else None
+
+        return OrderResult(
+            order_id=order_id,
+            status=status,
+            filled_quantity=filled_qty,
+            avg_price=avg_price,
+            raw_response=payload_dict,
+        )
+
+    def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> None:
+        if "trade" not in self._permission_set:
+            raise PermissionError("Aktualne poświadczenia nie mają uprawnień tradingowych.")
+        if not symbol:
+            raise ValueError("Anulowanie na Binance Futures wymaga podania symbolu.")
+
+        params: dict[str, object] = {"orderId": order_id, "symbol": symbol}
+        response = self._signed_request("/fapi/v1/order", method="DELETE", params=params)
+        if isinstance(response, Mapping):
+            response_map = dict(response)
+            status = response_map.get("status")
+            if status in {"CANCELED", "PENDING_CANCEL", "NEW"}:
+                return
+            raise RuntimeError(f"Nieoczekiwana odpowiedź anulowania z Binance Futures: {response_map}")
+        raise RuntimeError("Niepoprawna odpowiedź anulowania z Binance Futures")
+
+    def stream_public_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Stream publiczny futures zostanie dodany w kolejnej iteracji.")
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Stream prywatny futures zostanie dodany w kolejnej iteracji.")
+
+
+__all__ = ["BinanceFuturesAdapter"]

--- a/bot_core/exchanges/binance/spot.py
+++ b/bot_core/exchanges/binance/spot.py
@@ -1,0 +1,326 @@
+"""Adapter REST dla rynku spot Binance do obsługi danych publicznych i prywatnych."""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import time
+from hashlib import sha256
+from typing import Iterable, Mapping, Optional, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_HEADERS = {"User-Agent": "bot-core/1.0 (+https://github.com/)"}
+
+
+def _to_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _determine_public_base(environment: Environment) -> str:
+    """Zwraca właściwy punkt końcowy REST dla danych publicznych."""
+
+    # Binance nie udostępnia pełnych danych historycznych na testnecie,
+    # dlatego zarówno środowisko PAPER, jak i TESTNET wykorzystują publiczny endpoint produkcyjny.
+    return "https://api.binance.com"
+
+
+def _determine_trading_base(environment: Environment) -> str:
+    """Zwraca punkt końcowy dla operacji wymagających podpisu."""
+
+    if environment is Environment.TESTNET or environment is Environment.PAPER:
+        # Oficjalny testnet Binance udostępnia podpisane endpointy pod domeną testnet.binance.vision.
+        return "https://testnet.binance.vision"
+    return "https://api.binance.com"
+
+
+def _stringify_params(params: Mapping[str, object]) -> list[tuple[str, str]]:
+    """Konwertuje wartości parametrów na tekst wymagany przez API Binance."""
+
+    normalized: list[tuple[str, str]] = []
+    for key, value in params.items():
+        if isinstance(value, bool):
+            normalized.append((key, "true" if value else "false"))
+        elif value is None:
+            continue
+        else:
+            normalized.append((key, str(value)))
+    return normalized
+
+
+class BinanceSpotAdapter(ExchangeAdapter):
+    """Adapter dla rynku spot Binance z obsługą danych publicznych i podpisanych."""
+
+    __slots__ = (
+        "_environment",
+        "_public_base",
+        "_trading_base",
+        "_ip_allowlist",
+        "_permission_set",
+    )
+
+    name: str = "binance_spot"
+
+    def __init__(self, credentials: ExchangeCredentials, *, environment: Environment | None = None) -> None:
+        super().__init__(credentials)
+        self._environment = environment or credentials.environment
+        self._public_base = _determine_public_base(self._environment)
+        self._trading_base = _determine_trading_base(self._environment)
+        self._ip_allowlist: tuple[str, ...] = ()
+        self._permission_set = frozenset(perm.lower() for perm in self._credentials.permissions)
+
+    def _public_request(
+        self,
+        path: str,
+        params: Optional[Mapping[str, object]] = None,
+        *,
+        method: str = "GET",
+    ) -> dict[str, object] | list[object]:
+        query = f"?{urlencode(_stringify_params(params or {}))}" if params else ""
+        url = f"{self._public_base}{path}{query}"
+        data = None
+        headers = dict(_DEFAULT_HEADERS)
+        if method in {"POST", "PUT"} and params:
+            data = urlencode(_stringify_params(params)).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request = Request(url, headers=headers, data=data, method=method)
+        return self._execute_request(request)
+
+    def _signed_request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        params: Optional[Mapping[str, object]] = None,
+    ) -> dict[str, object] | list[object]:
+        if not self._credentials.secret:
+            raise RuntimeError("Do podpisanych endpointów wymagany jest secret klucza API Binance.")
+
+        timestamp_ms = int(time.time() * 1000)
+        base_params = dict(params or {})
+        base_params.setdefault("timestamp", timestamp_ms)
+        payload_items = _stringify_params(base_params)
+        query_string = urlencode(payload_items)
+        signature = hmac.new(
+            self._credentials.secret.encode("utf-8"),
+            query_string.encode("utf-8"),
+            sha256,
+        ).hexdigest()
+        signed_query = f"{query_string}&signature={signature}"
+
+        url = f"{self._trading_base}{path}"
+        headers = dict(_DEFAULT_HEADERS)
+        headers["X-MBX-APIKEY"] = self._credentials.key_id
+
+        data: Optional[bytes]
+        if method in {"POST", "PUT"}:
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+            data = signed_query.encode("utf-8")
+            request = Request(url, headers=headers, data=data, method=method)
+        else:
+            separator = "?" if "?" not in url else "&"
+            request = Request(f"{url}{separator}{signed_query}", headers=headers, method=method)
+            data = None
+
+        return self._execute_request(request)
+
+    @staticmethod
+    def _execute_request(request: Request) -> dict[str, object] | list[object]:
+        try:
+            with urlopen(request, timeout=15) as response:  # nosec: B310 - endpoint zaufany
+                payload = response.read()
+        except HTTPError as exc:  # pragma: no cover - zależne od API i środowiska sieciowego
+            _LOGGER.error("Błąd HTTP podczas komunikacji z Binance: %s", exc)
+            raise RuntimeError(f"Binance API zwróciło błąd HTTP: {exc}") from exc
+        except URLError as exc:  # pragma: no cover - zależne od sieci
+            _LOGGER.error("Błąd sieci podczas komunikacji z Binance: %s", exc)
+            raise RuntimeError("Nie udało się połączyć z API Binance") from exc
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:  # pragma: no cover - niepoprawne JSON to błąd API
+            _LOGGER.error("Niepoprawna odpowiedź JSON od Binance: %s", exc)
+            raise RuntimeError("Niepoprawna odpowiedź JSON od API Binance") from exc
+        return data
+
+    def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:
+        """Zachowuje konfigurację allowlisty, aby risk engine mógł ją audytować."""
+
+        if ip_allowlist is None:
+            self._ip_allowlist = ()
+        else:
+            self._ip_allowlist = tuple(ip_allowlist)
+        _LOGGER.info("Ustawiono allowlistę IP dla Binance: %s", self._ip_allowlist)
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        """Pobiera podstawowe dane o stanie rachunku do oceny limitów ryzyka."""
+
+        if not ({"read", "trade"} & self._permission_set):
+            raise PermissionError("Poświadczenia nie pozwalają na odczyt danych konta Binance.")
+
+        payload = self._signed_request("/api/v3/account")
+        if not isinstance(payload, dict):
+            raise RuntimeError("Niepoprawna odpowiedź konta z Binance")
+
+        balances_section = payload.get("balances", [])
+        balances: dict[str, float] = {}
+        available_margin = 0.0
+        if isinstance(balances_section, list):
+            for entry in balances_section:
+                if not isinstance(entry, Mapping):
+                    continue
+                asset = entry.get("asset")
+                free = _to_float(entry.get("free", 0.0))
+                locked = _to_float(entry.get("locked", 0.0))
+                if not isinstance(asset, str):
+                    continue
+                balances[asset] = free + locked
+                available_margin += free
+
+        total_equity = sum(balances.values())
+        maintenance_margin = _to_float(
+            payload.get("maintMarginBalance", payload.get("totalMarginBalance", 0.0))
+        )
+
+        return AccountSnapshot(
+            balances=balances,
+            total_equity=total_equity,
+            available_margin=available_margin,
+            maintenance_margin=maintenance_margin,
+        )
+
+    def fetch_symbols(self) -> Iterable[str]:
+        """Pobiera listę aktywnych symboli spot z Binance."""
+
+        payload = self._public_request("/api/v3/exchangeInfo")
+        if not isinstance(payload, dict) or "symbols" not in payload:
+            raise RuntimeError("Niepoprawna odpowiedź exchangeInfo z Binance")
+
+        symbols_section = payload.get("symbols")
+        if not isinstance(symbols_section, list):
+            raise RuntimeError("Pole 'symbols' w odpowiedzi Binance ma niepoprawny format")
+
+        active_symbols: list[str] = []
+        for entry in symbols_section:
+            if not isinstance(entry, dict):
+                continue
+            status = entry.get("status")
+            symbol = entry.get("symbol")
+            if status != "TRADING" or not isinstance(symbol, str):
+                continue
+            active_symbols.append(symbol)
+        return active_symbols
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Sequence[float]]:
+        """Pobiera świece OHLCV w formacie zgodnym z modułem danych."""
+
+        params: dict[str, object] = {"symbol": symbol, "interval": interval}
+        if start is not None:
+            params["startTime"] = int(start)
+        if end is not None:
+            params["endTime"] = int(end)
+        if limit is not None:
+            params["limit"] = int(limit)
+
+        payload = self._public_request("/api/v3/klines", params=params)
+        if not isinstance(payload, list):
+            raise RuntimeError("Odpowiedź klines z Binance ma nieoczekiwany format")
+
+        candles: list[Sequence[float]] = []
+        for entry in payload:
+            if not isinstance(entry, list) or len(entry) < 6:
+                continue
+            open_time = float(entry[0])
+            open_price = float(entry[1])
+            high = float(entry[2])
+            low = float(entry[3])
+            close = float(entry[4])
+            volume = float(entry[5])
+            candles.append([open_time, open_price, high, low, close, volume])
+        return candles
+
+    def place_order(self, request: OrderRequest) -> OrderResult:
+        """Składa podpisane zlecenie typu limit/market na rynku spot."""
+
+        if "trade" not in self._permission_set:
+            raise PermissionError("Aktualne poświadczenia nie mają uprawnień tradingowych.")
+
+        params: dict[str, object] = {
+            "symbol": request.symbol,
+            "side": request.side.upper(),
+            "type": request.order_type.upper(),
+            "quantity": request.quantity,
+        }
+        if request.price is not None:
+            params["price"] = request.price
+        if request.time_in_force is not None:
+            params["timeInForce"] = request.time_in_force
+        if request.client_order_id is not None:
+            params["newClientOrderId"] = request.client_order_id
+
+        payload = self._signed_request("/api/v3/order", method="POST", params=params)
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("Odpowiedź z endpointu order ma niepoprawny format")
+
+        payload_dict = dict(payload)
+
+        order_id = str(payload_dict.get("orderId"))
+        status = str(payload_dict.get("status", "UNKNOWN"))
+        filled_qty = _to_float(payload_dict.get("executedQty", 0.0))
+        raw_price = payload_dict.get("price")
+        avg_price = _to_float(raw_price) if raw_price not in (None, "0", 0, 0.0) else None
+
+        return OrderResult(
+            order_id=order_id,
+            status=status,
+            filled_quantity=filled_qty,
+            avg_price=avg_price,
+            raw_response=payload_dict,
+        )
+
+    def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> None:
+        if "trade" not in self._permission_set:
+            raise PermissionError("Aktualne poświadczenia nie mają uprawnień tradingowych.")
+        params: dict[str, object] = {"orderId": order_id}
+        if symbol:
+            params["symbol"] = symbol
+        response = self._signed_request("/api/v3/order", method="DELETE", params=params)
+        if isinstance(response, Mapping):
+            response_map = dict(response)
+            if response_map.get("status") in {"CANCELED", "PENDING_CANCEL"}:
+                return
+        # Jeśli API zwróciło błąd, `urlopen` podniesie wyjątek HTTPError; jeśli odpowiedź jest dziwna,
+        # sygnalizujemy to wyjątkiem, aby egzekucja mogła przejść w tryb bezpieczny.
+            raise RuntimeError(f"Nieoczekiwana odpowiedź anulowania z Binance: {response_map}")
+        raise RuntimeError("Niepoprawna odpowiedź anulowania z Binance")
+
+    def stream_public_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Stream danych publicznych zostanie dodany w przyszłym etapie.")
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Stream danych prywatnych zostanie dodany w przyszłym etapie.")
+
+
+__all__ = ["BinanceSpotAdapter"]

--- a/bot_core/execution/__init__.py
+++ b/bot_core/execution/__init__.py
@@ -1,0 +1,19 @@
+"""Moduł egzekucji zleceń."""
+
+from bot_core.execution.base import ExecutionContext, ExecutionService, RetryPolicy
+from bot_core.execution.paper import (  # noqa: F401 - eksport publiczny
+    InsufficientBalanceError,
+    LedgerEntry,
+    MarketMetadata,
+    PaperTradingExecutionService,
+)
+
+__all__ = [
+    "ExecutionContext",
+    "ExecutionService",
+    "RetryPolicy",
+    "PaperTradingExecutionService",
+    "MarketMetadata",
+    "LedgerEntry",
+    "InsufficientBalanceError",
+]

--- a/bot_core/execution/base.py
+++ b/bot_core/execution/base.py
@@ -1,0 +1,44 @@
+"""Interfejs modułu egzekucji z obsługą retry i sanity-check."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Mapping, Protocol
+
+from bot_core.exchanges.base import OrderRequest, OrderResult
+
+
+@dataclass(slots=True)
+class ExecutionContext:
+    """Parametry wykonania przekazywane z warstwy strategii/ryzyka."""
+
+    portfolio_id: str
+    risk_profile: str
+    environment: str
+    metadata: Mapping[str, str]
+
+
+class ExecutionService(abc.ABC):
+    """Abstrakcyjny interfejs modułu egzekucji."""
+
+    @abc.abstractmethod
+    def execute(self, request: OrderRequest, context: ExecutionContext) -> OrderResult:
+        """Realizuje zlecenie z pełną obsługą retry/backoff."""
+
+    @abc.abstractmethod
+    def cancel(self, order_id: str, context: ExecutionContext) -> None:
+        """Anuluje zlecenie, uwzględniając wymogi giełdy."""
+
+    @abc.abstractmethod
+    def flush(self) -> None:
+        """Pozwala zakończyć proces (np. wysłać zaległe anulacje)."""
+
+
+class RetryPolicy(Protocol):
+    """Kontrakt polityki retry/backoff."""
+
+    def on_error(self, attempt: int, error: Exception) -> float:
+        ...
+
+
+__all__ = ["ExecutionContext", "ExecutionService", "RetryPolicy"]

--- a/bot_core/execution/paper.py
+++ b/bot_core/execution/paper.py
@@ -1,0 +1,272 @@
+"""Silnik paper trading odzwierciedlający koszty i poślizg."""
+from __future__ import annotations
+
+import itertools
+import logging
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from bot_core.execution.base import ExecutionContext, ExecutionService
+from bot_core.exchanges.base import OrderRequest, OrderResult
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class MarketMetadata:
+    """Parametry rynku wykorzystywane przez symulator paper tradingu."""
+
+    base_asset: str
+    quote_asset: str
+    min_quantity: float = 0.0
+    min_notional: float = 0.0
+    step_size: Optional[float] = None
+    tick_size: Optional[float] = None
+
+
+@dataclass(slots=True)
+class LedgerEntry:
+    """Pojedynczy wpis audytowy."""
+
+    timestamp: float
+    order_id: str
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    fee: float
+    fee_asset: str
+    status: str
+
+    def to_mapping(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "order_id": self.order_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "quantity": self.quantity,
+            "price": self.price,
+            "fee": self.fee,
+            "fee_asset": self.fee_asset,
+            "status": self.status,
+        }
+
+
+class InsufficientBalanceError(RuntimeError):
+    """Rzucany, gdy na rachunku brakuje środków na realizację zlecenia."""
+
+
+class PaperTradingExecutionService(ExecutionService):
+    """Symulator giełdy realizujący zlecenia natychmiast z kosztem prowizji i poślizgu."""
+
+    def __init__(
+        self,
+        markets: Mapping[str, MarketMetadata],
+        *,
+        initial_balances: Optional[Mapping[str, float]] = None,
+        maker_fee: float = 0.0004,
+        taker_fee: float = 0.0006,
+        slippage_bps: float = 5.0,
+        time_source: Optional[Callable[[], float]] = None,
+    ) -> None:
+        if not markets:
+            raise ValueError("Wymagana jest co najmniej jedna definicja rynku.")
+        self._markets: Dict[str, MarketMetadata] = dict(markets)
+        self._balances: MutableMapping[str, float] = {asset: float(value) for asset, value in (initial_balances or {}).items()}
+        self._maker_fee = max(0.0, maker_fee)
+        self._taker_fee = max(0.0, taker_fee)
+        self._slippage_bps = max(0.0, slippage_bps)
+        self._time = time_source or time.time
+        self._order_counter = itertools.count(1)
+        self._ledger: List[LedgerEntry] = []
+
+    # --- API ExecutionService -------------------------------------------------
+    def execute(self, request: OrderRequest, context: ExecutionContext) -> OrderResult:
+        symbol = request.symbol
+        market = self._markets.get(symbol)
+        if market is None:
+            raise KeyError(f"Brak konfiguracji rynku dla symbolu {symbol}")
+
+        side = request.side.lower()
+        if side not in {"buy", "sell"}:
+            raise ValueError("Obsługiwane są wyłącznie zlecenia kupna lub sprzedaży.")
+
+        if request.quantity <= 0:
+            raise ValueError("Wielkość zlecenia musi być dodatnia.")
+
+        self._validate_lot_size(request.quantity, market)
+
+        reference_price = self._determine_reference_price(request)
+        notional = reference_price * request.quantity
+        if notional < market.min_notional:
+            raise ValueError(
+                f"Notional {notional:.8f} jest mniejszy niż minimalna wartość {market.min_notional:.8f} dla {symbol}."
+            )
+
+        fill_price = self._apply_slippage(reference_price, side)
+        fee_rate = self._taker_fee if request.order_type.lower() == "market" else self._maker_fee
+        fee = request.quantity * fill_price * fee_rate
+
+        if side == "buy":
+            self._process_buy(symbol, market, request.quantity, fill_price, fee)
+        else:
+            self._process_sell(symbol, market, request.quantity, fill_price, fee)
+
+        order_id = f"paper-{next(self._order_counter)}"
+        result = OrderResult(
+            order_id=order_id,
+            status="filled",
+            filled_quantity=request.quantity,
+            avg_price=fill_price,
+            raw_response={
+                "environment": context.environment,
+                "risk_profile": context.risk_profile,
+                "portfolio_id": context.portfolio_id,
+                "fee": fee,
+                "fee_asset": market.quote_asset if side == "buy" else market.quote_asset,
+            },
+        )
+        self._ledger.append(
+            LedgerEntry(
+                timestamp=self._time(),
+                order_id=order_id,
+                symbol=symbol,
+                side=side,
+                quantity=request.quantity,
+                price=fill_price,
+                fee=fee,
+                fee_asset=market.quote_asset,
+                status=result.status,
+            )
+        )
+        _LOGGER.debug(
+            "Paper trade %s %s qty=%s price=%s fee=%s (env=%s)",
+            side,
+            symbol,
+            request.quantity,
+            fill_price,
+            fee,
+            context.environment,
+        )
+        return result
+
+    def cancel(self, order_id: str, context: ExecutionContext) -> None:  # noqa: ARG002 - wymagane przez interfejs
+        # Zlecenia w trybie paper trading są realizowane natychmiast – rejestrujemy jedynie próbę anulacji.
+        self._ledger.append(
+            LedgerEntry(
+                timestamp=self._time(),
+                order_id=order_id,
+                symbol="*",
+                side="cancel",
+                quantity=0.0,
+                price=0.0,
+                fee=0.0,
+                fee_asset="",
+                status="cancelled",
+            )
+        )
+        _LOGGER.info("Zarejestrowano anulację %s w symulatorze paper trading (brak otwartych zleceń).", order_id)
+
+    def flush(self) -> None:
+        # Symulator realizuje zlecenia natychmiast – flush nie musi nic robić.
+        _LOGGER.debug("PaperTradingExecutionService.flush() – brak zaległych operacji.")
+
+    # --- Funkcje pomocnicze ---------------------------------------------------
+    def _determine_reference_price(self, request: OrderRequest) -> float:
+        if request.price is None or request.price <= 0:
+            raise ValueError("Do symulacji wymagane jest podanie ceny referencyjnej w polu price.")
+        return request.price
+
+    def _apply_slippage(self, price: float, side: str) -> float:
+        if self._slippage_bps <= 0:
+            return price
+        adjustment = price * (self._slippage_bps / 10_000.0)
+        if side == "buy":
+            return price + adjustment
+        return max(0.0, price - adjustment)
+
+    def _validate_lot_size(self, quantity: float, market: MarketMetadata) -> None:
+        if quantity < market.min_quantity:
+            raise ValueError(
+                f"Wielkość zlecenia {quantity:.8f} jest mniejsza niż minimalna {market.min_quantity:.8f}."
+            )
+        if market.step_size:
+            remainder = (quantity / market.step_size) - round(quantity / market.step_size)
+            if abs(remainder) > 1e-8:
+                raise ValueError(
+                    f"Wielkość {quantity:.8f} nie spełnia kroku {market.step_size:.8f} dla rynku {market.base_asset}/{market.quote_asset}."
+                )
+
+    def _process_buy(
+        self,
+        symbol: str,
+        market: MarketMetadata,
+        quantity: float,
+        price: float,
+        fee: float,
+    ) -> None:
+        cost = quantity * price + fee
+        quote_balance = self._balances.get(market.quote_asset, 0.0)
+        if quote_balance + 1e-12 < cost:
+            raise InsufficientBalanceError(
+                f"Brak środków {market.quote_asset}. Dostępne {quote_balance:.8f}, wymagane {cost:.8f}."
+            )
+        self._balances[market.quote_asset] = quote_balance - cost
+        self._balances[market.base_asset] = self._balances.get(market.base_asset, 0.0) + quantity
+        _LOGGER.debug(
+            "BUY %s: -%s %s, +%s %s (fee=%s)",
+            symbol,
+            cost,
+            market.quote_asset,
+            quantity,
+            market.base_asset,
+            fee,
+        )
+
+    def _process_sell(
+        self,
+        symbol: str,
+        market: MarketMetadata,
+        quantity: float,
+        price: float,
+        fee: float,
+    ) -> None:
+        base_balance = self._balances.get(market.base_asset, 0.0)
+        if base_balance + 1e-12 < quantity:
+            raise InsufficientBalanceError(
+                f"Brak pozycji {market.base_asset}. Dostępne {base_balance:.8f}, wymagane {quantity:.8f}."
+            )
+        proceed = quantity * price - fee
+        if proceed < 0:
+            proceed = 0.0
+        self._balances[market.base_asset] = base_balance - quantity
+        self._balances[market.quote_asset] = self._balances.get(market.quote_asset, 0.0) + proceed
+        _LOGGER.debug(
+            "SELL %s: -%s %s, +%s %s (fee=%s)",
+            symbol,
+            quantity,
+            market.base_asset,
+            proceed,
+            market.quote_asset,
+            fee,
+        )
+
+    # --- Funkcje obserwowalne -------------------------------------------------
+    def balances(self) -> Mapping[str, float]:
+        """Zwraca bieżące saldo konta paper trading."""
+
+        return dict(self._balances)
+
+    def ledger(self) -> Iterable[Mapping[str, object]]:
+        """Zwraca kopię wpisów audytowych (do raportów compliance)."""
+
+        return [entry.to_mapping() for entry in self._ledger]
+
+
+__all__ = [
+    "PaperTradingExecutionService",
+    "MarketMetadata",
+    "LedgerEntry",
+    "InsufficientBalanceError",
+]

--- a/bot_core/risk/__init__.py
+++ b/bot_core/risk/__init__.py
@@ -1,0 +1,21 @@
+"""Warstwa ryzyka."""
+
+from bot_core.risk.base import RiskCheckResult, RiskEngine, RiskProfile, RiskRepository
+from bot_core.risk.engine import InMemoryRiskRepository, ThresholdRiskEngine
+from bot_core.risk.profiles.aggressive import AggressiveProfile
+from bot_core.risk.profiles.balanced import BalancedProfile
+from bot_core.risk.profiles.conservative import ConservativeProfile
+from bot_core.risk.profiles.manual import ManualProfile
+
+__all__ = [
+    "AggressiveProfile",
+    "BalancedProfile",
+    "ConservativeProfile",
+    "InMemoryRiskRepository",
+    "ManualProfile",
+    "RiskCheckResult",
+    "RiskEngine",
+    "RiskProfile",
+    "RiskRepository",
+    "ThresholdRiskEngine",
+]

--- a/bot_core/risk/base.py
+++ b/bot_core/risk/base.py
@@ -1,0 +1,100 @@
+"""Interfejs silnika zarządzania ryzykiem oraz profili."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping, Protocol
+
+from bot_core.exchanges.base import AccountSnapshot, OrderRequest
+
+
+@dataclass(slots=True)
+class RiskCheckResult:
+    """Wynik kontroli ryzyka."""
+
+    allowed: bool
+    reason: str | None = None
+    adjustments: Mapping[str, float] | None = None
+
+
+class RiskProfile(abc.ABC):
+    """Każdy profil musi dostarczać zestaw limitów i procedur kontroli."""
+
+    name: str
+
+    @abc.abstractmethod
+    def max_positions(self) -> int:
+        ...
+
+    @abc.abstractmethod
+    def max_leverage(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def drawdown_limit(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def daily_loss_limit(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def max_position_exposure(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def target_volatility(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def stop_loss_atr_multiple(self) -> float:
+        ...
+
+
+class RiskEngine(abc.ABC):
+    """Silnik ryzyka odpowiada za enforce limitów i pre-trade checks."""
+
+    @abc.abstractmethod
+    def register_profile(self, profile: RiskProfile) -> None:
+        ...
+
+    @abc.abstractmethod
+    def apply_pre_trade_checks(
+        self,
+        request: OrderRequest,
+        *,
+        account: AccountSnapshot,
+        profile_name: str,
+    ) -> RiskCheckResult:
+        ...
+
+    @abc.abstractmethod
+    def on_fill(
+        self,
+        *,
+        profile_name: str,
+        symbol: str,
+        side: str,
+        position_value: float,
+        pnl: float,
+        timestamp: datetime | None = None,
+    ) -> None:
+        ...
+
+    @abc.abstractmethod
+    def should_liquidate(self, *, profile_name: str) -> bool:
+        ...
+
+
+class RiskRepository(Protocol):
+    """Kontrakt dla repozytoriów stanu ryzyka (np. SQLite, Parquet)."""
+
+    def load(self, profile: str) -> Mapping[str, object] | None:
+        ...
+
+    def store(self, profile: str, state: Mapping[str, object]) -> None:
+        ...
+
+
+__all__ = ["RiskCheckResult", "RiskProfile", "RiskEngine", "RiskRepository"]

--- a/bot_core/risk/engine.py
+++ b/bot_core/risk/engine.py
@@ -1,0 +1,340 @@
+"""Implementacja silnika ryzyka egzekwującego limity profili."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Callable, Dict, Mapping, MutableMapping
+
+from bot_core.exchanges.base import AccountSnapshot, OrderRequest
+from bot_core.risk.base import RiskCheckResult, RiskEngine, RiskProfile, RiskRepository
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class PositionState:
+    """Stan pojedynczej pozycji wykorzystywany przez silnik ryzyka."""
+
+    side: str
+    notional: float
+
+    def to_mapping(self) -> Mapping[str, object]:
+        return {"side": self.side, "notional": self.notional}
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, object]) -> "PositionState":
+        side = str(data.get("side", "long"))
+        notional = float(data.get("notional", 0.0))
+        return cls(side=side, notional=max(0.0, notional))
+
+
+@dataclass(slots=True)
+class RiskState:
+    """Stan profilu wykorzystywany do egzekwowania limitów."""
+
+    profile: str
+    current_day: date
+    start_of_day_equity: float = 0.0
+    last_equity: float = 0.0
+    daily_realized_pnl: float = 0.0
+    peak_equity: float = 0.0
+    force_liquidation: bool = False
+    positions: Dict[str, PositionState] = field(default_factory=dict)
+
+    def gross_notional(self) -> float:
+        return sum(position.notional for position in self.positions.values())
+
+    def active_positions(self) -> int:
+        return sum(1 for position in self.positions.values() if position.notional > 0.0)
+
+    def to_mapping(self) -> Mapping[str, object]:
+        return {
+            "profile": self.profile,
+            "current_day": self.current_day.isoformat(),
+            "start_of_day_equity": self.start_of_day_equity,
+            "daily_realized_pnl": self.daily_realized_pnl,
+            "peak_equity": self.peak_equity,
+            "force_liquidation": self.force_liquidation,
+            "last_equity": self.last_equity,
+            "positions": {symbol: position.to_mapping() for symbol, position in self.positions.items()},
+        }
+
+    @classmethod
+    def from_mapping(cls, profile: str, data: Mapping[str, object]) -> "RiskState":
+        day_str = str(data.get("current_day", date.today().isoformat()))
+        parsed_day = datetime.fromisoformat(day_str).date()
+        positions_raw = data.get("positions", {})
+        positions: Dict[str, PositionState] = {}
+        if isinstance(positions_raw, Mapping):
+            for symbol, raw in positions_raw.items():
+                if isinstance(raw, Mapping):
+                    positions[str(symbol)] = PositionState.from_mapping(raw)
+        return cls(
+            profile=profile,
+            current_day=parsed_day,
+            start_of_day_equity=float(data.get("start_of_day_equity", 0.0)),
+            daily_realized_pnl=float(data.get("daily_realized_pnl", 0.0)),
+            peak_equity=float(data.get("peak_equity", 0.0)),
+            force_liquidation=bool(data.get("force_liquidation", False)),
+            last_equity=float(data.get("last_equity", 0.0)),
+            positions=positions,
+        )
+
+    def reset_for_new_day(self, *, equity: float, day: date) -> None:
+        self.current_day = day
+        self.start_of_day_equity = equity
+        self.daily_realized_pnl = 0.0
+        self.force_liquidation = False
+        self.last_equity = equity
+
+    def update_peak_equity(self, equity: float) -> None:
+        self.peak_equity = max(self.peak_equity, equity)
+        self.last_equity = equity
+
+    def daily_loss_pct(self) -> float:
+        if self.start_of_day_equity <= 0:
+            return 0.0
+        loss = min(0.0, self.daily_realized_pnl)
+        return abs(loss) / self.start_of_day_equity
+
+    def drawdown_pct(self, current_equity: float) -> float:
+        if self.peak_equity <= 0:
+            return 0.0
+        drawdown_value = self.peak_equity - current_equity
+        if drawdown_value <= 0:
+            return 0.0
+        return drawdown_value / self.peak_equity
+
+    def update_position(self, symbol: str, side: str, notional: float) -> None:
+        if notional <= 0:
+            self.positions.pop(symbol, None)
+            return
+        self.positions[symbol] = PositionState(side=side, notional=notional)
+
+
+class InMemoryRiskRepository(RiskRepository):
+    """Najprostsze repozytorium używane do testów i trybu offline."""
+
+    def __init__(self) -> None:
+        self._storage: Dict[str, MutableMapping[str, object]] = {}
+
+    def load(self, profile: str) -> Mapping[str, object] | None:
+        return self._storage.get(profile)
+
+    def store(self, profile: str, state: Mapping[str, object]) -> None:
+        self._storage[profile] = dict(state)
+
+
+class ThresholdRiskEngine(RiskEngine):
+    """Silnik egzekwujący limity dzienne, ekspozycji i dźwigni."""
+
+    def __init__(
+        self,
+        repository: RiskRepository | None = None,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._repository = repository or InMemoryRiskRepository()
+        self._clock = clock or datetime.utcnow
+        self._profiles: Dict[str, RiskProfile] = {}
+        self._states: Dict[str, RiskState] = {}
+
+    def register_profile(self, profile: RiskProfile) -> None:
+        self._profiles[profile.name] = profile
+        state = self._repository.load(profile.name)
+        if state is None:
+            today = self._clock().date()
+            self._states[profile.name] = RiskState(profile=profile.name, current_day=today)
+            self._repository.store(profile.name, self._states[profile.name].to_mapping())
+        else:
+            self._states[profile.name] = RiskState.from_mapping(profile.name, state)
+        _LOGGER.info("Zarejestrowano profil ryzyka %s", profile.name)
+
+    def apply_pre_trade_checks(
+        self,
+        request: OrderRequest,
+        *,
+        account: AccountSnapshot,
+        profile_name: str,
+    ) -> RiskCheckResult:
+        profile = self._profiles.get(profile_name)
+        if profile is None:
+            raise KeyError(f"Profil ryzyka {profile_name} nie został zarejestrowany")
+
+        state = self._states.get(profile_name)
+        if state is None:
+            raise KeyError(f"Brak stanu ryzyka dla profilu {profile_name}")
+
+        now = self._clock()
+        current_day = now.date()
+        if state.current_day != current_day:
+            state.reset_for_new_day(equity=account.total_equity, day=current_day)
+            _LOGGER.info("Reset dziennego licznika PnL dla profilu %s", profile_name)
+
+        state.update_peak_equity(account.total_equity)
+
+        drawdown = state.drawdown_pct(account.total_equity)
+        daily_loss = state.daily_loss_pct()
+
+        force_reason: str | None = None
+        if profile.drawdown_limit() > 0 and drawdown >= profile.drawdown_limit():
+            state.force_liquidation = True
+            force_reason = "Przekroczono limit obsunięcia portfela."
+
+        if profile.daily_loss_limit() > 0 and daily_loss >= profile.daily_loss_limit():
+            state.force_liquidation = True
+            force_reason = "Przekroczono dzienny limit straty."
+
+        price = request.price
+        if price is None or price <= 0:
+            self._persist_state(profile_name)
+            return RiskCheckResult(
+                allowed=False,
+                reason=(
+                    "Brak ceny referencyjnej uniemożliwia obliczenie ekspozycji. Podaj midpoint z orderbooka lub cenę limit."
+                ),
+            )
+
+        symbol = request.symbol
+        position = state.positions.get(symbol)
+        is_buy = request.side.lower() == "buy"
+        notional = abs(request.quantity) * price
+        current_notional = position.notional if position else 0.0
+        current_side = position.side if position else ("long" if is_buy else "short")
+
+        if position:
+            if position.side == "long" and not is_buy and notional > current_notional:
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason=(
+                        "Zlecenie sprzedaży przekracza wielkość istniejącej pozycji. Zamknij pozycję przed odwróceniem kierunku."
+                    ),
+                )
+            if position.side == "short" and is_buy and notional > current_notional:
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason=(
+                        "Zlecenie kupna przekracza wielkość krótkiej pozycji. Zamknij pozycję przed odwróceniem kierunku."
+                    ),
+                )
+
+        if is_buy:
+            if current_side == "long":
+                new_notional = current_notional + notional
+            else:
+                new_notional = max(current_notional - notional, 0.0)
+        else:
+            if current_side == "short":
+                new_notional = current_notional + notional
+            else:
+                new_notional = max(current_notional - notional, 0.0)
+
+        is_reducing = new_notional < current_notional
+
+        is_new_position = current_notional == 0.0 and new_notional > 0.0 and not is_reducing
+
+        if state.force_liquidation and not is_reducing:
+            self._persist_state(profile_name)
+            return RiskCheckResult(
+                allowed=False,
+                reason=(
+                    (force_reason + " Dozwolone są wyłącznie transakcje redukujące ekspozycję.")
+                    if force_reason
+                    else "Profil w trybie awaryjnym – dozwolone są wyłącznie transakcje redukujące ekspozycję."
+                ),
+            )
+
+        if is_new_position:
+            if state.active_positions() >= profile.max_positions():
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Limit liczby równoległych pozycji został osiągnięty.",
+                )
+
+        max_position_pct = profile.max_position_exposure()
+        if not is_reducing and max_position_pct > 0:
+            max_notional = max_position_pct * account.total_equity
+            if max_notional <= 0:
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Kapitał konta jest zbyt niski do otwierania nowych pozycji.",
+                )
+            if new_notional > max_notional:
+                allowed_notional = max_notional
+                allowed_quantity = max(0.0, allowed_notional - current_notional) / price
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Wielkość zlecenia przekracza limit ekspozycji na instrument.",
+                    adjustments={"max_quantity": max(0.0, allowed_quantity)},
+                )
+
+        max_leverage = profile.max_leverage()
+        if not is_reducing and max_leverage > 0:
+            gross_without_symbol = state.gross_notional() - current_notional
+            max_total_notional = max_leverage * account.total_equity
+            if max_total_notional <= 0:
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Kapitał konta nie pozwala na otwieranie pozycji przy zadanej dźwigni.",
+                )
+            new_gross = gross_without_symbol + new_notional
+            if new_gross > max_total_notional:
+                remaining_notional = max(0.0, max_total_notional - gross_without_symbol)
+                allowed_quantity = remaining_notional / price
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Przekroczono maksymalną dźwignię portfela.",
+                    adjustments={"max_quantity": max(0.0, allowed_quantity)},
+                )
+
+        self._persist_state(profile_name)
+
+        return RiskCheckResult(allowed=True)
+
+    def on_fill(
+        self,
+        *,
+        profile_name: str,
+        symbol: str,
+        side: str,
+        position_value: float,
+        pnl: float,
+        timestamp: datetime | None = None,
+    ) -> None:
+        profile = self._profiles.get(profile_name)
+        if profile is None:
+            raise KeyError(f"Profil ryzyka {profile_name} nie został zarejestrowany")
+
+        state = self._states.get(profile_name)
+        if state is None:
+            raise KeyError(f"Brak stanu ryzyka dla profilu {profile_name}")
+
+        now = timestamp or self._clock()
+        current_day = now.date()
+        if state.current_day != current_day:
+            state.reset_for_new_day(equity=state.last_equity, day=current_day)
+
+        state.daily_realized_pnl += pnl
+        state.update_position(symbol, side=side, notional=max(0.0, position_value))
+        self._persist_state(profile_name)
+
+    def should_liquidate(self, *, profile_name: str) -> bool:
+        state = self._states.get(profile_name)
+        if state is None:
+            raise KeyError(f"Brak stanu ryzyka dla profilu {profile_name}")
+        return state.force_liquidation
+
+    def _persist_state(self, profile_name: str) -> None:
+        state = self._states[profile_name]
+        self._repository.store(profile_name, state.to_mapping())
+
+
+__all__ = ["InMemoryRiskRepository", "ThresholdRiskEngine", "RiskState", "PositionState"]

--- a/bot_core/risk/profiles/__init__.py
+++ b/bot_core/risk/profiles/__init__.py
@@ -1,0 +1,13 @@
+"""Profile ryzyka."""
+
+from bot_core.risk.profiles.aggressive import AggressiveProfile
+from bot_core.risk.profiles.balanced import BalancedProfile
+from bot_core.risk.profiles.conservative import ConservativeProfile
+from bot_core.risk.profiles.manual import ManualProfile
+
+__all__ = [
+    "AggressiveProfile",
+    "BalancedProfile",
+    "ConservativeProfile",
+    "ManualProfile",
+]

--- a/bot_core/risk/profiles/aggressive.py
+++ b/bot_core/risk/profiles/aggressive.py
@@ -1,0 +1,44 @@
+"""Profil agresywny zgodny z wymaganiami klienta."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bot_core.risk.base import RiskProfile
+
+
+@dataclass(slots=True)
+class AggressiveProfile(RiskProfile):
+    """Profil o wysokiej tolerancji ryzyka."""
+
+    name: str = "aggressive"
+    _max_positions: int = 10
+    _max_leverage: float = 5.0
+    _drawdown_limit: float = 0.20
+    _daily_loss_limit: float = 0.03
+    _max_position_pct: float = 0.10
+    _target_volatility: float = 0.19
+    _stop_loss_atr_multiple: float = 2.0
+
+    def max_positions(self) -> int:
+        return self._max_positions
+
+    def max_leverage(self) -> float:
+        return self._max_leverage
+
+    def drawdown_limit(self) -> float:
+        return self._drawdown_limit
+
+    def daily_loss_limit(self) -> float:
+        return self._daily_loss_limit
+
+    def max_position_exposure(self) -> float:
+        return self._max_position_pct
+
+    def target_volatility(self) -> float:
+        return self._target_volatility
+
+    def stop_loss_atr_multiple(self) -> float:
+        return self._stop_loss_atr_multiple
+
+
+__all__ = ["AggressiveProfile"]

--- a/bot_core/risk/profiles/balanced.py
+++ b/bot_core/risk/profiles/balanced.py
@@ -1,0 +1,44 @@
+"""Profil zbalansowany będący ustawieniem domyślnym."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bot_core.risk.base import RiskProfile
+
+
+@dataclass(slots=True)
+class BalancedProfile(RiskProfile):
+    """Profil o średniej tolerancji ryzyka."""
+
+    name: str = "balanced"
+    _max_positions: int = 5
+    _max_leverage: float = 3.0
+    _drawdown_limit: float = 0.10
+    _daily_loss_limit: float = 0.015
+    _max_position_pct: float = 0.05
+    _target_volatility: float = 0.11
+    _stop_loss_atr_multiple: float = 1.5
+
+    def max_positions(self) -> int:
+        return self._max_positions
+
+    def max_leverage(self) -> float:
+        return self._max_leverage
+
+    def drawdown_limit(self) -> float:
+        return self._drawdown_limit
+
+    def daily_loss_limit(self) -> float:
+        return self._daily_loss_limit
+
+    def max_position_exposure(self) -> float:
+        return self._max_position_pct
+
+    def target_volatility(self) -> float:
+        return self._target_volatility
+
+    def stop_loss_atr_multiple(self) -> float:
+        return self._stop_loss_atr_multiple
+
+
+__all__ = ["BalancedProfile"]

--- a/bot_core/risk/profiles/conservative.py
+++ b/bot_core/risk/profiles/conservative.py
@@ -1,0 +1,44 @@
+"""Profil konserwatywny zgodny z wymaganiami klienta."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bot_core.risk.base import RiskProfile
+
+
+@dataclass(slots=True)
+class ConservativeProfile(RiskProfile):
+    """Profil o niskiej tolerancji ryzyka."""
+
+    name: str = "conservative"
+    _max_positions: int = 3
+    _max_leverage: float = 2.0
+    _drawdown_limit: float = 0.05
+    _daily_loss_limit: float = 0.01
+    _max_position_pct: float = 0.03
+    _target_volatility: float = 0.07
+    _stop_loss_atr_multiple: float = 1.0
+
+    def max_positions(self) -> int:
+        return self._max_positions
+
+    def max_leverage(self) -> float:
+        return self._max_leverage
+
+    def drawdown_limit(self) -> float:
+        return self._drawdown_limit
+
+    def daily_loss_limit(self) -> float:
+        return self._daily_loss_limit
+
+    def max_position_exposure(self) -> float:
+        return self._max_position_pct
+
+    def target_volatility(self) -> float:
+        return self._target_volatility
+
+    def stop_loss_atr_multiple(self) -> float:
+        return self._stop_loss_atr_multiple
+
+
+__all__ = ["ConservativeProfile"]

--- a/bot_core/risk/profiles/manual.py
+++ b/bot_core/risk/profiles/manual.py
@@ -1,0 +1,65 @@
+"""Profil ręczny pozwalający na własne limity."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bot_core.risk.base import RiskProfile
+
+
+@dataclass(slots=True, init=False)
+class ManualProfile(RiskProfile):
+    """Profil konfigurowany przez użytkownika."""
+
+    name: str
+    _max_positions: int
+    _max_leverage: float
+    _drawdown_limit: float
+    _daily_loss_limit: float
+    _max_position_pct: float
+    _target_volatility: float
+    _stop_loss_atr_multiple: float
+
+    def __init__(
+        self,
+        *,
+        name: str = "manual",
+        max_positions: int,
+        max_leverage: float,
+        drawdown_limit: float,
+        daily_loss_limit: float,
+        max_position_pct: float,
+        target_volatility: float,
+        stop_loss_atr_multiple: float,
+    ) -> None:
+        self.name = name
+        self._max_positions = max_positions
+        self._max_leverage = max_leverage
+        self._drawdown_limit = drawdown_limit
+        self._daily_loss_limit = daily_loss_limit
+        self._max_position_pct = max_position_pct
+        self._target_volatility = target_volatility
+        self._stop_loss_atr_multiple = stop_loss_atr_multiple
+
+    def max_positions(self) -> int:
+        return self._max_positions
+
+    def max_leverage(self) -> float:
+        return self._max_leverage
+
+    def drawdown_limit(self) -> float:
+        return self._drawdown_limit
+
+    def daily_loss_limit(self) -> float:
+        return self._daily_loss_limit
+
+    def max_position_exposure(self) -> float:
+        return self._max_position_pct
+
+    def target_volatility(self) -> float:
+        return self._target_volatility
+
+    def stop_loss_atr_multiple(self) -> float:
+        return self._stop_loss_atr_multiple
+
+
+__all__ = ["ManualProfile"]

--- a/bot_core/runtime/__init__.py
+++ b/bot_core/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Infrastruktura runtime nowej architektury bota."""
+
+from bot_core.runtime.bootstrap import BootstrapContext, bootstrap_environment
+
+__all__ = ["BootstrapContext", "bootstrap_environment"]

--- a/bot_core/runtime/bootstrap.py
+++ b/bot_core/runtime/bootstrap.py
@@ -1,0 +1,291 @@
+"""Procedury rozruchowe spinające konfigurację z modułami runtime."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, MutableMapping, Sequence
+
+from bot_core.alerts import (
+    DefaultAlertRouter,
+    EmailChannel,
+    InMemoryAlertAuditLog,
+    SMSChannel,
+    TelegramChannel,
+    get_sms_provider,
+)
+from bot_core.alerts.base import AlertChannel
+from bot_core.alerts.channels.providers import SmsProviderConfig
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import (
+    CoreConfig,
+    EmailChannelSettings,
+    EnvironmentConfig,
+    RiskProfileConfig,
+    SMSProviderSettings,
+    TelegramChannelSettings,
+)
+from bot_core.exchanges.base import Environment, ExchangeAdapter, ExchangeAdapterFactory, ExchangeCredentials
+from bot_core.exchanges.binance import BinanceFuturesAdapter, BinanceSpotAdapter
+from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.profiles.manual import ManualProfile
+from bot_core.security import SecretManager, SecretStorageError
+
+_DEFAULT_ADAPTERS: Mapping[str, ExchangeAdapterFactory] = {
+    "binance_spot": BinanceSpotAdapter,
+    "binance_futures": BinanceFuturesAdapter,
+}
+
+
+@dataclass(slots=True)
+class BootstrapContext:
+    """Zawiera wszystkie komponenty zainicjalizowane dla danego środowiska."""
+
+    core_config: CoreConfig
+    environment: EnvironmentConfig
+    credentials: ExchangeCredentials
+    adapter: ExchangeAdapter
+    risk_engine: ThresholdRiskEngine
+    alert_router: DefaultAlertRouter
+    alert_channels: Mapping[str, AlertChannel]
+    audit_log: InMemoryAlertAuditLog
+
+
+def bootstrap_environment(
+    environment_name: str,
+    *,
+    config_path: str | Path,
+    secret_manager: SecretManager,
+    adapter_factories: Mapping[str, ExchangeAdapterFactory] | None = None,
+) -> BootstrapContext:
+    """Tworzy kompletny kontekst uruchomieniowy dla wskazanego środowiska."""
+
+    core_config = load_core_config(config_path)
+    if environment_name not in core_config.environments:
+        raise KeyError(f"Środowisko '{environment_name}' nie istnieje w konfiguracji")
+
+    environment = core_config.environments[environment_name]
+    risk_profile_config = _resolve_risk_profile(core_config.risk_profiles, environment.risk_profile)
+
+    risk_engine = ThresholdRiskEngine()
+    profile = ManualProfile(
+        name=risk_profile_config.name,
+        max_positions=risk_profile_config.max_open_positions,
+        max_leverage=risk_profile_config.max_leverage,
+        drawdown_limit=risk_profile_config.hard_drawdown_pct,
+        daily_loss_limit=risk_profile_config.max_daily_loss_pct,
+        max_position_pct=risk_profile_config.max_position_pct,
+        target_volatility=risk_profile_config.target_volatility,
+        stop_loss_atr_multiple=risk_profile_config.stop_loss_atr_multiple,
+    )
+    risk_engine.register_profile(profile)
+
+    credentials = secret_manager.load_exchange_credentials(
+        environment.keychain_key,
+        expected_environment=environment.environment,
+        purpose=environment.credential_purpose,
+    )
+
+    factories = dict(_DEFAULT_ADAPTERS)
+    if adapter_factories:
+        factories.update(adapter_factories)
+    adapter = _instantiate_adapter(environment.exchange, credentials, factories, environment.environment)
+    adapter.configure_network(ip_allowlist=environment.ip_allowlist or None)
+
+    alert_channels, alert_router, audit_log = _build_alert_channels(
+        core_config=core_config,
+        environment=environment,
+        secret_manager=secret_manager,
+    )
+
+    return BootstrapContext(
+        core_config=core_config,
+        environment=environment,
+        credentials=credentials,
+        adapter=adapter,
+        risk_engine=risk_engine,
+        alert_router=alert_router,
+        alert_channels=alert_channels,
+        audit_log=audit_log,
+    )
+
+
+def _instantiate_adapter(
+    exchange_name: str,
+    credentials: ExchangeCredentials,
+    factories: Mapping[str, ExchangeAdapterFactory],
+    environment: Environment,
+) -> ExchangeAdapter:
+    try:
+        factory = factories[exchange_name]
+    except KeyError as exc:
+        raise KeyError(f"Brak fabryki adaptera dla giełdy '{exchange_name}'") from exc
+    return factory(credentials, environment=environment)
+
+
+def _resolve_risk_profile(
+    profiles: Mapping[str, RiskProfileConfig],
+    profile_name: str,
+) -> RiskProfileConfig:
+    try:
+        return profiles[profile_name]
+    except KeyError as exc:
+        raise KeyError(f"Profil ryzyka '{profile_name}' nie istnieje w konfiguracji") from exc
+
+
+def _build_alert_channels(
+    *,
+    core_config: CoreConfig,
+    environment: EnvironmentConfig,
+    secret_manager: SecretManager,
+) -> tuple[Mapping[str, AlertChannel], DefaultAlertRouter, InMemoryAlertAuditLog]:
+    audit_log = InMemoryAlertAuditLog()
+    router = DefaultAlertRouter(audit_log=audit_log)
+    channels: MutableMapping[str, AlertChannel] = {}
+
+    for entry in environment.alert_channels:
+        channel_type, _, channel_key = entry.partition(":")
+        channel_type = channel_type.strip().lower()
+        channel_key = channel_key.strip() or "default"
+
+        if channel_type == "telegram":
+            channel = _build_telegram_channel(core_config.telegram_channels, channel_key, secret_manager)
+        elif channel_type == "email":
+            channel = _build_email_channel(core_config.email_channels, channel_key, secret_manager)
+        elif channel_type == "sms":
+            channel = _build_sms_channel(core_config.sms_providers, channel_key, secret_manager)
+        else:
+            raise KeyError(f"Nieobsługiwany typ kanału alertów: {channel_type}")
+
+        router.register(channel)
+        channels[channel.name] = channel
+
+    return channels, router, audit_log
+
+
+def _build_telegram_channel(
+    definitions: Mapping[str, TelegramChannelSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> TelegramChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji kanału Telegram '{channel_key}'") from exc
+
+    token = secret_manager.load_secret_value(settings.token_secret, purpose="alerts:telegram")
+
+    return TelegramChannel(
+        bot_token=token,
+        chat_id=settings.chat_id,
+        parse_mode=settings.parse_mode,
+        name=f"telegram:{channel_key}",
+    )
+
+
+def _build_email_channel(
+    definitions: Mapping[str, EmailChannelSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> EmailChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji kanału e-mail '{channel_key}'") from exc
+
+    username = None
+    password = None
+    if settings.credential_secret:
+        raw_secret = secret_manager.load_secret_value(settings.credential_secret, purpose="alerts:email")
+        try:
+            parsed = json.loads(raw_secret) if raw_secret else {}
+        except json.JSONDecodeError as exc:  # pragma: no cover - uszkodzony sekret to błąd konfiguracji
+            raise SecretStorageError(
+                "Sekret dla kanału e-mail musi zawierać poprawny JSON z polami 'username' i 'password'."
+            ) from exc
+        username = parsed.get("username")
+        password = parsed.get("password")
+
+    return EmailChannel(
+        host=settings.host,
+        port=settings.port,
+        from_address=settings.from_address,
+        recipients=settings.recipients,
+        username=username,
+        password=password,
+        use_tls=settings.use_tls,
+        name=f"email:{channel_key}",
+    )
+
+
+def _build_sms_channel(
+    definitions: Mapping[str, SMSProviderSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> SMSChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji dostawcy SMS '{channel_key}'") from exc
+
+    if not settings.credential_key:
+        raise SecretStorageError(
+            f"Konfiguracja dostawcy SMS '{channel_key}' musi wskazywać 'credential_key'."
+        )
+
+    raw_secret = secret_manager.load_secret_value(settings.credential_key, purpose="alerts:sms")
+    try:
+        payload = json.loads(raw_secret)
+    except json.JSONDecodeError as exc:  # pragma: no cover - uszkodzone dane w magazynie
+        raise SecretStorageError(
+            "Sekret dostawcy SMS powinien zawierać JSON z polami 'account_sid' i 'auth_token'."
+        ) from exc
+
+    account_sid = payload.get("account_sid")
+    auth_token = payload.get("auth_token")
+    if not account_sid or not auth_token:
+        raise SecretStorageError(
+            "Sekret dostawcy SMS musi zawierać pola 'account_sid' oraz 'auth_token'."
+        )
+
+    provider_config = _resolve_sms_provider(settings)
+    sender = (
+        settings.sender_id
+        if settings.allow_alphanumeric_sender and settings.sender_id
+        else settings.from_number
+    )
+    if not sender:
+        raise SecretStorageError(
+            f"Konfiguracja dostawcy SMS '{channel_key}' wymaga pola 'from_number' lub 'sender_id'."
+        )
+
+    recipients: Sequence[str] = tuple(settings.recipients)
+    if not recipients:
+        raise SecretStorageError(
+            f"Konfiguracja dostawcy SMS '{channel_key}' wymaga co najmniej jednego odbiorcy."
+        )
+
+    return SMSChannel(
+        account_sid=str(account_sid),
+        auth_token=str(auth_token),
+        from_number=sender,
+        recipients=recipients,
+        provider=provider_config,
+        name=f"sms:{channel_key}",
+    )
+
+
+def _resolve_sms_provider(settings: SMSProviderSettings) -> SmsProviderConfig:
+    base = get_sms_provider(settings.provider_key)
+    return SmsProviderConfig(
+        provider_id=base.provider_id,
+        display_name=base.display_name,
+        api_base_url=settings.api_base_url or base.api_base_url,
+        iso_country_code=base.iso_country_code,
+        supports_alphanumeric_sender=settings.allow_alphanumeric_sender,
+        notes=base.notes,
+        max_sender_length=base.max_sender_length,
+    )
+
+
+__all__ = ["BootstrapContext", "bootstrap_environment"]

--- a/bot_core/security/__init__.py
+++ b/bot_core/security/__init__.py
@@ -1,0 +1,17 @@
+"""Warstwa bezpieczeństwa i obsługi sekretów bota handlowego."""
+
+from bot_core.security.base import (
+    SecretManager,
+    SecretPayload,
+    SecretStorage,
+    SecretStorageError,
+)
+from bot_core.security.keyring_storage import KeyringSecretStorage
+
+__all__ = [
+    "SecretManager",
+    "SecretPayload",
+    "SecretStorage",
+    "SecretStorageError",
+    "KeyringSecretStorage",
+]

--- a/bot_core/security/keyring_storage.py
+++ b/bot_core/security/keyring_storage.py
@@ -1,0 +1,40 @@
+"""Implementacja magazynu sekretów oparta o bibliotekę ``keyring``."""
+from __future__ import annotations
+
+from typing import Optional
+
+from bot_core.security.base import SecretStorage, SecretStorageError
+
+
+class KeyringSecretStorage(SecretStorage):
+    """Odwzorowuje interfejs ``SecretStorage`` na natywne keychainy systemów operacyjnych."""
+
+    def __init__(self, *, service_name: str = "dudzian.trading") -> None:
+        try:
+            import keyring  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - zależne od środowiska CI
+            raise SecretStorageError(
+                "Biblioteka 'keyring' nie jest dostępna. Zainstaluj ją, aby korzystać z natywnego "
+                "przechowywania sekretów (pip install keyring)."
+            ) from exc
+
+        self._keyring = keyring
+        self._service_name = service_name
+
+    def get_secret(self, key: str) -> Optional[str]:
+        return self._keyring.get_password(self._service_name, key)
+
+    def set_secret(self, key: str, value: str) -> None:
+        result = self._keyring.set_password(self._service_name, key, value)
+        if result is not None:  # pragma: no cover - większość backendów zwraca None
+            raise SecretStorageError(f"Nie udało się zapisać sekretu '{key}'.")
+
+    def delete_secret(self, key: str) -> None:
+        try:
+            self._keyring.delete_password(self._service_name, key)
+        except self._keyring.errors.PasswordDeleteError:
+            # Wyrównujemy zachowanie do idempotentnego kasowania – ignorujemy brak wpisu.
+            return
+
+
+__all__ = ["KeyringSecretStorage"]

--- a/bot_core/strategies/__init__.py
+++ b/bot_core/strategies/__init__.py
@@ -1,0 +1,5 @@
+"""Silniki strategii oraz optymalizacja."""
+
+from bot_core.strategies.base import MarketSnapshot, StrategyEngine, StrategySignal, WalkForwardOptimizer
+
+__all__ = ["MarketSnapshot", "StrategyEngine", "StrategySignal", "WalkForwardOptimizer"]

--- a/bot_core/strategies/base.py
+++ b/bot_core/strategies/base.py
@@ -1,0 +1,56 @@
+"""Interfejsy strategii oraz kontrakty walk-forward."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Mapping, Protocol, Sequence
+
+
+@dataclass(slots=True)
+class MarketSnapshot:
+    """Minimalny zestaw danych przekazywany do strategii."""
+
+    symbol: str
+    timestamp: int
+    close: float
+    indicators: Mapping[str, float]
+
+
+@dataclass(slots=True)
+class StrategySignal:
+    """Rezultat działania strategii (np. sygnał wejścia/wyjścia)."""
+
+    symbol: str
+    side: str
+    confidence: float
+    metadata: Mapping[str, float]
+
+
+class StrategyEngine(abc.ABC):
+    """Bazowy interfejs silników strategii."""
+
+    @abc.abstractmethod
+    def on_data(self, snapshot: MarketSnapshot) -> Sequence[StrategySignal]:
+        """Przetwarza nowy pakiet danych i zwraca sygnały."""
+
+    @abc.abstractmethod
+    def warm_up(self, history: Sequence[MarketSnapshot]) -> None:
+        """Pozwala przygotować wskaźniki przed startem live/paper."""
+
+
+class WalkForwardOptimizer(Protocol):
+    """Kontrakt dla optymalizatorów walk-forward."""
+
+    def split(self, data: Sequence[MarketSnapshot]) -> Sequence[tuple[Sequence[MarketSnapshot], Sequence[MarketSnapshot]]]:
+        ...
+
+    def select_parameters(self, in_sample: Sequence[MarketSnapshot]) -> Mapping[str, float]:
+        ...
+
+
+__all__ = [
+    "MarketSnapshot",
+    "StrategySignal",
+    "StrategyEngine",
+    "WalkForwardOptimizer",
+]

--- a/config/core.yaml
+++ b/config/core.yaml
@@ -1,0 +1,148 @@
+# Konfiguracja bazowa etapu 1 – wartości placeholder do dalszego dostosowania.
+
+risk_profiles:
+  conservative:
+    max_daily_loss_pct: 0.01
+    max_position_pct: 0.03
+    target_volatility: 0.07
+    max_leverage: 2.0
+    stop_loss_atr_multiple: 1.0
+    max_open_positions: 3
+    hard_drawdown_pct: 0.05
+  balanced:
+    max_daily_loss_pct: 0.015
+    max_position_pct: 0.05
+    target_volatility: 0.11
+    max_leverage: 3.0
+    stop_loss_atr_multiple: 1.5
+    max_open_positions: 5
+    hard_drawdown_pct: 0.10
+  aggressive:
+    max_daily_loss_pct: 0.03
+    max_position_pct: 0.10
+    target_volatility: 0.19
+    max_leverage: 5.0
+    stop_loss_atr_multiple: 2.0
+    max_open_positions: 10
+    hard_drawdown_pct: 0.20
+  manual:
+    max_daily_loss_pct: 0.0
+    max_position_pct: 0.0
+    target_volatility: 0.0
+    max_leverage: 0.0
+    stop_loss_atr_multiple: 0.0
+    max_open_positions: 0
+    hard_drawdown_pct: 0.0
+
+environments:
+  binance_paper:
+    exchange: binance_spot
+    environment: paper
+    keychain_key: binance_paper_trading
+    credential_purpose: trading
+    data_cache_path: ./var/data/binance_paper
+    risk_profile: balanced
+    alert_channels: ["telegram:primary", "email:ops"]
+    ip_allowlist: []
+  binance_live:
+    exchange: binance_spot
+    environment: live
+    keychain_key: binance_live_trading
+    data_cache_path: ./var/data/binance_live
+    risk_profile: conservative
+    alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
+    ip_allowlist: []
+  binance_futures_paper:
+    exchange: binance_futures
+    environment: paper
+    keychain_key: binance_futures_paper_trading
+    data_cache_path: ./var/data/binance_futures_paper
+    risk_profile: balanced
+    alert_channels: ["telegram:primary", "email:ops"]
+    ip_allowlist: []
+  binance_futures_live:
+    exchange: binance_futures
+    environment: live
+    keychain_key: binance_futures_live_trading
+    data_cache_path: ./var/data/binance_futures_live
+    risk_profile: conservative
+    alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
+    ip_allowlist: []
+  kraken_paper:
+    exchange: kraken_spot
+    environment: paper
+    keychain_key: kraken_paper_trading
+    data_cache_path: ./var/data/kraken_paper
+    risk_profile: balanced
+    alert_channels: ["telegram:primary", "email:ops"]
+    ip_allowlist: []
+  zonda_paper:
+    exchange: zonda_spot
+    environment: paper
+    keychain_key: zonda_paper_trading
+    data_cache_path: ./var/data/zonda_paper
+    risk_profile: conservative
+    alert_channels: ["telegram:primary"]
+    ip_allowlist: []
+
+reporting:
+  daily_report_time_utc: "21:00"
+  weekly_report_day: "sunday"
+  retention_months: "24"
+
+
+alerts:
+  telegram_channels:
+    primary:
+      chat_id: "123456789"
+      token_secret: telegram_primary_token
+      parse_mode: MarkdownV2
+  email_channels:
+    ops:
+      host: smtp.example.com
+      port: 587
+      from_address: bot@example.com
+      recipients:
+        - ops@example.com
+      credential_secret: smtp_ops_credentials
+      use_tls: true
+  sms_providers:
+    orange_local:
+      provider: orange_pl
+      api_base_url: https://api.orange.pl/sms/v1
+      from_number: "+48500100100"
+      recipients: ["+48555111222"]
+      allow_alphanumeric_sender: true
+      sender_id: "BOT-ORANGE"
+      credential_key: orange_sms_credentials
+    tmobile_local:
+      provider: tmobile_pl
+      api_base_url: https://api.t-mobile.pl/sms/v1
+      from_number: "+48500100101"
+      recipients: ["+48555111333"]
+      allow_alphanumeric_sender: true
+      sender_id: "BOT-TMOBILE"
+      credential_key: tmobile_sms_credentials
+    plus_local:
+      provider: plus_pl
+      api_base_url: https://api.plus.pl/messaging/v1
+      from_number: "+48500100102"
+      recipients: ["+48555111444"]
+      allow_alphanumeric_sender: false
+      credential_key: plus_sms_credentials
+    play_local:
+      provider: play_pl
+      api_base_url: https://api.play.pl/sms/v1
+      from_number: "+48500100103"
+      recipients: ["+48555111555"]
+      allow_alphanumeric_sender: true
+      sender_id: "BOT-PLAY"
+      credential_key: play_sms_credentials
+    nova_is:
+      provider: nova_is
+      api_base_url: https://api.nova.is/sms/v1
+      from_number: "+3546001001"
+      recipients: ["+3546601234"]
+      allow_alphanumeric_sender: true
+      sender_id: "BOT-NOVA"
+      credential_key: nova_sms_credentials

--- a/docs/architecture/phase1_foundation.md
+++ b/docs/architecture/phase1_foundation.md
@@ -1,0 +1,117 @@
+# Architektura rdzenia – etap 1
+
+Dokument opisuje modularną architekturę przygotowującą bota do integracji z Binance (spot + futures),
+Krakenem i Zondą. W pierwszym etapie budujemy szkielet umożliwiający bezpieczny rozwój bez licencji
+zewnętrznych, z jasnym podziałem na warstwy i środowiska.
+
+## Podział na moduły
+
+| Moduł | Odpowiedzialność | Kluczowe klasy/interfejsy |
+| --- | --- | --- |
+| `bot_core/exchanges` | Adaptery giełdowe z rozdzieleniem środowisk i uprawnień | `ExchangeAdapter`, `ExchangeCredentials`, `BinanceSpotAdapter`, `BinanceFuturesAdapter` |
+| `bot_core/data` | Pobieranie, normalizacja i cache danych OHLCV | `DataSource`, `CachedOHLCVSource`, `PublicAPIDataSource` |
+| `bot_core/strategies` | Silnik strategii i walk-forward | `StrategyEngine`, `MarketSnapshot`, `StrategySignal`, `WalkForwardOptimizer` |
+| `bot_core/risk` | Profile i enforcement limitów ryzyka | `RiskProfile`, `RiskEngine`, `RiskCheckResult`, profile konserwatywny/zbalansowany/agresywny/ręczny |
+| `bot_core/execution` | Warstwa składania zleceń z retry/backoff | `ExecutionService`, `ExecutionContext`, `RetryPolicy` |
+| `bot_core/alerts` | Wspólne API alertów i kanały powiadomień | `AlertChannel`, `AlertRouter`, kanały `TelegramChannel`, `EmailChannel`, `SMSChannel` |
+| `bot_core/config` | Ładowanie konfiguracji i mapowanie na dataclasses | `CoreConfig`, `EnvironmentConfig`, `RiskProfileConfig`, `load_core_config` |
+| `bot_core/security` | Bezpieczne przechowywanie kluczy API i integracja z keychainami | `SecretManager`, `KeyringSecretStorage` |
+
+Adaptery `BinanceSpotAdapter` oraz `BinanceFuturesAdapter` obsługują dane publiczne (lista symboli,
+świece OHLCV) oraz podpisane wywołania konta i składania/anulowania zleceń. Wspierają separację
+środowisk (`live`/`paper`/`testnet`), podpis HMAC SHA-256 oraz kontrolę uprawnień (`read`/`trade`).
+Wersja futures korzysta z endpointów USD-M, wymaga jawnego podania symbolu przy anulowaniu i
+odczytuje metryki marginesu z `totalMarginBalance`/`totalAvailableBalance`. Testy jednostkowe
+potwierdzają poprawność podpisów i mapowania odpowiedzi.
+
+## Warstwa konfiguracji
+
+Plik `config/core.yaml` przechowuje:
+
+- parametry profili ryzyka (zgodne z wymaganiami: dzienne limity strat, ATR, dźwignia, liczba pozycji,
+  hard-stop drawdown),
+- definicje środowisk (paper/live/testnet) wraz z kluczami do menedżera sekretów, nazwą wpisu w
+  keychainie (`credential_purpose`), ścieżkami cache i listą kanałów alertów,
+- ustawienia raportowania (czas dziennych/tygodniowych raportów, retencja logów).
+
+Loader `load_core_config` mapuje YAML na dataclasses i zapewnia konwersję pól liczbowych oraz
+walidację środowiska poprzez `Environment` enum. Dzięki temu logika aplikacji otrzymuje w pełni
+ustrukturyzowany obiekt konfiguracyjny.
+
+### Bootstrap środowiska
+
+Nowy moduł `bot_core/runtime/bootstrap.py` dostarcza funkcję `bootstrap_environment`, która w oparciu
+o `core.yaml` i `SecretManager` buduje kompletny kontekst uruchomieniowy (`BootstrapContext`). W jego
+skład wchodzą: zainicjalizowany adapter giełdowy (z fabryki dopasowanej do `exchange`), zarejestrowany
+profil ryzyka w `ThresholdRiskEngine`, skonfigurowany router alertów z kanałami Telegram/E-mail/SMS
+oraz dziennik audytu. Dzięki temu pojedyncze środowisko (paper/live/testnet) można uruchomić w sposób
+deterministyczny, a desktopowy interfejs w kolejnych etapach będzie mógł komunikować się z core przez
+prostą warstwę IPC, korzystając z gotowego kontekstu.
+
+## Środowiska i separacja uprawnień
+
+Każdy adapter giełdowy otrzymuje `ExchangeCredentials` z informacją o środowisku (live/paper/testnet)
+oraz zakresem uprawnień. Struktura przygotowuje grunt pod rozdzielenie kluczy `read-only` i `trading`
+w Windows Credential Manager/macOS Keychain/Linux keyring (`keychain_key` w konfiguracji). Metoda
+`configure_network` umożliwi egzekwowanie IP allowlist.
+
+## Dane rynkowe
+
+`PublicAPIDataSource` zostanie połączony z adapterami do pobierania danych OHLCV z publicznych API.
+`CachedOHLCVSource` w połączeniu z `OHLCVBackfillService` obsługuje proces „backfill + cache” z
+podziałem na okna czasowe oraz deduplikacją zapisów. Domyślny backend `SQLiteCacheStorage`
+przechowuje dane w pliku `ohlcv.sqlite` (tryb WAL) i udostępnia metadane do audytu. Dla użytkownika
+końcowego przygotowano skrypt `scripts/backfill_ohlcv.py`, który na podstawie `config/core.yaml`
+pobiera świece z Binance i aktualizuje lokalny cache w trybie bezkosztowym.
+
+## Strategie i walk-forward
+
+`StrategyEngine` definiuje kontrakt odbierania snapshotów rynkowych oraz generowania sygnałów. W
+kolejnych iteracjach zaimplementujemy strategię trend-following D1 i momentum breakout z możliwością
+walk-forward (`WalkForwardOptimizer`). Interfejsy są przygotowane pod rozszerzenia (mean reversion,
+arbitraż, itp.).
+
+## Zarządzanie ryzykiem
+
+`RiskProfile` i `ThresholdRiskEngine` egzekwują dzienny limit straty, liczbę równoległych pozycji,
+dźwignię, ekspozycję per instrument oraz hard-stop drawdown. Dostępne są cztery gotowe profile
+(konserwatywny, zbalansowany, agresywny, manualny) odwzorowujące wymagane parametry. Silnik
+utrzymuje stan w repozytorium (`RiskRepository`), kontroluje reset doby w UTC, wymusza tryb
+awaryjny po przekroczeniu limitów i wskazuje dopuszczalną maksymalną wielkość zlecenia.
+
+## Bezpieczeństwo i przechowywanie sekretów
+
+Warstwa `bot_core/security` dostarcza `SecretManager`, który serializuje poświadczenia giełdowe i
+umieszcza je w natywnym keychainie systemu operacyjnego poprzez `KeyringSecretStorage`. Dzięki
+temu klucze API są składowane poza repozytorium kodu, z rozdzieleniem środowisk i uprawnień.
+Manager pilnuje zgodności środowiska (paper/live/testnet) oraz pozwala na wielokrotne
+zapisanie/rotację kluczy bez ręcznych zmian w konfiguracji YAML. W środowiskach headless można
+docelowo podmienić implementację `SecretStorage` na wariant oparty o zaszyfrowany plik (np. `age`).
+
+## Egzekucja
+
+`ExecutionService` definiuje pełny cykl życia zlecenia z kontekstem (`ExecutionContext`) zawierającym
+informacje o profilu ryzyka i środowisku. Interfejs `RetryPolicy` pozwoli na polityki zależne od
+błędów API (np. exponential backoff, circuit breaker). Pierwszą implementacją jest
+`PaperTradingExecutionService`, który symuluje egzekucję z natychmiastowym fill'em,
+uwzględnia prowizje maker/taker, poślizg (w punktach bazowych), walidację wielkości zlecenia oraz
+prowadzi dziennik audytowy transakcji.
+
+## Alerty i obserwowalność
+
+`AlertChannel` i `AlertRouter` zapewniają jednolite API dla powiadomień (Telegram, e-mail, SMS, a w
+przyszłości Signal/WhatsApp/Messenger). Implementacja `DefaultAlertRouter` obsługuje audyt (`InMemoryAlertAuditLog`),
+kontynuuje wysyłkę pomimo błędów pojedynczych kanałów i zwraca migawkę `health_check` do monitoringu SLO.
+Adaptery kanałów posiadają zabezpieczenia (timeouty, logowanie błędów, walidację odpowiedzi API) oraz
+formatowanie wiadomości z kontekstem ryzyka i znacznikami czasu UTC.
+
+## Kolejne kroki implementacyjne
+
+1. Rozszerzyć system alertów o kolejne kanały komunikatorów (Signal/WhatsApp/Messenger) oraz mechanizm
+   throttle/acknowledgement dla krytycznych incydentów.
+2. Podłączyć metryki Prometheus (latencja wysyłek, error rate) i dashboard zgodny z wymaganiami SLO.
+3. Ustandaryzować eksport audytu do formatu Parquet/CSV z podpisem kryptograficznym oraz przygotować
+   rotację logów zgodną z polityką 24–60 miesięcy.
+4. Zintegrować alerty z planowanym modułem raportowania dziennego/tygodniowego.
+
+Dokument będzie aktualizowany wraz z postępem implementacji kolejnych modułów.

--- a/scripts/backfill_ohlcv.py
+++ b/scripts/backfill_ohlcv.py
@@ -1,0 +1,158 @@
+"""Uruchamia proces backfillu OHLCV zgodny z architekturą etapu 1."""
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Sequence
+
+from bot_core.config.loader import load_core_config
+from bot_core.data.ohlcv import (
+    OHLCVBackfillService,
+    CachedOHLCVSource,
+    PublicAPIDataSource,
+    SQLiteCacheStorage,
+)
+from bot_core.exchanges.base import Environment, ExchangeCredentials
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _parse_timestamp(value: str) -> int:
+    """Zamienia wejście użytkownika na timestamp w milisekundach (UTC)."""
+
+    value = value.strip()
+    if value.isdigit():
+        return int(value)
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - walidacja wejścia
+        raise argparse.ArgumentTypeError(
+            "Użyj formatu ISO (YYYY-MM-DD) lub liczby milisekund od epochy."
+        ) from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _build_adapter(exchange: str, environment: Environment) -> PublicAPIDataSource:
+    """Zwraca adapter publicznego API dla wskazanej giełdy."""
+
+    builders: dict[str, Callable[[Environment], PublicAPIDataSource]] = {
+        "binance_spot": lambda env: PublicAPIDataSource(
+            exchange_adapter=BinanceSpotAdapter(
+                ExchangeCredentials(key_id="public", environment=env)
+            )
+        )
+    }
+
+    try:
+        builder = builders[exchange]
+    except KeyError as exc:  # pragma: no cover - zabezpieczenie przyszłych rozszerzeń
+        raise ValueError(f"Brak obsługi exchange={exchange} w procesie backfillu") from exc
+
+    return builder(environment)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Backfill danych OHLCV z publicznych API")
+    parser.add_argument(
+        "--config",
+        default="config/core.yaml",
+        help="Ścieżka do pliku konfiguracji",
+    )
+    parser.add_argument(
+        "--environment",
+        default="binance_paper",
+        help="Nazwa środowiska z konfiguracji",
+    )
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        default=(
+            "BTCUSDT",
+            "ETHUSDT",
+            "BTCEUR",
+            "ETHEUR",
+            "SOLUSDT",
+            "BNBUSDT",
+            "XRPUSDT",
+            "ADAUSDT",
+            "LTCUSDT",
+            "MATICUSDT",
+        ),
+        help="Lista symboli do backfillu",
+    )
+    parser.add_argument("--interval", default="1d", help="Interwał (np. 1d, 1h)")
+    parser.add_argument("--start", required=True, type=_parse_timestamp, help="Początek zakresu")
+    parser.add_argument(
+        "--end",
+        type=_parse_timestamp,
+        help="Koniec zakresu (domyślnie teraz)",
+    )
+    parser.add_argument(
+        "--chunk-limit",
+        type=int,
+        default=1000,
+        help="Liczba świec pobieranych jednorazowo (maks. limit API)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Poziom logowania",
+    )
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+
+    config = load_core_config(args.config)
+    try:
+        env_cfg = config.environments[args.environment]
+    except KeyError as exc:
+        raise SystemExit(f"Nie znaleziono środowiska {args.environment} w konfiguracji") from exc
+
+    storage_path = Path(env_cfg.data_cache_path) / "ohlcv.sqlite"
+    storage = SQLiteCacheStorage(storage_path)
+
+    upstream_source = _build_adapter(env_cfg.exchange, env_cfg.environment)
+    upstream_source.exchange_adapter.configure_network(ip_allowlist=env_cfg.ip_allowlist)
+
+    cached_source = CachedOHLCVSource(storage=storage, upstream=upstream_source)
+    backfill_service = OHLCVBackfillService(cached_source, chunk_limit=args.chunk_limit)
+
+    end_ts = args.end or int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+    _LOGGER.info(
+        "Rozpoczynam backfill: env=%s, interval=%s, start=%s, end=%s, symbole=%s",
+        args.environment,
+        args.interval,
+        args.start,
+        end_ts,
+        ",".join(args.symbols),
+    )
+
+    summaries = backfill_service.synchronize(
+        symbols=tuple(args.symbols),
+        interval=args.interval,
+        start=args.start,
+        end=end_ts,
+    )
+
+    for summary in summaries:
+        _LOGGER.info(
+            "Symbol %s (%s): pobrano %s nowych świec (pominięto %s).",
+            summary.symbol,
+            summary.interval,
+            summary.fetched_candles,
+            summary.skipped_candles,
+        )
+
+    _LOGGER.info("Backfill zakończony – łączna liczba symboli: %s", len(summaries))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - punkt wejścia CLI
+    raise SystemExit(main())

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,242 @@
+"""Testy modułu alertów."""
+from __future__ import annotations
+
+import base64
+from email.message import EmailMessage
+from pathlib import Path
+from typing import List
+from urllib import request
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from bot_core.alerts import (
+    AlertDeliveryError,
+    AlertMessage,
+    DefaultAlertRouter,
+    EmailChannel,
+    InMemoryAlertAuditLog,
+    SMSChannel,
+    TelegramChannel,
+    DEFAULT_SMS_PROVIDERS,
+    get_sms_provider,
+)
+from bot_core.alerts.base import AlertChannel
+
+
+class DummyChannel(AlertChannel):
+    name = "dummy"
+
+    def __init__(self) -> None:
+        self.messages: List[AlertMessage] = []
+
+    def send(self, message: AlertMessage) -> None:
+        self.messages.append(message)
+
+    def health_check(self) -> dict[str, str]:
+        return {"status": "ok", "delivered": str(len(self.messages))}
+
+
+class FailingChannel(AlertChannel):
+    name = "failing"
+
+    def send(self, message: AlertMessage) -> None:  # noqa: ARG002 - interfejs wymaga parametru
+        raise AlertDeliveryError("celowy błąd")
+
+    def health_check(self) -> dict[str, str]:
+        return {"status": "error"}
+
+
+@pytest.fixture()
+def sample_message() -> AlertMessage:
+    return AlertMessage(
+        category="risk",
+        title="Limit ryzyka osiągnięty",
+        body="Dzienne straty przekroczyły próg.",
+        severity="critical",
+        context={"profile": "conservative", "instrument": "BTC/USDT"},
+    )
+
+
+def test_router_dispatch_records_audit(sample_message: AlertMessage) -> None:
+    audit = InMemoryAlertAuditLog()
+    router = DefaultAlertRouter(audit_log=audit)
+    channel = DummyChannel()
+    router.register(channel)
+
+    router.dispatch(sample_message)
+
+    assert channel.messages == [sample_message]
+    exported = tuple(audit.export())
+    assert len(exported) == 1
+    assert exported[0]["channel"] == "dummy"
+
+
+def test_router_continues_on_error(sample_message: AlertMessage, caplog: pytest.LogCaptureFixture) -> None:
+    audit = InMemoryAlertAuditLog()
+    router = DefaultAlertRouter(audit_log=audit)
+    router.register(FailingChannel())
+    router.register(DummyChannel())
+
+    router.dispatch(sample_message)
+
+    exported = tuple(audit.export())
+    assert len(exported) == 1
+    assert exported[0]["channel"] == "dummy"
+    assert any("Część kanałów zgłosiła błędy" in record.message for record in caplog.records)
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status: int, payload: bytes) -> None:
+        self.status = status
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def getcode(self) -> int:
+        return self.status
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401, ANN001
+        return None
+
+
+def test_telegram_channel_sends_payload(sample_message: AlertMessage) -> None:
+    captured: dict[str, request.Request] = {}
+
+    def opener(req: request.Request, *, timeout: float):  # noqa: ANN001
+        captured["request"] = req
+        return _FakeHTTPResponse(200, b"{\"ok\": true}")
+
+    channel = TelegramChannel(bot_token="token", chat_id="chat", _opener=opener)
+    channel.send(sample_message)
+
+    sent_request = captured["request"]
+    assert sent_request.full_url.endswith("/sendMessage")
+    body = sent_request.data.decode("utf-8")
+    assert "chat" in body
+    assert "Limit ryzyka" in body
+    assert channel.health_check()["status"] == "ok"
+
+
+class _FakeSMTP:
+    def __init__(self, host: str, port: int, timeout: float) -> None:  # noqa: D401
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.sent: list[EmailMessage] = []
+
+    def __enter__(self) -> "_FakeSMTP":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401, ANN001
+        return None
+
+    def ehlo(self) -> None:
+        return None
+
+    def starttls(self) -> None:
+        return None
+
+    def login(self, username: str, password: str) -> None:  # noqa: D401
+        self.username = username
+        self.password = password
+
+    def send_message(self, message: EmailMessage) -> None:
+        self.sent.append(message)
+
+
+def test_email_channel_builds_message(sample_message: AlertMessage) -> None:
+    fake_smtp = _FakeSMTP("localhost", 25, timeout=5)
+
+    def factory(host: str, port: int, timeout: float) -> _FakeSMTP:  # noqa: ANN001
+        assert host == "localhost"
+        assert port == 25
+        assert timeout == 5
+        return fake_smtp
+
+    channel = EmailChannel(
+        host="localhost",
+        port=25,
+        from_address="bot@example.com",
+        recipients=["user@example.com"],
+        username="user",
+        password="secret",
+        use_tls=True,
+        timeout=5,
+        _smtp_factory=factory,  # type: ignore[arg-type]
+    )
+
+    channel.send(sample_message)
+
+    assert len(fake_smtp.sent) == 1
+    email = fake_smtp.sent[0]
+    assert email["Subject"] == "[CRITICAL] Limit ryzyka osiągnięty"
+    assert "Dzienne straty" in email.get_content()
+    assert channel.health_check()["status"] == "ok"
+
+
+def test_sms_channel_sends_to_all_recipients(sample_message: AlertMessage) -> None:
+    captured_requests: list[request.Request] = []
+
+    def opener(req: request.Request, *, timeout: float):  # noqa: ANN001
+        captured_requests.append(req)
+        return _FakeHTTPResponse(201, b"{}")
+
+    channel = SMSChannel(
+        account_sid="AC123",
+        auth_token="token",
+        from_number="123",
+        recipients=("+48111222333", "+3546600000"),
+        _opener=opener,
+    )
+
+    channel.send(sample_message)
+
+    assert len(captured_requests) == 2
+    first_request = captured_requests[0]
+    assert first_request.data is not None
+    decoded_body = first_request.data.decode("utf-8")
+    assert "To=%2B48111222333" in decoded_body
+    auth_header = first_request.get_header("Authorization")
+    assert auth_header is not None
+    decoded_auth = base64.b64decode(auth_header.split()[1]).decode("utf-8")
+    assert decoded_auth == "AC123:token"
+    assert channel.health_check()["status"] == "ok"
+
+
+def test_default_sms_providers_cover_regions() -> None:
+    required = {"orange_pl", "tmobile_pl", "plus_pl", "play_pl", "nova_is"}
+    assert required.issubset(DEFAULT_SMS_PROVIDERS.keys())
+
+
+def test_sms_channel_uses_provider_metadata(sample_message: AlertMessage) -> None:
+    captured = []
+
+    def opener(req: request.Request, *, timeout: float):  # noqa: ANN001
+        captured.append(req)
+        return _FakeHTTPResponse(200, b"{}")
+
+    provider = get_sms_provider("orange_pl")
+    channel = SMSChannel(
+        account_sid="AC456",
+        auth_token="token",
+        from_number="123",
+        recipients=("+48555111222",),
+        provider=provider,
+        _opener=opener,
+    )
+
+    channel.send(sample_message)
+
+    assert captured
+    assert captured[0].full_url.startswith(provider.api_base_url)
+    health = channel.health_check()
+    assert health["provider"] == "orange_pl"
+    assert health["country"] == "PL"

--- a/tests/test_binance_futures_adapter.py
+++ b/tests/test_binance_futures_adapter.py
@@ -1,0 +1,199 @@
+"""Testy jednostkowe adaptera Binance Futures."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.request import Request
+
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeCredentials, OrderRequest
+from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_fetch_account_snapshot_parses_assets(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "assets": [
+                {"asset": "USDT", "walletBalance": "120.5"},
+                {"asset": "BUSD", "walletBalance": "50"},
+            ],
+            "totalMarginBalance": "180.5",
+            "totalAvailableBalance": "150.5",
+            "totalMaintMargin": "12.0",
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="futures-key",
+        secret="secret",
+        permissions=("read", "trade"),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    snapshot = adapter.fetch_account_snapshot()
+
+    assert isinstance(snapshot, AccountSnapshot)
+    assert snapshot.balances["USDT"] == pytest.approx(120.5)
+    assert snapshot.balances["BUSD"] == pytest.approx(50.0)
+    assert snapshot.total_equity == pytest.approx(180.5)
+    assert snapshot.available_margin == pytest.approx(150.5)
+    assert snapshot.maintenance_margin == pytest.approx(12.0)
+    assert captured_request is not None
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "futures-key"
+    assert "signature=" in captured_request.full_url
+    assert captured_request.full_url.startswith("https://fapi.binance.com/fapi/v2/account")
+
+
+def test_place_order_builds_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "orderId": 999,
+            "status": "NEW",
+            "executedQty": "0",
+            "avgPrice": "0",
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.time.time", lambda: 1_700_000_100.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    order_request = OrderRequest(
+        symbol="BTCUSDT",
+        side="sell",
+        quantity=0.05,
+        order_type="limit",
+        price=25_000,
+        time_in_force="GTC",
+        client_order_id="abc-123",
+    )
+
+    result = adapter.place_order(order_request)
+
+    assert result.order_id == "999"
+    assert result.status == "NEW"
+    assert result.filled_quantity == pytest.approx(0)
+    assert result.avg_price is None
+    assert captured_request is not None
+    assert captured_request.get_method() == "POST"
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "key"
+    body = captured_request.data.decode("utf-8") if captured_request.data else ""
+    expected_prefix = (
+        "symbol=BTCUSDT&side=SELL&type=LIMIT&quantity=0.05&price=25000&timeInForce=GTC&newClientOrderId=abc-123"
+    )
+    assert body.startswith(expected_prefix)
+    assert "signature=" in body
+    assert captured_request.full_url.startswith("https://fapi.binance.com/fapi/v1/order")
+
+
+def test_cancel_order_requires_symbol() -> None:
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    with pytest.raises(ValueError):
+        adapter.cancel_order("1")
+
+
+def test_cancel_order_uses_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {"status": "CANCELED"}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.time.time", lambda: 1_700_000_200.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    adapter.cancel_order("42", symbol="BTCUSDT")
+
+    assert captured_request is not None
+    assert captured_request.get_method() == "DELETE"
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "key"
+    url = captured_request.full_url
+    assert url.startswith("https://fapi.binance.com/fapi/v1/order")
+    assert "symbol=BTCUSDT" in url
+    assert "orderId=42" in url
+    assert "signature=" in url
+
+
+def test_fetch_symbols_filters_non_trading(monkeypatch: pytest.MonkeyPatch) -> None:
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("read",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    payload = {
+        "symbols": [
+            {"symbol": "BTCUSDT", "status": "TRADING", "contractType": "PERPETUAL"},
+            {"symbol": "ETHUSDT", "status": "TRADING", "contractType": "CURRENT_QUARTER"},
+            {"symbol": "BAD", "status": "HALT"},
+            {"symbol": None, "status": "TRADING"},
+        ]
+    }
+
+    monkeypatch.setattr(adapter, "_public_request", lambda path, params=None, method="GET": payload)
+
+    symbols = list(adapter.fetch_symbols())
+
+    assert symbols == ["BTCUSDT", "ETHUSDT"]
+

--- a/tests/test_binance_spot_adapter.py
+++ b/tests/test_binance_spot_adapter.py
@@ -1,0 +1,150 @@
+"""Testy jednostkowe adaptera Binance Spot."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.request import Request
+
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeCredentials, OrderRequest
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_fetch_account_snapshot_parses_balances(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "balances": [
+                {"asset": "BTC", "free": "0.5", "locked": "0.1"},
+                {"asset": "USDT", "free": "100", "locked": "0"},
+            ],
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="test-key",
+        secret="secret",
+        permissions=("read", "trade"),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceSpotAdapter(credentials)
+
+    snapshot = adapter.fetch_account_snapshot()
+
+    assert isinstance(snapshot, AccountSnapshot)
+    assert snapshot.balances["BTC"] == pytest.approx(0.6)
+    assert snapshot.balances["USDT"] == pytest.approx(100.0)
+    assert snapshot.total_equity == pytest.approx(100.6)
+    assert snapshot.available_margin == pytest.approx(100.5)
+    assert captured_request is not None
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "test-key"
+    assert "signature=" in captured_request.full_url
+
+
+def test_place_order_builds_signed_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "orderId": 12345,
+            "status": "NEW",
+            "executedQty": "0",
+            "price": "0",
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceSpotAdapter(credentials)
+
+    order_request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.01,
+        order_type="limit",
+        price=20_000,
+        time_in_force="GTC",
+        client_order_id="cli-1",
+    )
+
+    result = adapter.place_order(order_request)
+
+    assert result.order_id == "12345"
+    assert result.status == "NEW"
+    assert result.filled_quantity == pytest.approx(0)
+    assert result.avg_price is None
+    assert captured_request is not None
+    assert captured_request.get_method() == "POST"
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "key"
+    body = captured_request.data.decode("utf-8") if captured_request.data else ""
+    expected_prefix = "symbol=BTCUSDT&side=BUY&type=LIMIT&quantity=0.01&price=20000&timeInForce=GTC&newClientOrderId=cli-1&timestamp=1700000000000"
+    assert body.startswith(expected_prefix)
+    assert "signature=" in body
+
+
+def test_cancel_order_uses_delete_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {"status": "CANCELED"}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceSpotAdapter(credentials)
+
+    adapter.cancel_order("123", symbol="BTCUSDT")
+
+    assert captured_request is not None
+    assert captured_request.get_method() == "DELETE"
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "key"
+    assert "symbol=BTCUSDT" in captured_request.full_url
+    assert "orderId=123" in captured_request.full_url
+    assert "signature=" in captured_request.full_url

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,67 @@
+"""Testy ładowania konfiguracji."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.config import SMSProviderSettings, load_core_config
+
+
+def test_load_core_config_reads_sms_providers(tmp_path: Path) -> None:
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(
+        """
+        risk_profiles: {}
+        environments: {}
+        reporting: {}
+        alerts:
+          sms_providers:
+            orange_local:
+              provider: orange_pl
+              api_base_url: https://api.orange.pl/sms/v1
+              from_number: "+48500100100"
+              recipients: ["+48555111222"]
+              allow_alphanumeric_sender: true
+              sender_id: BOT-ORANGE
+              credential_key: orange_sms_credentials
+          telegram_channels:
+            primary:
+              chat_id: "123456789"
+              token_secret: telegram_primary_token
+              parse_mode: MarkdownV2
+          email_channels:
+            ops:
+              host: smtp.example.com
+              port: 587
+              from_address: bot@example.com
+              recipients: ["ops@example.com"]
+              credential_secret: smtp_ops_credentials
+              use_tls: true
+        """,
+        encoding="utf-8",
+    )
+
+    config = load_core_config(config_path)
+
+    assert "orange_local" in config.sms_providers
+    provider = config.sms_providers["orange_local"]
+    assert isinstance(provider, SMSProviderSettings)
+    assert provider.provider_key == "orange_pl"
+    assert provider.api_base_url == "https://api.orange.pl/sms/v1"
+    assert provider.allow_alphanumeric_sender is True
+    assert provider.sender_id == "BOT-ORANGE"
+    assert provider.credential_key == "orange_sms_credentials"
+    assert "primary" in config.telegram_channels
+    telegram = config.telegram_channels["primary"]
+    assert telegram.chat_id == "123456789"
+    assert telegram.token_secret == "telegram_primary_token"
+    assert telegram.parse_mode == "MarkdownV2"
+    email = config.email_channels["ops"]
+    assert email.host == "smtp.example.com"
+    assert email.port == 587
+    assert email.from_address == "bot@example.com"
+    assert email.recipients == ("ops@example.com",)
+    assert email.credential_secret == "smtp_ops_credentials"
+    assert email.use_tls is True

--- a/tests/test_ohlcv_backfill.py
+++ b/tests/test_ohlcv_backfill.py
@@ -1,0 +1,108 @@
+"""Testy procesu backfillu OHLCV."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.data.base import CacheStorage, DataSource, OHLCVRequest, OHLCVResponse
+from bot_core.data.ohlcv.backfill import OHLCVBackfillService
+from bot_core.data.ohlcv.cache import CachedOHLCVSource
+
+
+class InMemoryStorage(CacheStorage):
+    """Prosta pamięciowa implementacja magazynu do testów."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, Mapping[str, Sequence[Sequence[float]]]] = {}
+        self._metadata: dict[str, str] = {}
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        if key not in self._store:
+            raise KeyError(key)
+        return self._store[key]
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        self._store[key] = payload
+
+    def metadata(self) -> MutableMapping[str, str]:
+        return self._metadata
+
+    def latest_timestamp(self, key: str) -> float | None:
+        try:
+            rows = self._store[key]["rows"]
+        except KeyError:
+            return None
+        if not rows:
+            return None
+        return float(rows[-1][0])
+
+
+@dataclass(slots=True)
+class StubSource(DataSource):
+    """Źródło danych generujące deterministyczne świece dla testów."""
+
+    interval_ms: int
+
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        rows: list[Sequence[float]] = []
+        current = request.start
+        limit = request.limit or 1000
+        while current <= request.end and len(rows) < limit:
+            rows.append([float(current), 1.0, 2.0, 0.5, 1.5, 10.0])
+            current += self.interval_ms
+        return OHLCVResponse(columns=("open_time", "open", "high", "low", "close", "volume"), rows=rows)
+
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:  # pragma: no cover
+        del symbols, intervals
+
+
+def test_backfill_downloads_missing_candles() -> None:
+    storage = InMemoryStorage()
+    cached = CachedOHLCVSource(storage=storage, upstream=StubSource(interval_ms=86_400_000))
+    service = OHLCVBackfillService(cached, chunk_limit=2)
+
+    summaries = service.synchronize(
+        symbols=("BTCUSDT",),
+        interval="1d",
+        start=0,
+        end=86_400_000 * 4,
+    )
+
+    summary = summaries[0]
+    assert summary.fetched_candles == 5
+    assert summary.skipped_candles == 0
+
+
+def test_backfill_skips_up_to_date_symbol() -> None:
+    storage = InMemoryStorage()
+    # Wstępnie zapisujemy trzy świece
+    storage.write(
+        "BTCUSDT::1d",
+        {
+            "columns": ("open_time", "open", "high", "low", "close", "volume"),
+            "rows": [
+                [0.0, 1.0, 2.0, 0.5, 1.5, 10.0],
+                [86_400_000.0, 1.0, 2.0, 0.5, 1.5, 10.0],
+                [172_800_000.0, 1.0, 2.0, 0.5, 1.5, 10.0],
+            ],
+        },
+    )
+
+    cached = CachedOHLCVSource(storage=storage, upstream=StubSource(interval_ms=86_400_000))
+    service = OHLCVBackfillService(cached, chunk_limit=2)
+
+    summaries = service.synchronize(
+        symbols=("BTCUSDT",),
+        interval="1d",
+        start=0,
+        end=172_800_000,
+    )
+
+    summary = summaries[0]
+    assert summary.fetched_candles == 0
+    assert summary.skipped_candles == 3

--- a/tests/test_paper_execution.py
+++ b/tests/test_paper_execution.py
@@ -1,0 +1,124 @@
+"""Testy symulatora paper trading."""
+from __future__ import annotations
+
+import pytest
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.execution import (  # type: ignore[import-not-found]
+    ExecutionContext,
+    InsufficientBalanceError,
+    MarketMetadata,
+    PaperTradingExecutionService,
+)
+from bot_core.exchanges.base import OrderRequest
+
+
+def _default_service(**kwargs: object) -> PaperTradingExecutionService:
+    markets = {
+        "BTCUSDT": MarketMetadata(
+            base_asset="BTC",
+            quote_asset="USDT",
+            min_quantity=0.001,
+            min_notional=10.0,
+            step_size=0.001,
+        )
+    }
+    balances = {"USDT": 100_000.0, "BTC": 1.0}
+    return PaperTradingExecutionService(markets, initial_balances=balances, **kwargs)
+
+
+def _default_context() -> ExecutionContext:
+    return ExecutionContext(
+        portfolio_id="paper-1",
+        risk_profile="balanced",
+        environment="paper",
+        metadata={},
+    )
+
+
+def test_buy_order_consumes_quote_balance() -> None:
+    service = _default_service()
+    context = _default_context()
+    request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.5,
+        order_type="market",
+        price=20_000.0,
+    )
+
+    result = service.execute(request, context)
+
+    assert result.status == "filled"
+    balances = service.balances()
+    assert balances["BTC"] > 1.0
+    assert balances["USDT"] < 100_000.0
+
+
+def test_sell_requires_position() -> None:
+    service = _default_service()
+    context = _default_context()
+    request = OrderRequest(
+        symbol="BTCUSDT",
+        side="sell",
+        quantity=5.0,
+        order_type="market",
+        price=20_000.0,
+    )
+
+    with pytest.raises(InsufficientBalanceError):
+        service.execute(request, context)
+
+
+def test_slippage_affects_price_directionally() -> None:
+    service = _default_service(slippage_bps=10.0)
+    context = _default_context()
+
+    buy_request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.1,
+        order_type="market",
+        price=20_000.0,
+    )
+    sell_request = OrderRequest(
+        symbol="BTCUSDT",
+        side="sell",
+        quantity=0.1,
+        order_type="market",
+        price=20_000.0,
+    )
+
+    buy_result = service.execute(buy_request, context)
+    sell_result = service.execute(sell_request, context)
+
+    assert buy_result.avg_price and sell_result.avg_price
+    assert buy_result.avg_price > 20_000.0
+    assert sell_result.avg_price < 20_000.0
+
+
+def test_ledger_contains_audit_entries() -> None:
+    service = _default_service()
+    context = _default_context()
+
+    service.execute(
+        OrderRequest(
+            symbol="BTCUSDT",
+            side="buy",
+            quantity=0.2,
+            order_type="limit",
+            price=19_500.0,
+        ),
+        context,
+    )
+
+    entries = list(service.ledger())
+    assert entries
+    first = entries[0]
+    assert first["symbol"] == "BTCUSDT"
+    assert first["status"] == "filled"
+    assert first["fee"] > 0

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.alerts import EmailChannel, SMSChannel, TelegramChannel
+from bot_core.exchanges.base import AccountSnapshot, Environment, OrderRequest
+from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.runtime import BootstrapContext, bootstrap_environment
+from bot_core.security import SecretManager, SecretStorage
+
+
+class _MemorySecretStorage(SecretStorage):
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    def get_secret(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    def set_secret(self, key: str, value: str) -> None:
+        self._store[key] = value
+
+    def delete_secret(self, key: str) -> None:
+        self._store.pop(key, None)
+
+
+def _write_config(tmp_path: Path) -> Path:
+    content = """
+    risk_profiles:
+      balanced:
+        max_daily_loss_pct: 0.015
+        max_position_pct: 0.05
+        target_volatility: 0.11
+        max_leverage: 3.0
+        stop_loss_atr_multiple: 1.5
+        max_open_positions: 5
+        hard_drawdown_pct: 0.10
+    environments:
+      binance_paper:
+        exchange: binance_spot
+        environment: paper
+        keychain_key: binance_paper_key
+        credential_purpose: trading
+        data_cache_path: ./var/data/binance_paper
+        risk_profile: balanced
+        alert_channels: ["telegram:primary", "email:ops", "sms:orange_local"]
+        ip_allowlist: ["127.0.0.1"]
+    reporting: {}
+    alerts:
+      telegram_channels:
+        primary:
+          chat_id: "123456789"
+          token_secret: telegram_token
+      email_channels:
+        ops:
+          host: smtp.example.com
+          port: 587
+          from_address: bot@example.com
+          recipients: ["ops@example.com"]
+          credential_secret: smtp_credentials
+      sms_providers:
+        orange_local:
+          provider: orange_pl
+          api_base_url: https://api.orange.pl/sms/v1
+          from_number: BOT-ORANGE
+          recipients: ["+48555111222"]
+          allow_alphanumeric_sender: true
+          sender_id: BOT-ORANGE
+          credential_key: sms_orange
+    """
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(content, encoding="utf-8")
+    return config_path
+
+
+def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
+    storage = _MemorySecretStorage()
+    manager = SecretManager(storage, namespace="tests")
+
+    config_path = _write_config(tmp_path)
+    credentials_payload = {
+        "key_id": "paper-key",
+        "secret": "paper-secret",
+        "passphrase": None,
+        "permissions": ["read", "trade"],
+        "environment": Environment.PAPER.value,
+    }
+    storage.set_secret("tests:binance_paper_key:trading", json.dumps(credentials_payload))
+    manager.store_secret_value("telegram_token", "telegram-secret", purpose="alerts:telegram")
+    manager.store_secret_value(
+        "smtp_credentials",
+        json.dumps({"username": "bot", "password": "secret"}),
+        purpose="alerts:email",
+    )
+    manager.store_secret_value(
+        "sms_orange",
+        json.dumps({"account_sid": "AC123", "auth_token": "token"}),
+        purpose="alerts:sms",
+    )
+
+    context = bootstrap_environment(
+        "binance_paper", config_path=config_path, secret_manager=manager
+    )
+
+    assert isinstance(context, BootstrapContext)
+    assert context.environment.name == "binance_paper"
+    assert context.credentials.key_id == "paper-key"
+    assert context.adapter.credentials.key_id == "paper-key"
+
+    assert isinstance(context.risk_engine, ThresholdRiskEngine)
+    result = context.risk_engine.apply_pre_trade_checks(
+        OrderRequest(symbol="BTCUSDT", side="buy", quantity=0.2, order_type="limit", price=100.0),
+        account=AccountSnapshot(
+            balances={"USDT": 1000.0},
+            total_equity=1000.0,
+            available_margin=1000.0,
+            maintenance_margin=0.0,
+        ),
+        profile_name="balanced",
+    )
+    assert result.allowed is True
+
+    assert set(context.alert_channels.keys()) == {
+        "telegram:primary",
+        "email:ops",
+        "sms:orange_local",
+    }
+    assert isinstance(context.alert_channels["telegram:primary"], TelegramChannel)
+    assert isinstance(context.alert_channels["email:ops"], EmailChannel)
+    assert isinstance(context.alert_channels["sms:orange_local"], SMSChannel)
+    assert len(context.alert_router.channels) == 3
+    assert context.alert_router.audit_log is context.audit_log
+
+    # Health check nie powinien zgłaszać wyjątków dla świeżo zainicjalizowanych kanałów.
+    snapshot = context.alert_router.health_snapshot()
+    assert snapshot["telegram:primary"]["status"] == "ok"
+
+    assert context.risk_engine.should_liquidate(profile_name="balanced") is False
+

--- a/tests/test_security_manager.py
+++ b/tests/test_security_manager.py
@@ -1,0 +1,118 @@
+"""Testy warstwy zarządzania sekretami wykorzystującej natywne keychainy."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import Environment, ExchangeCredentials
+from bot_core.security import KeyringSecretStorage, SecretManager, SecretStorageError
+
+
+class _InMemoryKeyring:
+    """Minimalna implementacja back-endu keyring na potrzeby testów."""
+
+    class errors:
+        class PasswordDeleteError(Exception):
+            """Wyjątek naśladujący oryginalny interfejs biblioteki keyring."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        try:
+            del self._store[(service, username)]
+        except KeyError as exc:
+            raise self.errors.PasswordDeleteError(str(exc)) from exc
+
+
+@pytest.fixture(autouse=True)
+def fake_keyring() -> types.ModuleType:
+    """Podmienia moduł ``keyring`` na wariant in-memory, aby testy były deterministyczne."""
+
+    module = types.ModuleType("keyring")
+    backend = _InMemoryKeyring()
+    module.get_password = backend.get_password
+    module.set_password = backend.set_password
+    module.delete_password = backend.delete_password
+    module.errors = backend.errors
+    sys.modules["keyring"] = module
+    yield module
+    sys.modules.pop("keyring", None)
+
+
+def test_roundtrip_store_and_load_credentials() -> None:
+    storage = KeyringSecretStorage(service_name="unit.test")
+    manager = SecretManager(storage, namespace="tests")
+
+    credentials = ExchangeCredentials(
+        key_id="abc",
+        secret="topsecret",
+        passphrase="phrase",
+        environment=Environment.PAPER,
+        permissions=("read", "trade"),
+    )
+
+    manager.store_exchange_credentials("binance_paper_trading", credentials)
+    loaded = manager.load_exchange_credentials(
+        "binance_paper_trading", expected_environment=Environment.PAPER
+    )
+
+    assert loaded.key_id == credentials.key_id
+    assert loaded.secret == credentials.secret
+    assert loaded.passphrase == credentials.passphrase
+    assert loaded.permissions == credentials.permissions
+    assert loaded.environment == Environment.PAPER
+
+
+def test_load_missing_secret_raises_error() -> None:
+    storage = KeyringSecretStorage(service_name="unit.test")
+    manager = SecretManager(storage)
+
+    with pytest.raises(SecretStorageError):
+        manager.load_exchange_credentials("missing", expected_environment=Environment.LIVE)
+
+
+def test_environment_mismatch_detected() -> None:
+    storage = KeyringSecretStorage(service_name="unit.test")
+    manager = SecretManager(storage)
+
+    credentials = ExchangeCredentials(
+        key_id="abc",
+        secret="topsecret",
+        passphrase=None,
+        environment=Environment.PAPER,
+        permissions=("read",),
+    )
+
+    manager.store_exchange_credentials("binance_paper", credentials)
+
+    with pytest.raises(SecretStorageError) as excinfo:
+        manager.load_exchange_credentials("binance_paper", expected_environment=Environment.LIVE)
+
+    assert "nie pasuje" in str(excinfo.value)
+
+
+def test_store_and_load_generic_secret() -> None:
+    storage = KeyringSecretStorage(service_name="unit.test")
+    manager = SecretManager(storage, namespace="tests")
+
+    manager.store_secret_value("telegram_bot", "token123", purpose="alerts")
+    loaded = manager.load_secret_value("telegram_bot", purpose="alerts")
+
+    assert loaded == "token123"
+
+    manager.delete_secret_value("telegram_bot", purpose="alerts")
+
+    with pytest.raises(SecretStorageError):
+        manager.load_secret_value("telegram_bot", purpose="alerts")


### PR DESCRIPTION
## Summary
- introduce a runtime bootstrap that loads exchange adapters, risk profiles and alert channels from configuration and the secret manager
- extend the configuration schema with telegram and email channel definitions, update the sample core.yaml and document the new bootstrap flow
- add generic secret helpers plus unit tests for the bootstrap and secret manager to cover the new paths

## Testing
- python -m compileall bot_core
- pytest tests/test_config_loader.py tests/test_security_manager.py tests/test_alerts.py tests/test_runtime_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68d7fdff8a58832aba7e15f29e548f4e