### PR TITLE
Implement trading controller alerting and health checks

### DIFF
--- a/bot_core/runtime/__init__.py
+++ b/bot_core/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Infrastruktura runtime nowej architektury bota."""
 
 from bot_core.runtime.bootstrap import BootstrapContext, bootstrap_environment
+from bot_core.runtime.controller import TradingController
 
-__all__ = ["BootstrapContext", "bootstrap_environment"]
+__all__ = ["BootstrapContext", "TradingController", "bootstrap_environment"]

--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1,0 +1,265 @@
+"""Kontroler spinający strategię, silnik ryzyka i moduł alertów."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Mapping, MutableMapping, Sequence
+
+from bot_core.alerts import AlertMessage, DefaultAlertRouter
+from bot_core.execution import ExecutionContext, ExecutionService
+from bot_core.exchanges.base import AccountSnapshot, OrderRequest, OrderResult
+from bot_core.risk import RiskCheckResult, RiskEngine
+from bot_core.strategies import StrategySignal
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _as_timedelta(value: timedelta | float | int) -> timedelta:
+    if isinstance(value, timedelta):
+        return value
+    seconds = float(value)
+    if seconds < 0:
+        raise ValueError("Czas health-check nie może być ujemny")
+    return timedelta(seconds=seconds)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass(slots=True, kw_only=True)
+class TradingController:
+    """Podstawowy kontroler zarządzający przepływem sygnałów i alertów."""
+
+    risk_engine: RiskEngine
+    execution_service: ExecutionService
+    alert_router: DefaultAlertRouter
+    account_snapshot_provider: Callable[[], AccountSnapshot]
+    portfolio_id: str
+    environment: str
+    risk_profile: str
+    order_metadata_defaults: Mapping[str, str] | None = None
+    clock: Callable[[], datetime] = _now
+    health_check_interval: timedelta | float | int = timedelta(hours=1)
+    execution_metadata: Mapping[str, str] | None = None
+    _clock: Callable[[], datetime] = field(init=False, repr=False)
+    _health_interval: timedelta = field(init=False, repr=False)
+    _execution_context: ExecutionContext = field(init=False, repr=False)
+    _order_defaults: dict[str, str] = field(init=False, repr=False)
+    _last_health_report: datetime = field(init=False, repr=False)
+    _liquidation_alerted: bool = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._clock = self.clock
+        self._health_interval = _as_timedelta(self.health_check_interval)
+        metadata: MutableMapping[str, str] = {}
+        if self.execution_metadata:
+            metadata.update({str(k): str(v) for k, v in self.execution_metadata.items()})
+        self._execution_context = ExecutionContext(
+            portfolio_id=self.portfolio_id,
+            risk_profile=self.risk_profile,
+            environment=self.environment,
+            metadata=metadata,
+        )
+        self._order_defaults = {
+            str(k): str(v)
+            for k, v in (self.order_metadata_defaults or {}).items()
+        }
+        self._last_health_report = self._clock()
+        self._liquidation_alerted = False
+
+    # ------------------------------------------------------------------ API --
+    def process_signals(self, signals: Sequence[StrategySignal]) -> list[OrderResult]:
+        """Przetwarza listę sygnałów strategii i zarządza alertami."""
+
+        results: list[OrderResult] = []
+        for signal in signals:
+            if signal.side.upper() not in {"BUY", "SELL"}:
+                _LOGGER.debug("Pomijam sygnał %s o kierunku %s", signal.symbol, signal.side)
+                continue
+            try:
+                result = self._handle_signal(signal)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Błąd podczas przetwarzania sygnału %s", signal)
+                raise
+            if result is not None:
+                results.append(result)
+
+        self.maybe_report_health()
+        return results
+
+    def maybe_report_health(self, *, force: bool = False) -> None:
+        """Publikuje raport health-check, gdy minął interwał lub wymusimy wysyłkę."""
+
+        if self._health_interval.total_seconds() == 0 and not force:
+            return
+
+        now = self._clock()
+        if not force and now - self._last_health_report < self._health_interval:
+            return
+
+        snapshot = self.alert_router.health_snapshot()
+        body_lines = []
+        for channel, data in snapshot.items():
+            status = data.get("status", "unknown")
+            rest = {k: v for k, v in data.items() if k != "status"}
+            details = ", ".join(f"{k}={v}" for k, v in rest.items())
+            if details:
+                body_lines.append(f"{channel}: {status} ({details})")
+            else:
+                body_lines.append(f"{channel}: {status}")
+        body = "\n".join(body_lines) if body_lines else "Brak kanałów alertowych do zraportowania."
+
+        message = AlertMessage(
+            category="health",
+            title="Raport health-check kanałów alertowych",
+            body=body,
+            severity="info",
+            context={
+                "environment": self.environment,
+                "portfolio": self.portfolio_id,
+                "risk_profile": self.risk_profile,
+                "channel_count": str(len(snapshot)),
+                "generated_at": now.isoformat(),
+            },
+        )
+        _LOGGER.info("Publikuję raport health-check (%s kanałów)", len(snapshot))
+        self.alert_router.dispatch(message)
+        self._last_health_report = now
+
+    # ------------------------------------------------------------ internals --
+    def _handle_signal(self, signal: StrategySignal) -> OrderResult | None:
+        self._emit_signal_alert(signal)
+        request = self._build_order_request(signal)
+        account = self.account_snapshot_provider()
+        risk_result = self.risk_engine.apply_pre_trade_checks(
+            request,
+            account=account,
+            profile_name=self.risk_profile,
+        )
+
+        if not risk_result.allowed:
+            self._emit_order_rejected_alert(signal, request, risk_result)
+            self._handle_liquidation_state(risk_result)
+            return None
+
+        result = self.execution_service.execute(request, self._execution_context)
+        self._handle_liquidation_state(risk_result)
+        return result
+
+    def _build_order_request(self, signal: StrategySignal) -> OrderRequest:
+        metadata = dict(self._order_defaults)
+        metadata.update({str(k): str(v) for k, v in signal.metadata.items()})
+
+        try:
+            quantity = float(metadata["quantity"])
+        except KeyError as exc:  # pragma: no cover - kontrakt kontrolera
+            raise ValueError("Sygnał nie zawiera wielkości zlecenia (quantity)") from exc
+        except ValueError as exc:
+            raise ValueError("Wielkość zlecenia musi być liczbą zmiennoprzecinkową") from exc
+
+        if quantity <= 0:
+            raise ValueError("Wielkość zlecenia musi być dodatnia")
+
+        price_value = metadata.get("price")
+        price = float(price_value) if price_value is not None else None
+
+        order_type = metadata.get("order_type", "market").upper()
+        time_in_force = metadata.get("time_in_force")
+        client_order_id = metadata.get("client_order_id")
+
+        request = OrderRequest(
+            symbol=signal.symbol,
+            side=signal.side.upper(),
+            quantity=quantity,
+            order_type=order_type,
+            price=price,
+            time_in_force=time_in_force,
+            client_order_id=client_order_id,
+        )
+        return request
+
+    def _emit_signal_alert(self, signal: StrategySignal) -> None:
+        context = {
+            "symbol": signal.symbol,
+            "side": signal.side.upper(),
+            "confidence": f"{signal.confidence:.2f}",
+            "environment": self.environment,
+            "risk_profile": self.risk_profile,
+        }
+        for key, value in signal.metadata.items():
+            context[f"meta_{key}"] = str(value)
+
+        message = AlertMessage(
+            category="strategy",
+            title=f"Sygnał {signal.side.upper()} dla {signal.symbol}",
+            body="Strategia wygenerowała sygnał wymagający decyzji egzekucyjnej.",
+            severity="info",
+            context=context,
+        )
+        _LOGGER.debug("Publikuję alert sygnału %s %s", signal.side.upper(), signal.symbol)
+        self.alert_router.dispatch(message)
+
+    def _emit_order_rejected_alert(
+        self,
+        signal: StrategySignal,
+        request: OrderRequest,
+        risk_result: RiskCheckResult,
+    ) -> None:
+        adjustments = risk_result.adjustments or {}
+        context = {
+            "symbol": request.symbol,
+            "side": request.side,
+            "order_type": request.order_type,
+            "quantity": f"{request.quantity:.8f}",
+            "environment": self.environment,
+            "risk_profile": self.risk_profile,
+        }
+        context.update({f"adjust_{k}": str(v) for k, v in adjustments.items()})
+
+        message = AlertMessage(
+            category="risk",
+            title=f"Zlecenie odrzucone przez risk engine ({request.symbol})",
+            body=risk_result.reason or "Brak szczegółów",
+            severity="warning",
+            context=context,
+        )
+        _LOGGER.warning(
+            "Risk engine odrzucił zlecenie %s %s: %s",
+            request.side,
+            request.symbol,
+            risk_result.reason,
+        )
+        self.alert_router.dispatch(message)
+
+    def _handle_liquidation_state(self, risk_result: RiskCheckResult) -> None:
+        if not self.risk_engine.should_liquidate(profile_name=self.risk_profile):
+            if self._liquidation_alerted:
+                _LOGGER.info("Profil %s wyszedł z trybu awaryjnego", self.risk_profile)
+            self._liquidation_alerted = False
+            return
+
+        if self._liquidation_alerted:
+            return
+
+        reason = risk_result.reason or "Profil ryzyka w trybie awaryjnym – przekroczono limit straty lub obsunięcia."
+        context = {
+            "risk_profile": self.risk_profile,
+            "environment": self.environment,
+            "portfolio": self.portfolio_id,
+        }
+        message = AlertMessage(
+            category="risk",
+            title="Profil w trybie awaryjnym",
+            body=reason,
+            severity="critical",
+            context=context,
+        )
+        _LOGGER.error("Profil %s przekroczył limity – wysyłam alert krytyczny", self.risk_profile)
+        self.alert_router.dispatch(message)
+        self._liquidation_alerted = True
+
+
+__all__ = ["TradingController"]
+

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -73,6 +73,8 @@ def test_router_dispatch_records_audit(sample_message: AlertMessage) -> None:
     exported = tuple(audit.export())
     assert len(exported) == 1
     assert exported[0]["channel"] == "dummy"
