### PR TITLE
Add daily trend controller pipeline and integration test

### DIFF
--- a/bot_core/config/loader.py
+++ b/bot_core/config/loader.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 import yaml
 
 from bot_core.config.models import (
+    ControllerRuntimeConfig,
     CoreConfig,
     DailyTrendMomentumStrategyConfig,
     EmailChannelSettings,
@@ -156,6 +157,15 @@ def load_core_config(path: str | Path) -> CoreConfig:
         for name, entry in alerts.get("email_channels", {}).items()
     }
 
+    controllers_raw = raw.get("runtime", {}).get("controllers", {})
+    runtime_controllers = {
+        name: ControllerRuntimeConfig(
+            tick_seconds=float(entry.get("tick_seconds", entry.get("tick", 60.0))),
+            interval=str(entry.get("interval", "1d")),
+        )
+        for name, entry in controllers_raw.items()
+    }
+
     return CoreConfig(
         environments=environments,
         risk_profiles=risk_profiles,
@@ -165,6 +175,7 @@ def load_core_config(path: str | Path) -> CoreConfig:
         sms_providers=sms_providers,
         telegram_channels=telegram_channels,
         email_channels=email_channels,
+        runtime_controllers=runtime_controllers,
     )
 
 

--- a/bot_core/config/models.py
+++ b/bot_core/config/models.py
@@ -119,6 +119,14 @@ class EmailChannelSettings:
 
 
 @dataclass(slots=True)
+class ControllerRuntimeConfig:
+    """Parametry sterujące cyklem pracy kontrolerów runtime."""
+
+    tick_seconds: float
+    interval: str
+
+
+@dataclass(slots=True)
 class CoreConfig:
     """Najwyższego poziomu konfiguracja aplikacji."""
 
@@ -130,6 +138,7 @@ class CoreConfig:
     sms_providers: Mapping[str, SMSProviderSettings]
     telegram_channels: Mapping[str, TelegramChannelSettings]
     email_channels: Mapping[str, EmailChannelSettings]
