### PR TITLE
Move legacy shims into legacy_bridge and enforce import guard

### DIFF
--- a/KryptoLowca/README.markdown
+++ b/KryptoLowca/README.markdown
@@ -5,6 +5,11 @@ KryptoŁowca is a production-grade cryptocurrency trading bot with a graphical u
 > **Important:** Legacy source code that previously lived under `KryptoLowca/bot` has been archived in `archive/legacy_bot/`.
 > The archived snapshot is kept for reference only and must not be executed in new environments. Always use the modules from
 > the top-level `KryptoLowca` package when developing, deploying, or testing the bot.
+>
+> **Warning:** Nowe moduły (np. w `bot_core/`) nie mogą importować `KryptoLowca`
+> – w razie potrzeby należy użyć gotowych wrapperów z katalogu
+> `legacy_bridge/`. Pakiet `legacy_bridge/` jest oznaczony jako read-only i
+> służy wyłącznie do utrzymania kompatybilności z historycznym API.
 
 ## Project Structure
 

--- a/KryptoLowca/core/order_executor.py
+++ b/KryptoLowca/core/order_executor.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple
 try:  # pragma: no cover
     from KryptoLowca.managers.exchange_core import Mode, OrderStatus  # type: ignore
 except Exception:  # pragma: no cover
-    from managers.exchange_core import Mode, OrderStatus  # type: ignore
+    from legacy_bridge.managers.exchange_core import Mode, OrderStatus  # type: ignore
 
 try:  # pragma: no cover - opcjonalne
     import ccxt  # type: ignore

--- a/KryptoLowca/core/trading_engine.py
+++ b/KryptoLowca/core/trading_engine.py
@@ -35,12 +35,16 @@ try:  # pragma: no cover
         TradingStrategies,
     )
 except Exception:  # pragma: no cover
-    from core.order_executor import ExecutionResult, OrderExecutor
-    from managers.ai_manager import AIManager
-    from managers.database_manager import DatabaseManager
-    from managers.exchange_manager import ExchangeManager
-    from managers.risk_manager_adapter import RiskManager
-    from trading_strategies import EngineConfig, TradingParameters, TradingStrategies
+    from legacy_bridge.core.order_executor import ExecutionResult, OrderExecutor
+    from legacy_bridge.managers.ai_manager import AIManager
+    from legacy_bridge.managers.database_manager import DatabaseManager
+    from legacy_bridge.managers.exchange_manager import ExchangeManager
+    from legacy_bridge.managers.risk_manager_adapter import RiskManager
+    from legacy_bridge.trading_strategies import (
+        EngineConfig,
+        TradingParameters,
+        TradingStrategies,
+    )
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:

--- a/KryptoLowca/database_manager.py
+++ b/KryptoLowca/database_manager.py
@@ -22,8 +22,8 @@ try:  # pragma: no cover
         DatabaseManager as _CoreDatabaseManager,
     )
 except Exception:  # pragma: no cover
-    from managers import database_manager as _core
-    from managers.database_manager import DatabaseManager as _CoreDatabaseManager
+    from legacy_bridge import database_manager as _core
+    from legacy_bridge.database_manager import DatabaseManager as _CoreDatabaseManager
 
 from sqlalchemy import DateTime, Integer, String, Text, UniqueConstraint, select
 from sqlalchemy.engine import make_url

--- a/KryptoLowca/exchange_manager.py
+++ b/KryptoLowca/exchange_manager.py
@@ -84,7 +84,7 @@ except Exception:  # pragma: no cover - starsze wersje ccxt
 try:  # pragma: no cover
     from KryptoLowca.managers.exchange_core import Mode  # type: ignore
 except Exception:  # pragma: no cover
-    from managers.exchange_core import Mode  # type: ignore
+    from legacy_bridge.managers.exchange_core import Mode  # type: ignore
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:

--- a/KryptoLowca/tests/test_config_manager.py
+++ b/KryptoLowca/tests/test_config_manager.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 try:  # pragma: no cover
     from KryptoLowca.managers.config_manager import ConfigManager  # type: ignore
 except Exception:  # pragma: no cover
-    from managers.config_manager import ConfigManager
+    from legacy_bridge.managers.config_manager import ConfigManager
 
 
 @pytest.fixture()

--- a/KryptoLowca/tests/test_order_executor.py
+++ b/KryptoLowca/tests/test_order_executor.py
@@ -19,8 +19,14 @@ try:  # pragma: no cover
         OrderType,
     )
 except Exception:  # pragma: no cover
-    from core.order_executor import OrderExecutor
-    from managers.exchange_core import Mode, OrderDTO, OrderSide, OrderStatus, OrderType
+    from legacy_bridge.core.order_executor import OrderExecutor
+    from legacy_bridge.managers.exchange_core import (
+        Mode,
+        OrderDTO,
+        OrderSide,
+        OrderStatus,
+        OrderType,
+    )
 
 
 class DummyExchange:

