### PR TITLE
Add ticker-based valuation to Binance spot snapshot

### DIFF
--- a/tests/test_binance_spot_adapter.py
+++ b/tests/test_binance_spot_adapter.py
@@ -32,16 +32,26 @@ class _FakeResponse:
 
 def test_fetch_account_snapshot_parses_balances(monkeypatch: pytest.MonkeyPatch) -> None:
     captured_request: Request | None = None
+    ticker_requested = False
 
     def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
-        nonlocal captured_request
-        captured_request = request
-        payload = {
-            "balances": [
-                {"asset": "BTC", "free": "0.5", "locked": "0.1"},
-                {"asset": "USDT", "free": "100", "locked": "0"},
-            ],
-        }
+        nonlocal captured_request, ticker_requested
+        if "/api/v3/account" in request.full_url:
+            captured_request = request
+            payload: dict[str, Any] = {
+                "balances": [
+                    {"asset": "BTC", "free": "0.5", "locked": "0.1"},
+                    {"asset": "USDT", "free": "100", "locked": "0"},
+                ],
+            }
+        elif "/api/v3/ticker/price" in request.full_url:
+            ticker_requested = True
+            payload = [
+                {"symbol": "BTCUSDT", "price": "10000"},
+                {"symbol": "USDCUSDT", "price": "1"},
+            ]
+        else:  # pragma: no cover - zabezpieczenie dodatkowych endpointów
+            raise AssertionError(f"Unexpected endpoint requested: {request.full_url}")
         return _FakeResponse(payload)
 
     monkeypatch.setattr("bot_core.exchanges.binance.spot.urlopen", fake_urlopen)
@@ -60,12 +70,59 @@ def test_fetch_account_snapshot_parses_balances(monkeypatch: pytest.MonkeyPatch)
     assert isinstance(snapshot, AccountSnapshot)
     assert snapshot.balances["BTC"] == pytest.approx(0.6)
     assert snapshot.balances["USDT"] == pytest.approx(100.0)
-    assert snapshot.total_equity == pytest.approx(100.6)
-    assert snapshot.available_margin == pytest.approx(100.5)
+    assert snapshot.total_equity == pytest.approx(6100.0)
+    assert snapshot.available_margin == pytest.approx(5100.0)
+    assert ticker_requested is True
     assert captured_request is not None
     headers = {name.lower(): value for name, value in captured_request.header_items()}
     assert headers["x-mbx-apikey"] == "test-key"
     assert "signature=" in captured_request.full_url
+
+
+def test_fetch_account_snapshot_values_mixed_portfolio(monkeypatch: pytest.MonkeyPatch) -> None:
+    signed_request: Request | None = None
+    ticker_requested = False
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal signed_request, ticker_requested
+        if "/api/v3/account" in request.full_url:
+            signed_request = request
+            payload: dict[str, Any] = {
+                "balances": [
+                    {"asset": "BTC", "free": "0.2", "locked": "0"},
+                    {"asset": "USDT", "free": "50", "locked": "0"},
+                ]
+            }
+        elif "/api/v3/ticker/price" in request.full_url:
+            ticker_requested = True
+            payload = [
+                {"symbol": "BTCUSDC", "price": "27000"},
+                {"symbol": "USDCUSDT", "price": "1"},
+            ]
+        else:  # pragma: no cover - zabezpieczenie dodatkowych endpointów
+            raise AssertionError(f"Unexpected endpoint requested: {request.full_url}")
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="test-key",
+        secret="secret",
+        permissions=("read", "trade"),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceSpotAdapter(credentials)
+
+    snapshot = adapter.fetch_account_snapshot()
+
+    assert isinstance(snapshot, AccountSnapshot)
+    assert snapshot.balances["BTC"] == pytest.approx(0.2)
+    assert snapshot.balances["USDT"] == pytest.approx(50.0)
+    assert snapshot.total_equity == pytest.approx(5450.0)
+    assert snapshot.available_margin == pytest.approx(5450.0)
+    assert ticker_requested is True
+    assert signed_request is not None
 
 
 def test_place_order_builds_signed_payload(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- fetch Binance spot tickers when building account snapshots
- value balances in a common USDT currency with support for triangulation through stablecoins
- extend Binance spot adapter tests with valuation scenarios for mixed portfolios

## Testing
- pytest tests/test_binance_spot_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68d847bf531c832a957601352370b627