+    runtime_controllers: Mapping[str, ControllerRuntimeConfig] = field(default_factory=dict)
 
 
 __all__ = [
@@ -142,5 +151,6 @@ __all__ = [
     "SMSProviderSettings",
     "TelegramChannelSettings",
     "EmailChannelSettings",
+    "ControllerRuntimeConfig",
     "CoreConfig",
 ]

--- a/bot_core/runtime/__init__.py
+++ b/bot_core/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Infrastruktura runtime nowej architektury bota."""
 
 from bot_core.runtime.bootstrap import BootstrapContext, bootstrap_environment
+from bot_core.runtime.controller import DailyTrendController
 
-__all__ = ["BootstrapContext", "bootstrap_environment"]
+__all__ = ["BootstrapContext", "bootstrap_environment", "DailyTrendController"]

--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1,0 +1,232 @@
+"""Kontroler łączący warstwę danych, strategię, ryzyko i egzekucję."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Mapping, Sequence
+
+from bot_core.config.models import CoreConfig, ControllerRuntimeConfig
+from bot_core.data.base import OHLCVRequest
+from bot_core.data.ohlcv.backfill import OHLCVBackfillService
+from bot_core.data.ohlcv.cache import CachedOHLCVSource
+from bot_core.execution.base import ExecutionContext, ExecutionService
+from bot_core.exchanges.base import AccountSnapshot, OrderRequest, OrderResult
+from bot_core.risk.base import RiskEngine
+from bot_core.strategies.base import MarketSnapshot, StrategySignal
+from bot_core.strategies.daily_trend import DailyTrendMomentumStrategy
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class DailyTrendController:
+    """Prosty kontroler realizujący cykl: backfill -> strategia -> ryzyko -> egzekucja."""
+
+    core_config: CoreConfig
+    environment_name: str
+    controller_name: str
+    symbols: Sequence[str]
+    backfill_service: OHLCVBackfillService
+    data_source: CachedOHLCVSource
+    strategy: DailyTrendMomentumStrategy
+    risk_engine: RiskEngine
+    execution_service: ExecutionService
+    account_loader: Callable[[], AccountSnapshot]
+    execution_context: ExecutionContext
+    position_size: float = 1.0
+    _environment: object = field(init=False, repr=False)
+    _runtime: ControllerRuntimeConfig = field(init=False, repr=False)
+    _risk_profile: str = field(init=False, repr=False)
+    _positions: dict[str, float] = field(init=False, repr=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.symbols:
+            raise ValueError("Wymagany jest przynajmniej jeden symbol do obsługi.")
+        try:
+            self._environment = self.core_config.environments[self.environment_name]
+        except KeyError as exc:
+            raise KeyError(f"Brak konfiguracji środowiska '{self.environment_name}' w CoreConfig") from exc
+        try:
+            self._runtime: ControllerRuntimeConfig = self.core_config.runtime_controllers[self.controller_name]
+        except KeyError as exc:
+            raise KeyError(f"Brak sekcji runtime dla kontrolera '{self.controller_name}' w CoreConfig") from exc
+        self._risk_profile = self._environment.risk_profile
+
+    @property
+    def tick_seconds(self) -> float:
+        """Częstotliwość wywołań kontrolera z konfiguracji."""
+
+        return self._runtime.tick_seconds
+
+    @property
+    def interval(self) -> str:
+        """Interwał OHLCV wykorzystywany przez kontroler."""
+
+        return self._runtime.interval
+
+    def run_cycle(self, *, start: int, end: int) -> list[OrderResult]:
+        """Przeprowadza pojedynczy cykl przetwarzania danych i składania zleceń."""
+
+        if start > end:
+            raise ValueError("Parametr start nie może być większy niż end")
+
+        self.backfill_service.synchronize(
+            symbols=self.symbols,
+            interval=self.interval,
+            start=start,
+            end=end,
+        )
+
+        executed: list[OrderResult] = []
+        for symbol in self.symbols:
+            response = self.data_source.fetch_ohlcv(
+                OHLCVRequest(symbol=symbol, interval=self.interval, start=start, end=end)
+            )
+            snapshots = self._to_snapshots(symbol, response.columns, response.rows)
+            for snapshot in snapshots:
+                signals = self.strategy.on_data(snapshot)
+                executed.extend(self._handle_signals(snapshot, signals))
+        return executed
+
+    # ------------------------------------------------------------------
+    # Metody pomocnicze
+    # ------------------------------------------------------------------
+    def _handle_signals(
+        self,
+        snapshot: MarketSnapshot,
+        signals: Sequence[StrategySignal],
+    ) -> list[OrderResult]:
+        results: list[OrderResult] = []
+        for signal in signals:
+            base_request = self._build_order_request(snapshot, signal)
+            account_snapshot = self.account_loader()
+            risk_result = self.risk_engine.apply_pre_trade_checks(
+                base_request,
+                account=account_snapshot,
+                profile_name=self._risk_profile,
+            )
+            if not risk_result.allowed:
+                _LOGGER.info(
+                    "Kontroler %s: sygnał %s dla %s odrzucony przez silnik ryzyka (%s)",
+                    self.controller_name,
+                    signal.side,
+                    snapshot.symbol,
+                    risk_result.reason,
+                )
+                continue
+
+            quantity = base_request.quantity
+            if risk_result.adjustments and "quantity" in risk_result.adjustments:
+                quantity = float(risk_result.adjustments["quantity"])
+            if quantity <= 0:
+                _LOGGER.debug(
+                    "Kontroler %s: dostosowana wielkość <= 0 dla %s – pomijam egzekucję.",
+                    self.controller_name,
+                    snapshot.symbol,
+                )
+                continue
+
+            request = OrderRequest(
+                symbol=base_request.symbol,
+                side=base_request.side,
+                quantity=quantity,
+                order_type=base_request.order_type,
+                price=base_request.price,
+                time_in_force=base_request.time_in_force,
+                client_order_id=base_request.client_order_id,
+            )
+            result = self.execution_service.execute(request, self.execution_context)
+            self._post_fill(signal.side, snapshot.symbol, request, result)
+            results.append(result)
+        return results
+
+    def _build_order_request(self, snapshot: MarketSnapshot, signal: StrategySignal) -> OrderRequest:
+        side = signal.side.lower()
+        price = snapshot.close
+        return OrderRequest(
+            symbol=snapshot.symbol,
+            side=side,
+            quantity=self.position_size,
+            order_type="market",
+            price=price,
+        )
+
+    def _to_snapshots(
+        self,
+        symbol: str,
+        columns: Sequence[str],
+        rows: Sequence[Sequence[float]],
+    ) -> list[MarketSnapshot]:
+        if not rows:
+            return []
+
+        index: Mapping[str, int] = {column.lower(): idx for idx, column in enumerate(columns)}
+        try:
+            open_time_idx = index["open_time"]
+        except KeyError as exc:
+            if "timestamp" in index:
+                open_time_idx = index["timestamp"]
+            else:  # pragma: no cover - zabezpieczenie na inne formaty
+                raise ValueError("Brak kolumny open_time w danych OHLCV") from exc
+        for key in ("open", "high", "low", "close"):
+            if key not in index:
+                raise ValueError(f"Brak kolumny '{key}' w danych OHLCV")
+        open_idx = index["open"]
+        high_idx = index["high"]
+        low_idx = index["low"]
+        close_idx = index["close"]
+        volume_idx = index.get("volume")
+
+        snapshots = [
+            MarketSnapshot(
+                symbol=symbol,
+                timestamp=int(float(row[open_time_idx])),
+                open=float(row[open_idx]),
+                high=float(row[high_idx]),
+                low=float(row[low_idx]),
+                close=float(row[close_idx]),
+                volume=float(row[volume_idx]) if volume_idx is not None else 0.0,
+            )
+            for row in rows
+            if len(row) > close_idx
+        ]
+        snapshots.sort(key=lambda item: item.timestamp)
+        return snapshots
+
+    def _post_fill(
+        self,
+        side: str,
+        symbol: str,
+        request: OrderRequest,
+        result: OrderResult,
+    ) -> None:
+        avg_price = result.avg_price or request.price or 0.0
+        notional = avg_price * request.quantity
+        side_lower = side.lower()
+        pnl = 0.0
+        if side_lower == "buy":
+            self._positions[symbol] = avg_price
+            position_value = notional
+        else:
+            entry_price = self._positions.pop(symbol, avg_price)
+            pnl = (avg_price - entry_price) * request.quantity
+            position_value = 0.0
+        self.risk_engine.on_fill(
+            profile_name=self._risk_profile,
+            symbol=symbol,
+            side=side_lower,
+            position_value=position_value,
+            pnl=pnl,
+        )
+        _LOGGER.info(
+            "Kontroler %s: wykonano %s %s qty=%s avg_price=%s pnl=%s",
+            self.controller_name,
+            side_lower,
+            symbol,
+            request.quantity,
+            avg_price,
+            pnl,
+        )
+
+
+__all__ = ["DailyTrendController"]

--- a/config/core.yaml
+++ b/config/core.yaml
@@ -34,6 +34,12 @@ risk_profiles:
     max_open_positions: 0
     hard_drawdown_pct: 0.0
 
+runtime:
+  controllers:
+    daily_trend_core:
+      tick_seconds: 86400
+      interval: 1d
+
 strategies:
   core_daily_trend:
     engine: daily_trend_momentum

--- a/tests/test_controller_daily_trend.py
+++ b/tests/test_controller_daily_trend.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.config.models import (
+    ControllerRuntimeConfig,
+    CoreConfig,
+    EnvironmentConfig,
+    InstrumentUniverseConfig,
+    RiskProfileConfig,
+)
+from bot_core.data.base import CacheStorage, DataSource, OHLCVRequest, OHLCVResponse
+from bot_core.data.ohlcv.backfill import OHLCVBackfillService
+from bot_core.data.ohlcv.cache import CachedOHLCVSource
+from bot_core.execution.base import ExecutionContext
+from bot_core.execution.paper import MarketMetadata, PaperTradingExecutionService
+from bot_core.exchanges.base import AccountSnapshot, Environment
+from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.profiles.manual import ManualProfile
+from bot_core.runtime.controller import DailyTrendController
+from bot_core.strategies.daily_trend import DailyTrendMomentumSettings, DailyTrendMomentumStrategy
+
+
+class _InMemoryStorage(CacheStorage):
+    def __init__(self) -> None:
+        self._store: dict[str, Mapping[str, Sequence[Sequence[float]]]] = {}
+        self._metadata: dict[str, str] = {}
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        if key not in self._store:
+            raise KeyError(key)
+        return self._store[key]
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        self._store[key] = payload
+
+    def metadata(self) -> MutableMapping[str, str]:
+        return self._metadata
+
+    def latest_timestamp(self, key: str) -> float | None:
+        try:
+            rows = self._store[key]["rows"]
+        except KeyError:
+            return None
+        if not rows:
+            return None
+        return float(rows[-1][0])
+
+
+@dataclass(slots=True)
+class _FixtureSource(DataSource):
+    rows: Sequence[Sequence[float]]
+
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        filtered = [row for row in self.rows if request.start <= float(row[0]) <= request.end]
+        limit = request.limit or len(filtered)
+        return OHLCVResponse(
+            columns=("open_time", "open", "high", "low", "close", "volume"),
+            rows=filtered[:limit],
+        )
+
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:  # pragma: no cover
+        del symbols, intervals
+
+
+def _core_config(runtime: ControllerRuntimeConfig, environment_name: str, risk_profile: str) -> CoreConfig:
+    return CoreConfig(
+        environments={
+            environment_name: EnvironmentConfig(
+                name=environment_name,
+                exchange="paper",
+                environment=Environment.PAPER,
+                keychain_key="paper",  # nieużywane w teście
+                data_cache_path="./var/data",
+                risk_profile=risk_profile,
+                alert_channels=(),
+            )
+        },
+        risk_profiles={
+            risk_profile: RiskProfileConfig(
+                name=risk_profile,
+                max_daily_loss_pct=1.0,
+                max_position_pct=1.0,
+                target_volatility=0.0,
+                max_leverage=10.0,
+                stop_loss_atr_multiple=2.0,
+                max_open_positions=10,
+                hard_drawdown_pct=1.0,
+            )
+        },
+        instrument_universes={
+            "default": InstrumentUniverseConfig(name="default", description="", instruments=())
+        },
+        strategies={},
+        reporting={},
+        sms_providers={},
+        telegram_channels={},
+        email_channels={},
+        runtime_controllers={"daily_trend": runtime},
+    )
+
+
+def test_daily_trend_controller_executes_signal() -> None:
+    day_ms = 86_400_000
+    start_time = 1_600_000_000_000
+    candles = [
+        [float(start_time + i * day_ms), 100.0 + i, 100.5 + i, 99.5 + i, 100.0 + i, 10.0]
+        for i in range(5)
+    ]
+    candles.append([float(start_time + 5 * day_ms), 107.0, 110.0, 106.0, 108.0, 12.0])
+
+    storage = _InMemoryStorage()
+    source = _FixtureSource(rows=candles)
+    cached = CachedOHLCVSource(storage=storage, upstream=source)
+    backfill = OHLCVBackfillService(cached, chunk_limit=10)
+
+    settings = DailyTrendMomentumSettings(
+        fast_ma=3,
+        slow_ma=5,
+        breakout_lookback=4,
+        momentum_window=3,
+        atr_window=3,
+        atr_multiplier=1.5,
+        min_trend_strength=0.0,
+        min_momentum=0.0,
+    )
+    strategy = DailyTrendMomentumStrategy(settings)
+
+    runtime_cfg = ControllerRuntimeConfig(tick_seconds=60.0, interval="1d")
+    core_cfg = _core_config(runtime_cfg, "paper", "paper_risk")
+
+    risk_engine = ThresholdRiskEngine()
+    profile = ManualProfile(
+        name="paper_risk",
+        max_positions=5,
+        max_leverage=5.0,
+        drawdown_limit=1.0,
+        daily_loss_limit=1.0,
+        max_position_pct=1.0,
+        target_volatility=0.0,
+        stop_loss_atr_multiple=2.0,
+    )
+    risk_engine.register_profile(profile)
+
+    execution_service = PaperTradingExecutionService(
+        {"BTCUSDT": MarketMetadata(base_asset="BTC", quote_asset="USDT", min_notional=0.0)},
+        initial_balances={"USDT": 100_000.0},
+        maker_fee=0.0,
+        taker_fee=0.0,
+        slippage_bps=0.0,
+    )
+
+    account_snapshot = AccountSnapshot(
+        balances={"USDT": 100_000.0},
+        total_equity=100_000.0,
+        available_margin=100_000.0,
+        maintenance_margin=0.0,
+    )
+
+    controller = DailyTrendController(
+        core_config=core_cfg,
+        environment_name="paper",
+        controller_name="daily_trend",
+        symbols=("BTCUSDT",),
+        backfill_service=backfill,
+        data_source=cached,
+        strategy=strategy,
+        risk_engine=risk_engine,
+        execution_service=execution_service,
+        account_loader=lambda: account_snapshot,
+        execution_context=ExecutionContext(
+            portfolio_id="paper-demo",
+            risk_profile="paper_risk",
+            environment=Environment.PAPER.value,
+            metadata={},
+        ),
+        position_size=0.1,
+    )
+
+    results = controller.run_cycle(start=candles[0][0], end=candles[-1][0])
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.status == "filled"
+    assert result.filled_quantity == 0.1
+    assert controller.tick_seconds == runtime_cfg.tick_seconds
+    assert controller.interval == runtime_cfg.interval
+    assert risk_engine.should_liquidate(profile_name="paper_risk") is False


### PR DESCRIPTION
## Summary
- add a DailyTrendController that drives backfill, strategy evaluation, risk checks and execution
- extend core configuration and loader with controller runtime settings and defaults
- cover the controller with a paper-trading integration test using fixture candles

## Testing
- pytest tests/test_controller_daily_trend.py

------
https://chatgpt.com/codex/tasks/task_e_68d847bf8f7c832aaf2096f1275ccfc6