--- a/KryptoLowca/tests/test_trading_engine.py
+++ b/KryptoLowca/tests/test_trading_engine.py
@@ -28,8 +28,14 @@ try:  # pragma: no cover
     )
     from KryptoLowca.trading_strategies import EngineConfig, TradingParameters  # type: ignore
 except Exception:  # pragma: no cover
-    from core.trading_engine import TradingEngine
-    from managers.exchange_core import Mode, OrderDTO, OrderSide, OrderStatus, OrderType
+    from legacy_bridge.core.trading_engine import TradingEngine
+    from legacy_bridge.managers.exchange_core import (
+        Mode,
+        OrderDTO,
+        OrderSide,
+        OrderStatus,
+        OrderType,
+    )
     from trading_strategies import EngineConfig, TradingParameters
 
 

--- a/core/order_executor.py
+++ b/core/order_executor.py
@@ -1,1 +1,0 @@
-from KryptoLowca.core.order_executor import *  # noqa: F401,F403

--- a/core/trading_engine.py
+++ b/core/trading_engine.py
@@ -1,1 +1,0 @@
-from KryptoLowca.core.trading_engine import *  # noqa: F401,F403

--- a/docs/architecture/phase1_foundation.md
+++ b/docs/architecture/phase1_foundation.md
@@ -4,6 +4,12 @@ Dokument opisuje modularną architekturę przygotowującą bota do integracji z 
 Krakenem i Zondą. W pierwszym etapie budujemy szkielet umożliwiający bezpieczny rozwój bez licencji
 zewnętrznych, z jasnym podziałem na warstwy i środowiska.
 
+> **Zasada etapu 1:** wszystkie nowe moduły aplikacji korzystają wyłącznie z
+> przestrzeni nazw `bot_core`. Kod znajdujący się w `legacy_bridge/` jest
+> wyłącznie mostkiem zgodności do historycznego pakietu `KryptoLowca` i ma
+> charakter read-only – nie wolno go rozszerzać ani modyfikować przy pracach nad
+> fundamentem architektury.
+
 ## Podział na moduły
 
 | Moduł | Odpowiedzialność | Kluczowe klasy/interfejsy |

--- a/legacy_bridge/__init__.py
+++ b/legacy_bridge/__init__.py
@@ -1,0 +1,10 @@
+"""Read-only compatibility wrappers bridging legacy entry points.
+
+The modules in this package only re-export symbols from the modern
+``KryptoLowca`` namespace so that historical imports keep working.
+Do not modify them – new code must target ``bot_core`` instead.
+"""
+
+from __future__ import annotations
+
+__all__ = []

--- a/legacy_bridge/ai_manager.py
+++ b/legacy_bridge/ai_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``trading_strategies``."""
+"""Wejściowy moduł zgodności dla ``ai_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.trading_strategies import *  # noqa: F401,F403
+from KryptoLowca.ai_manager import *  # noqa: F401,F403

--- a/legacy_bridge/auto_trader.py
+++ b/legacy_bridge/auto_trader.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``ai_manager``."""
+"""Wejściowy moduł zgodności dla ``auto_trader``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.ai_manager import *  # noqa: F401,F403
+from KryptoLowca.auto_trader import *  # noqa: F401,F403

--- a/legacy_bridge/config_manager.py
+++ b/legacy_bridge/config_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.exchange_manager``."""
+"""Wejściowy moduł zgodności dla ``config_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.exchange_manager import *  # noqa: F401,F403
+from KryptoLowca.config_manager import *  # noqa: F401,F403

--- a/legacy_bridge/core/__init__.py
+++ b/legacy_bridge/core/__init__.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.exchange_core``."""
+"""Wejściowy moduł zgodności dla ``core``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.exchange_core import *  # noqa: F401,F403
+from KryptoLowca.core import *  # noqa: F401,F403

--- a/legacy_bridge/core/order_executor.py
+++ b/legacy_bridge/core/order_executor.py
@@ -1,0 +1,3 @@
+"""Read-only compatibility shim re-exporting :mod:`KryptoLowca.core.order_executor`."""
+
+from KryptoLowca.core.order_executor import *  # noqa: F401,F403

--- a/legacy_bridge/core/trading_engine.py
+++ b/legacy_bridge/core/trading_engine.py
@@ -1,0 +1,3 @@
+"""Read-only compatibility shim re-exporting :mod:`KryptoLowca.core.trading_engine`."""
+
+from KryptoLowca.core.trading_engine import *  # noqa: F401,F403