+    assert channel.messages[0].severity == "critical"
+    assert exported[0]["severity"] == "critical"
 
 
 def test_router_continues_on_error(sample_message: AlertMessage, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Mapping
+
+from bot_core.alerts import AlertMessage, DefaultAlertRouter, InMemoryAlertAuditLog
+from bot_core.alerts.base import AlertChannel
+from bot_core.execution import ExecutionService
+from bot_core.exchanges.base import AccountSnapshot, OrderRequest, OrderResult
+from bot_core.risk import RiskCheckResult, RiskEngine, RiskProfile
+from bot_core.runtime import TradingController
+from bot_core.strategies import StrategySignal
+
+
+class CollectingChannel(AlertChannel):
+    name = "collector"
+
+    def __init__(self) -> None:
+        self.messages: list[AlertMessage] = []
+
+    def send(self, message: AlertMessage) -> None:
+        self.messages.append(message)
+
+    def health_check(self) -> Mapping[str, str]:
+        return {"status": "ok", "latency_ms": "5"}
+
+
+class DummyRiskEngine(RiskEngine):
+    def __init__(self) -> None:
+        self._result = RiskCheckResult(allowed=True)
+        self._liquidate = False
+        self.last_checks: list[tuple[OrderRequest, AccountSnapshot, str]] = []
+
+    def register_profile(self, profile: RiskProfile) -> None:  # pragma: no cover - nieużywane
+        return None
+
+    def apply_pre_trade_checks(
+        self,
+        request: OrderRequest,
+        *,
+        account: AccountSnapshot,
+        profile_name: str,
+    ) -> RiskCheckResult:
+        self.last_checks.append((request, account, profile_name))
+        return self._result
+
+    def on_fill(
+        self,
+        *,
+        profile_name: str,
+        symbol: str,
+        side: str,
+        position_value: float,
+        pnl: float,
+        timestamp: datetime | None = None,
+    ) -> None:  # pragma: no cover - testy nie wymagają implementacji
+        return None
+
+    def should_liquidate(self, *, profile_name: str) -> bool:
+        return self._liquidate
+
+    def set_result(self, result: RiskCheckResult, *, liquidate: bool = False) -> None:
+        self._result = result
+        self._liquidate = liquidate
+
+
+class DummyExecutionService(ExecutionService):
+    def __init__(self) -> None:
+        self.requests: list[OrderRequest] = []
+
+    def execute(self, request: OrderRequest, context) -> OrderResult:  # type: ignore[override]
+        self.requests.append(request)
+        return OrderResult(
+            order_id="order-1",
+            status="filled",
+            filled_quantity=request.quantity,
+            avg_price=request.price,
+            raw_response={"context": context.metadata},
+        )
+
+    def cancel(self, order_id: str, context) -> None:  # type: ignore[override]
+        return None
+
+    def flush(self) -> None:
+        return None
+
+
+def _account_snapshot() -> AccountSnapshot:
+    return AccountSnapshot(
+        balances={},
+        total_equity=100_000.0,
+        available_margin=90_000.0,
+        maintenance_margin=10_000.0,
+    )
+
+
+def _router_with_channel() -> tuple[DefaultAlertRouter, CollectingChannel, InMemoryAlertAuditLog]:
+    audit = InMemoryAlertAuditLog()
+    router = DefaultAlertRouter(audit_log=audit)
+    channel = CollectingChannel()
+    router.register(channel)
+    return router, channel, audit
+
+
+def _signal(side: str = "BUY", *, quantity: float = 1.0, price: float = 100.0) -> StrategySignal:
+    return StrategySignal(
+        symbol="BTC/USDT",
+        side=side,
+        confidence=0.75,
+        metadata={"quantity": str(quantity), "price": str(price), "order_type": "market"},
+    )
+
+
+def test_controller_emits_alert_on_buy_signal() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    router, channel, audit = _router_with_channel()
+    controller = TradingController(
+        risk_engine=risk_engine,
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        health_check_interval=timedelta(hours=1),
+    )
+
+    results = controller.process_signals([_signal("BUY")])
+
+    assert len(results) == 1
+    assert execution.requests[0].side == "BUY"
+    assert channel.messages[0].category == "strategy"
+    assert channel.messages[0].severity == "info"
+    exported = tuple(audit.export())
+    assert len(exported) >= 1
+
+
+def test_controller_alerts_on_risk_rejection_and_limit() -> None:
+    risk_engine = DummyRiskEngine()
+    risk_engine.set_result(
+        RiskCheckResult(allowed=False, reason="Przekroczono dzienny limit straty."),
+        liquidate=True,
+    )
+    execution = DummyExecutionService()
+    router, channel, audit = _router_with_channel()
+    controller = TradingController(
+        risk_engine=risk_engine,
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        health_check_interval=timedelta(hours=1),
+    )
+
+    results = controller.process_signals([_signal("SELL")])
+
+    assert results == []
+    severities = [message.severity for message in channel.messages]
+    assert severities == ["info", "warning", "critical"]
+    titles = [message.title for message in channel.messages]
+    assert "Profil w trybie awaryjnym" in titles[2]
+    exported = tuple(audit.export())
+    assert len(exported) == 3
+    assert exported[2]["severity"] == "critical"
+
+
+def test_controller_runs_health_report() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    router, channel, _ = _router_with_channel()
+
+    def clock() -> datetime:
+        return datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    controller = TradingController(
+        risk_engine=risk_engine,
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        health_check_interval=timedelta(seconds=0),
+        clock=clock,
+    )
+
+    controller.maybe_report_health(force=True)
+
+    assert len(channel.messages) == 1
+    message = channel.messages[0]
+    assert message.category == "health"
+    assert message.severity == "info"
+    assert message.context["channel_count"] == "1"


### PR DESCRIPTION
## Summary
- add a runtime TradingController that emits alerts for trading signals, rejected orders, and breached risk limits
- schedule periodic alert-channel health reports via the alert router and expose the controller through the runtime package
- extend alert tests and add controller tests covering critical alert delivery and health-check reporting

## Testing
- pytest tests/test_alerts.py tests/test_trading_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68d847c11158832aac8f06486641c08a