--- a/legacy_bridge/data_preprocessor.py
+++ b/legacy_bridge/data_preprocessor.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers``."""
+"""Wejściowy moduł zgodności dla ``data_preprocessor``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers import *  # noqa: F401,F403
+from KryptoLowca.data_preprocessor import *  # noqa: F401,F403

--- a/legacy_bridge/database_manager.py
+++ b/legacy_bridge/database_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.paper_exchange``."""
+"""Wejściowy moduł zgodności dla ``database_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.paper_exchange import *  # noqa: F401,F403
+from KryptoLowca.database_manager import *  # noqa: F401,F403

--- a/legacy_bridge/event_emitter_adapter.py
+++ b/legacy_bridge/event_emitter_adapter.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.risk_manager_adapter``."""
+"""Wejściowy moduł zgodności dla ``event_emitter_adapter``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.risk_manager_adapter import *  # noqa: F401,F403
+from KryptoLowca.event_emitter_adapter import *  # noqa: F401,F403

--- a/legacy_bridge/exchange_manager.py
+++ b/legacy_bridge/exchange_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``data_preprocessor``."""
+"""Wejściowy moduł zgodności dla ``exchange_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.data_preprocessor import *  # noqa: F401,F403
+from KryptoLowca.exchange_manager import *  # noqa: F401,F403

--- a/legacy_bridge/managers/__init__.py
+++ b/legacy_bridge/managers/__init__.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``core``."""
+"""Wejściowy moduł zgodności dla ``managers``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.core import *  # noqa: F401,F403
+from KryptoLowca.managers import *  # noqa: F401,F403

--- a/legacy_bridge/managers/ai_manager.py
+++ b/legacy_bridge/managers/ai_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.ai_manager``."""
+"""Wejściowy moduł zgodności dla ``managers.ai_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 

--- a/legacy_bridge/managers/config_manager.py
+++ b/legacy_bridge/managers/config_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``database_manager``."""
+"""Wejściowy moduł zgodności dla ``managers.config_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.database_manager import *  # noqa: F401,F403
+from KryptoLowca.managers.config_manager import *  # noqa: F401,F403

--- a/legacy_bridge/managers/database_manager.py
+++ b/legacy_bridge/managers/database_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.config_manager``."""
+"""Wejściowy moduł zgodności dla ``managers.database_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.config_manager import *  # noqa: F401,F403
+from KryptoLowca.managers.database_manager import *  # noqa: F401,F403

--- a/legacy_bridge/managers/exchange_adapter.py
+++ b/legacy_bridge/managers/exchange_adapter.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``trading_gui``."""
+"""Wejściowy moduł zgodności dla ``managers.exchange_adapter``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.trading_gui import *  # noqa: F401,F403
+from KryptoLowca.managers.exchange_adapter import *  # noqa: F401,F403

--- a/legacy_bridge/managers/exchange_core.py
+++ b/legacy_bridge/managers/exchange_core.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.report_manager``."""
+"""Wejściowy moduł zgodności dla ``managers.exchange_core``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.report_manager import *  # noqa: F401,F403
+from KryptoLowca.managers.exchange_core import *  # noqa: F401,F403

--- a/legacy_bridge/managers/exchange_manager.py
+++ b/legacy_bridge/managers/exchange_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.exchange_adapter``."""
+"""Wejściowy moduł zgodności dla ``managers.exchange_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.exchange_adapter import *  # noqa: F401,F403
+from KryptoLowca.managers.exchange_manager import *  # noqa: F401,F403

--- a/legacy_bridge/managers/paper_exchange.py
+++ b/legacy_bridge/managers/paper_exchange.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``event_emitter_adapter``."""
+"""Wejściowy moduł zgodności dla ``managers.paper_exchange``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.event_emitter_adapter import *  # noqa: F401,F403
+from KryptoLowca.managers.paper_exchange import *  # noqa: F401,F403

--- a/legacy_bridge/managers/report_manager.py
+++ b/legacy_bridge/managers/report_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.database_manager``."""
+"""Wejściowy moduł zgodności dla ``managers.report_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.database_manager import *  # noqa: F401,F403
+from KryptoLowca.managers.report_manager import *  # noqa: F401,F403

--- a/legacy_bridge/managers/risk_manager_adapter.py
+++ b/legacy_bridge/managers/risk_manager_adapter.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``risk_management``."""
+"""Wejściowy moduł zgodności dla ``managers.risk_manager_adapter``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.risk_management import *  # noqa: F401,F403
+from KryptoLowca.managers.risk_manager_adapter import *  # noqa: F401,F403

--- a/legacy_bridge/managers/security_manager.py
+++ b/legacy_bridge/managers/security_manager.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``auto_trader``."""
+"""Wejściowy moduł zgodności dla ``managers.security_manager``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.auto_trader import *  # noqa: F401,F403
+from KryptoLowca.managers.security_manager import *  # noqa: F401,F403

--- a/legacy_bridge/risk_management.py
+++ b/legacy_bridge/risk_management.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``managers.security_manager``."""
+"""Wejściowy moduł zgodności dla ``risk_management``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.managers.security_manager import *  # noqa: F401,F403
+from KryptoLowca.risk_management import *  # noqa: F401,F403

--- a/legacy_bridge/trading_gui.py
+++ b/legacy_bridge/trading_gui.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``exchange_manager``."""
+"""Wejściowy moduł zgodności dla ``trading_gui``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.exchange_manager import *  # noqa: F401,F403
+from KryptoLowca.trading_gui import *  # noqa: F401,F403

--- a/legacy_bridge/trading_strategies.py
+++ b/legacy_bridge/trading_strategies.py
@@ -1,4 +1,4 @@
-"""Wejściowy moduł zgodności dla ``config_manager``."""
+"""Wejściowy moduł zgodności dla ``trading_strategies``. (READ ONLY: przekierowuje do pakietu `KryptoLowca`)."""
 
 from __future__ import annotations
 
@@ -21,4 +21,4 @@ if __package__ in (None, ""):
     _ensure_repo_root()
 
 
-from KryptoLowca.config_manager import *  # noqa: F401,F403
+from KryptoLowca.trading_strategies import *  # noqa: F401,F403

--- a/scripts/lint_paths.py
+++ b/scripts/lint_paths.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""CI helper that ensures forbidden legacy directories stay archived."""
+"""CI helper that guards repo layout and import rules."""
 from __future__ import annotations
 
 import pathlib
+import re
 import sys
 
 # Paths are relative to repository root.
@@ -10,25 +11,55 @@ BANNED_PATHS = [
     pathlib.Path("KryptoLowca/bot"),
 ]
 
+# Python files inside these directories may still import ``KryptoLowca``
+# because they implement the legacy surface itself.
+_ALLOWED_KRYPTLOWCA_IMPORT_ROOTS = {
+    pathlib.Path("KryptoLowca"),
+    pathlib.Path("legacy_bridge"),
+    pathlib.Path("archive"),
+}
+
+_IMPORT_PATTERN = re.compile(r"^\s*(?:from|import)\s+KryptoLowca\b", re.MULTILINE)
+
 
 def main() -> int:
     repo_root = pathlib.Path(__file__).resolve().parents[1]
-    violations: list[str] = []
+    failures: list[str] = []
 
     for rel_path in BANNED_PATHS:
         candidate = repo_root / rel_path
         if candidate.exists():
-            violations.append(str(rel_path))
+            failures.append(
+                "Disallowed legacy paths detected: "
+                f"{rel_path}. Move files to archive/legacy_bot or delete them."
+            )
 
-    if violations:
-        joined = ", ".join(violations)
-        print(
-            "Disallowed legacy paths detected: "
-            f"{joined}. Move files to archive/legacy_bot or delete them."
+    forbidden_imports: list[str] = []
+    for py_file in repo_root.rglob("*.py"):
+        rel_file = py_file.relative_to(repo_root)
+        if rel_file.parts and pathlib.Path(rel_file.parts[0]) in _ALLOWED_KRYPTLOWCA_IMPORT_ROOTS:
+            continue
+        if any(part.startswith(".") for part in rel_file.parts):
+            continue
+        text = py_file.read_text(encoding="utf-8")
+        if _IMPORT_PATTERN.search(text):
+            forbidden_imports.append(str(rel_file))
+
+    if forbidden_imports:
+        failures.append(
+            "Found imports of KryptoLowca in new modules: "
+            + ", ".join(sorted(forbidden_imports))
+            + ". Use legacy_bridge or bot_core instead."
         )
+
+    if failures:
+        print("\n".join(failures))
         return 1
 
-    print("Path lint passed: no forbidden directories present.")
+    print(
+        "Repository layout lint passed: legacy directories absent and "
+        "no forbidden KryptoLowca imports found."
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary
- move the legacy compatibility wrappers into a dedicated `legacy_bridge/` package and mark the shims as read-only re-exports
- update the phase 1 architecture notes and README with guidance to build on `bot_core` and rely on the new bridge when legacy APIs are required
- teach the CI path linter to block new imports from `KryptoLowca` while repointing runtime/tests to consume the bridge modules

## Testing
- `python scripts/lint_paths.py`
- `pytest tests` *(fails: AttributeError in tests/test_config_loader.py: InstrumentUniverseConfig missing attribute `instru`)*

------
https://chatgpt.com/codex/tasks/task_e_68d847c1a958832a801b4f2917905d57