### PR TITLE
Add rolling walk-forward optimizer

### DIFF
--- a/bot_core/__init__.py
+++ b/bot_core/__init__.py
@@ -1,0 +1,37 @@
+"""Nowa modularna architektura bota handlowego."""
+
+from bot_core.alerts import (
+    AlertChannel,
+    AlertMessage,
+    DEFAULT_SMS_PROVIDERS,
+    SmsProviderConfig,
+    get_sms_provider,
+)
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import CoreConfig
+from bot_core.exchanges.base import ExchangeAdapter
+from bot_core.observability import MetricsRegistry, get_global_metrics_registry
+from bot_core.security import (
+    KeyringSecretStorage,
+    SecretManager,
+    SecretStorageError,
+)
+from bot_core.runtime import BootstrapContext, bootstrap_environment
+
+__all__ = [
+    "AlertChannel",
+    "AlertMessage",
+    "DEFAULT_SMS_PROVIDERS",
+    "SmsProviderConfig",
+    "get_sms_provider",
+    "CoreConfig",
+    "ExchangeAdapter",
+    "MetricsRegistry",
+    "KeyringSecretStorage",
+    "SecretManager",
+    "SecretStorageError",
+    "BootstrapContext",
+    "bootstrap_environment",
+    "load_core_config",
+    "get_global_metrics_registry",
+]

--- a/bot_core/__init__.py
+++ b/bot_core/__init__.py
@@ -16,7 +16,12 @@ from bot_core.security import (
     SecretManager,
     SecretStorageError,
 )
-from bot_core.runtime import BootstrapContext, bootstrap_environment
+from bot_core.runtime import (
+    BootstrapContext,
+    InstrumentUniverse,
+    UniverseInstrument,
+    bootstrap_environment,
+)
 
 __all__ = [
     "AlertChannel",
@@ -31,6 +36,8 @@ __all__ = [
     "SecretManager",
     "SecretStorageError",
     "BootstrapContext",
+    "InstrumentUniverse",
+    "UniverseInstrument",
     "bootstrap_environment",
     "load_core_config",
     "get_global_metrics_registry",

--- a/bot_core/alerts/__init__.py
+++ b/bot_core/alerts/__init__.py
@@ -1,0 +1,42 @@
+"""Pakiet kanałów alertów i routera."""
+
+from bot_core.alerts.audit import AlertAuditEntry, InMemoryAlertAuditLog
+from bot_core.alerts.base import (
+    AlertAuditLog,
+    AlertChannel,
+    AlertDeliveryError,
+    AlertMessage,
+    AlertRouter,
+)
+from bot_core.alerts.channels import (
+    DEFAULT_SMS_PROVIDERS,
+    EmailChannel,
+    MessengerChannel,
+    SMSChannel,
+    SignalChannel,
+    SmsProviderConfig,
+    TelegramChannel,
+    WhatsAppChannel,
+    get_sms_provider,
+)
+from bot_core.alerts.router import DefaultAlertRouter
+
+__all__ = [
+    "AlertAuditEntry",
+    "AlertAuditLog",
+    "AlertChannel",
+    "AlertDeliveryError",
+    "AlertMessage",
+    "AlertRouter",
+    "DefaultAlertRouter",
+    "EmailChannel",
+    "SMSChannel",
+    "SignalChannel",
+    "WhatsAppChannel",
+    "MessengerChannel",
+    "SmsProviderConfig",
+    "TelegramChannel",
+    "DEFAULT_SMS_PROVIDERS",
+    "get_sms_provider",
+    "InMemoryAlertAuditLog",
+]

--- a/bot_core/alerts/audit.py
+++ b/bot_core/alerts/audit.py
@@ -1,0 +1,52 @@
+"""Repozytoria audytu wykorzystywane przez system alertów."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Mapping
+
+from bot_core.alerts.base import AlertAuditLog, AlertMessage
+
+
+@dataclass(slots=True)
+class AlertAuditEntry:
+    """Pojedynczy zapis audytowy odpowiadający wysłanemu komunikatowi."""
+
+    channel: str
+    message: AlertMessage
+    created_at: datetime
+
+    def as_dict(self) -> Mapping[str, str]:
+        """Eksportuje wpis w formacie przyjaznym serializacji."""
+
+        payload: dict[str, str] = {
+            "channel": self.channel,
+            "category": self.message.category,
+            "title": self.message.title,
+            "severity": self.message.severity,
+            "timestamp": self.message.timestamp.isoformat(),
+            "created_at": self.created_at.isoformat(),
+        }
+        payload.update({f"ctx_{k}": v for k, v in self.message.context.items()})
+        payload["body"] = self.message.body
+        return payload
+
+
+class InMemoryAlertAuditLog(AlertAuditLog):
+    """Prosta implementacja audytu na potrzeby środowisk deweloperskich."""
+
+    __slots__ = ("_entries",)
+
+    def __init__(self) -> None:
+        self._entries: List[AlertAuditEntry] = []
+
+    def append(self, message: AlertMessage, *, channel: str) -> None:
+        entry = AlertAuditEntry(channel=channel, message=message, created_at=message.timestamp)
+        self._entries.append(entry)
+
+    def export(self) -> Iterable[Mapping[str, str]]:
+        return tuple(entry.as_dict() for entry in self._entries)
+
+
+__all__ = ["AlertAuditEntry", "InMemoryAlertAuditLog"]
+

--- a/bot_core/alerts/base.py
+++ b/bot_core/alerts/base.py
@@ -1,0 +1,61 @@
+"""Interfejsy kanałów alertów oraz audytu."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, MutableSequence, Protocol
+
+
+class AlertDeliveryError(RuntimeError):
+    """Sygnalizuje niepowodzenie podczas wysyłki alertu na kanał."""
+
+
+@dataclass(slots=True)
+class AlertMessage:
+    """Reprezentuje sformatowaną treść alertu wraz z metadanymi."""
+
+    category: str
+    title: str
+    body: str
+    severity: str
+    context: Mapping[str, str]
+    timestamp: datetime = field(default_factory=lambda: datetime.now(tz=timezone.utc))
+
+
+class AlertChannel(abc.ABC):
+    """Każdy kanał powiadomień musi implementować ten interfejs."""
+
+    name: str
+
+    @abc.abstractmethod
+    def send(self, message: AlertMessage) -> None:
+        """Publikuje alert na danym kanale."""
+
+    @abc.abstractmethod
+    def health_check(self) -> Mapping[str, str]:
+        """Zwraca stan kanału wykorzystywany w raportach SLO."""
+
+
+class AlertAuditLog(Protocol):
+    """Minimalny kontrakt repozytorium audytowego."""
+
+    def append(self, message: AlertMessage, *, channel: str) -> None:
+        ...
+
+    def export(self) -> Iterable[Mapping[str, str]]:
+        ...
+
+
+class AlertRouter(abc.ABC):
+    """Centralna szyna, która będzie sterować dostarczaniem alertów."""
+
+    channels: MutableSequence[AlertChannel]
+
+    @abc.abstractmethod
+    def register(self, channel: AlertChannel) -> None:
+        ...
+
+    @abc.abstractmethod
+    def dispatch(self, message: AlertMessage) -> None:
+        ...

--- a/bot_core/alerts/channels/__init__.py
+++ b/bot_core/alerts/channels/__init__.py
@@ -1,0 +1,25 @@
+"""Adaptery kanałów powiadomień."""
+
+from bot_core.alerts.channels.email import EmailChannel
+from bot_core.alerts.channels.messenger import MessengerChannel
+from bot_core.alerts.channels.providers import (
+    DEFAULT_SMS_PROVIDERS,
+    SmsProviderConfig,
+    get_sms_provider,
+)
+from bot_core.alerts.channels.signal import SignalChannel
+from bot_core.alerts.channels.sms import SMSChannel
+from bot_core.alerts.channels.telegram import TelegramChannel
+from bot_core.alerts.channels.whatsapp import WhatsAppChannel
+
+__all__ = [
+    "EmailChannel",
+    "SMSChannel",
+    "TelegramChannel",
+    "SignalChannel",
+    "WhatsAppChannel",
+    "MessengerChannel",
+    "SmsProviderConfig",
+    "DEFAULT_SMS_PROVIDERS",
+    "get_sms_provider",
+]

--- a/bot_core/alerts/channels/email.py
+++ b/bot_core/alerts/channels/email.py
@@ -1,0 +1,78 @@
+"""Adapter kanału e-mail bazujący na SMTP."""
+from __future__ import annotations
+
+import logging
+import smtplib
+from dataclasses import dataclass, field
+from email.message import EmailMessage
+from typing import Callable, Sequence
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+
+
+@dataclass(slots=True)
+class EmailChannel(AlertChannel):
+    """Wysyła powiadomienia korzystając z serwera SMTP."""
+
+    host: str
+    port: int
+    from_address: str
+    recipients: Sequence[str]
+    username: str | None = None
+    password: str | None = None
+    use_tls: bool = True
+    timeout: float = 10.0
+    name: str = "email"
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.email"))
+    _smtp_factory: Callable[[str, int, float], smtplib.SMTP] = field(default=smtplib.SMTP, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+    _last_success: str | None = field(default=None, init=False, repr=False)
+
+    def send(self, message: AlertMessage) -> None:
+        email = self._build_email(message)
+        try:
+            with self._smtp_factory(self.host, self.port, timeout=self.timeout) as client:
+                client.ehlo()
+                if self.use_tls:
+                    client.starttls()
+                    client.ehlo()
+                if self.username and self.password:
+                    client.login(self.username, self.password)
+                client.send_message(email)
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki e-maila")
+            raise AlertDeliveryError(f"Nie udało się wysłać e-maila: {exc}") from exc
+
+        self._last_error = None
+        self._last_success = message.timestamp.isoformat()
+
+    def health_check(self) -> dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: dict[str, str] = {"status": status}
+        if self._last_success:
+            data["last_success"] = self._last_success
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _build_email(self, message: AlertMessage) -> EmailMessage:
+        email = EmailMessage()
+        email["From"] = self.from_address
+        email["To"] = ", ".join(self.recipients)
+        email["Subject"] = f"[{message.severity.upper()}] {message.title}"
+        body_lines = [
+            message.body,
+            "",
+            "Kontekst:",
+            *[f"- {key}: {value}" for key, value in sorted(message.context.items())],
+            "",
+            f"Kategoria: {message.category}",
+            f"Znacznik czasu: {message.timestamp.isoformat()}",
+        ]
+        email.set_content("\n".join(body_lines))
+        return email
+
+
+__all__ = ["EmailChannel"]
+

--- a/bot_core/alerts/channels/messenger.py
+++ b/bot_core/alerts/channels/messenger.py
@@ -1,0 +1,105 @@
+"""Adapter do wysyłki alertów na Facebook Messenger."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Protocol, Sequence
+from urllib import request
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+
+
+class _HttpOpener(Protocol):
+    def __call__(self, req: request.Request, *, timeout: float) -> request.addinfourl:
+        ...
+
+
+def _default_opener(req: request.Request, *, timeout: float) -> request.addinfourl:
+    return request.urlopen(req, timeout=timeout)  # noqa: S310 - Graph API ma zaufany certyfikat
+
+
+@dataclass(slots=True)
+class MessengerChannel(AlertChannel):
+    """Adapter wykorzystujący Graph API do wysyłki wiadomości."""
+
+    page_id: str
+    access_token: str
+    recipients: Sequence[str]
+    api_base_url: str = "https://graph.facebook.com"
+    api_version: str = "v16.0"
+    name: str = "messenger"
+    timeout: float = 10.0
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.messenger"))
+    _opener: _HttpOpener = field(default=_default_opener, repr=False)
+    _last_success: datetime | None = field(default=None, init=False, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+
+    def send(self, message: AlertMessage) -> None:
+        url = f"{self.api_base_url.rstrip('/')}/{self.api_version}/me/messages"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.access_token}",
+        }
+        body = self._format_body(message)
+        payload_base = {
+            "messaging_type": "UPDATE",
+            "message": {"text": body},
+        }
+
+        for recipient in self.recipients:
+            payload = dict(payload_base)
+            payload["recipient"] = {"id": recipient}
+            req = request.Request(url, data=json.dumps(payload).encode("utf-8"), headers=headers)
+            self._send_request(req)
+
+        self._last_success = datetime.now(tz=timezone.utc)
+        self._last_error = None
+
+    def _send_request(self, req: request.Request) -> None:
+        try:
+            with self._opener(req, timeout=self.timeout) as response:
+                status = getattr(response, "status", response.getcode())
+                raw = response.read()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki przez Messenger")
+            raise AlertDeliveryError(f"Messenger: nie udało się wysłać powiadomienia ({exc})") from exc
+
+        if status >= 400:
+            detail = raw.decode("utf-8", errors="ignore") if raw else ""
+            self._last_error = detail or str(status)
+            self.logger.error("Messenger zwrócił status %s: %s", status, detail)
+            raise AlertDeliveryError(f"Messenger zwrócił status {status}: {detail}")
+
+        if raw:
+            try:
+                parsed: Dict[str, object] = json.loads(raw)
+            except json.JSONDecodeError:  # pragma: no cover
+                parsed = {"status": "ok"}
+            if isinstance(parsed, dict) and parsed.get("error"):
+                error = parsed["error"]
+                self._last_error = str(error)
+                self.logger.error("Messenger zwrócił błąd aplikacyjny: %s", error)
+                raise AlertDeliveryError(f"Messenger zwrócił błąd aplikacyjny: {error}")
+
+    def health_check(self) -> Dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: Dict[str, str] = {"status": status, "page_id": self.page_id}
+        if self._last_success:
+            data["last_success"] = self._last_success.isoformat()
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _format_body(self, message: AlertMessage) -> str:
+        context = "\n".join(f"• {key}: {value}" for key, value in sorted(message.context.items()))
+        parts = [f"{message.title} [{message.severity.upper()}]", message.body]
+        if context:
+            parts.append(context)
+        parts.append(f"Kategoria: {message.category}")
+        return "\n\n".join(part for part in parts if part)
+
+
+__all__ = ["MessengerChannel"]

--- a/bot_core/alerts/channels/providers.py
+++ b/bot_core/alerts/channels/providers.py
@@ -1,0 +1,75 @@
+"""Predefiniowane konfiguracje lokalnych dostawców SMS."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True, slots=True)
+class SmsProviderConfig:
+    """Opisuje parametry integracji z dostawcą SMS."""
+
+    provider_id: str
+    display_name: str
+    api_base_url: str
+    iso_country_code: str
+    supports_alphanumeric_sender: bool
+    notes: str | None = None
+    max_sender_length: int = 11
+
+
+#: Zestaw standardowych konfiguracji dla operatorów wymaganych w pierwszym etapie.
+DEFAULT_SMS_PROVIDERS: Dict[str, SmsProviderConfig] = {
+    "orange_pl": SmsProviderConfig(
+        provider_id="orange_pl",
+        display_name="Orange Polska",
+        api_base_url="https://api.orange.pl/sms/v1",
+        iso_country_code="PL",
+        supports_alphanumeric_sender=True,
+        notes="Wymaga whitelisting IP i zgłoszenia alfanumerycznego nadawcy do Orange.",
+    ),
+    "tmobile_pl": SmsProviderConfig(
+        provider_id="tmobile_pl",
+        display_name="T-Mobile Polska",
+        api_base_url="https://api.t-mobile.pl/sms/v1",
+        iso_country_code="PL",
+        supports_alphanumeric_sender=True,
+        notes="Obsługa w trybie REST, dostęp po podpisaniu umowy A2P.",
+    ),
+    "plus_pl": SmsProviderConfig(
+        provider_id="plus_pl",
+        display_name="Plus Polska",
+        api_base_url="https://api.plus.pl/messaging/v1",
+        iso_country_code="PL",
+        supports_alphanumeric_sender=False,
+        notes="Domyślnie preferuje numeryczny nadpis nadawcy, alfanumeryczny wymaga dodatkowej zgody.",
+    ),
+    "play_pl": SmsProviderConfig(
+        provider_id="play_pl",
+        display_name="Play Polska",
+        api_base_url="https://api.play.pl/sms/v1",
+        iso_country_code="PL",
+        supports_alphanumeric_sender=True,
+        notes="Wymaga wcześniejszego zgłoszenia puli IP oraz rejestracji brandu.",
+    ),
+    "nova_is": SmsProviderConfig(
+        provider_id="nova_is",
+        display_name="Nova Islandia",
+        api_base_url="https://api.nova.is/sms/v1",
+        iso_country_code="IS",
+        supports_alphanumeric_sender=True,
+        notes="Islandzki operator z obsługą webhooków statusowych i fallbackiem numerowym.",
+    ),
+}
+
+
+def get_sms_provider(provider_key: str) -> SmsProviderConfig:
+    """Zwraca konfigurację dostawcy na podstawie klucza."""
+
+    try:
+        return DEFAULT_SMS_PROVIDERS[provider_key]
+    except KeyError as exc:  # pragma: no cover - błąd sygnalizujemy w miejscu użycia
+        raise KeyError(f"Nieznany dostawca SMS: {provider_key}") from exc
+
+
+__all__ = ["SmsProviderConfig", "DEFAULT_SMS_PROVIDERS", "get_sms_provider"]

--- a/bot_core/alerts/channels/signal.py
+++ b/bot_core/alerts/channels/signal.py
@@ -1,0 +1,122 @@
+"""Adapter wysyłający alerty przez usługę Signal."""
+from __future__ import annotations
+
+import json
+import logging
+import ssl
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Protocol, Sequence
+from urllib import request
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+
+
+class _SignalHttpOpener(Protocol):
+    def __call__(
+        self,
+        req: request.Request,
+        *,
+        timeout: float,
+        context: ssl.SSLContext | None,
+    ) -> request.addinfourl:
+        ...
+
+
+def _default_signal_opener(
+    req: request.Request,
+    *,
+    timeout: float,
+    context: ssl.SSLContext | None,
+) -> request.addinfourl:
+    return request.urlopen(req, timeout=timeout, context=context)  # noqa: S310 - kontrolujemy docelowy serwer
+
+
+@dataclass(slots=True)
+class SignalChannel(AlertChannel):
+    """Integracja z lokalną instancją ``signal-cli`` lub kompatybilnym API."""
+
+    service_url: str
+    sender_number: str
+    recipients: Sequence[str]
+    auth_token: str | None = None
+    verify_tls: bool = True
+    name: str = "signal"
+    timeout: float = 10.0
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.signal"))
+    _opener: _SignalHttpOpener = field(default=_default_signal_opener, repr=False)
+    _ssl_context: ssl.SSLContext | None = field(default=None, init=False, repr=False)
+    _last_success: datetime | None = field(default=None, init=False, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._ssl_context = self._build_ssl_context()
+
+    def send(self, message: AlertMessage) -> None:
+        url = f"{self.service_url.rstrip('/')}/v2/send"
+        payload = {
+            "message": self._format_body(message),
+            "number": self.sender_number,
+            "recipients": list(self.recipients),
+        }
+        headers = {"Content-Type": "application/json"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+
+        req = request.Request(url, data=json.dumps(payload).encode("utf-8"), headers=headers)
+
+        try:
+            with self._opener(req, timeout=self.timeout, context=self._ssl_context) as response:
+                status = getattr(response, "status", response.getcode())
+                raw = response.read()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki przez Signal")
+            raise AlertDeliveryError(f"Signal: nie udało się wysłać powiadomienia ({exc})") from exc
+
+        if status >= 400:
+            detail = raw.decode("utf-8", errors="ignore") if raw else ""
+            self._last_error = detail or str(status)
+            self.logger.error("Signal zwrócił status %s: %s", status, detail)
+            raise AlertDeliveryError(f"Signal zwrócił status {status}: {detail}")
+
+        if raw:
+            try:
+                parsed: Dict[str, object] = json.loads(raw)
+            except json.JSONDecodeError:  # pragma: no cover - brak JSON traktujemy jako sukces
+                parsed = {"status": "ok"}
+            error = parsed.get("error") if isinstance(parsed, dict) else None
+            if error:
+                self._last_error = str(error)
+                self.logger.error("Signal zgłosił błąd aplikacyjny: %s", error)
+                raise AlertDeliveryError(f"Signal zgłosił błąd aplikacyjny: {error}")
+
+        self._last_success = datetime.now(tz=timezone.utc)
+        self._last_error = None
+
+    def health_check(self) -> Dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: Dict[str, str] = {"status": status, "service_url": self.service_url}
+        if self._last_success:
+            data["last_success"] = self._last_success.isoformat()
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _format_body(self, message: AlertMessage) -> str:
+        context = "\n".join(f"- {key}: {value}" for key, value in sorted(message.context.items()))
+        parts = [f"[{message.severity.upper()}] {message.title}", message.body]
+        if context:
+            parts.append(context)
+        parts.append(f"Kategoria: {message.category}")
+        return "\n\n".join(part for part in parts if part)
+
+    def _build_ssl_context(self) -> ssl.SSLContext | None:
+        if self.service_url.lower().startswith("http://"):
+            return None
+        if self.verify_tls:
+            return ssl.create_default_context()
+        return ssl._create_unverified_context()  # type: ignore[attr-defined]  # pragma: no cover
+
+
+__all__ = ["SignalChannel"]

--- a/bot_core/alerts/channels/sms.py
+++ b/bot_core/alerts/channels/sms.py
@@ -1,0 +1,121 @@
+"""Adapter SMS obsługujący dostawców z API HTTP (np. Twilio i operatorów lokalnych)."""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Protocol, Sequence
+from urllib import parse, request
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+from bot_core.alerts.channels.providers import SmsProviderConfig
+
+
+class _SmsHttpOpener(Protocol):
+    def __call__(self, req: request.Request, *, timeout: float) -> request.addinfourl:
+        ...
+
+
+def _default_sms_opener(req: request.Request, *, timeout: float) -> request.addinfourl:
+    return request.urlopen(req, timeout=timeout)  # noqa: S310 - kontrolujemy docelowe API
+
+
+@dataclass(slots=True)
+class SMSChannel(AlertChannel):
+    """Wysyła wiadomości SMS poprzez API kompatybilne z modelem Twilio."""
+
+    account_sid: str
+    auth_token: str
+    from_number: str
+    recipients: Sequence[str]
+    provider: SmsProviderConfig | None = None
+    provider_base_url: str = "https://api.twilio.com"
+    name: str = "sms"
+    timeout: float = 10.0
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.sms"))
+    _opener: _SmsHttpOpener = field(default=_default_sms_opener, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+    _last_success: datetime | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.provider is not None:
+            # Normalizujemy bazowy adres do postaci bez końcowego slasha.
+            base = self.provider.api_base_url.rstrip("/")
+            self.provider_base_url = base
+            self.logger.debug(
+                "SMSChannel skonfigurowany dla dostawcy", extra={"provider": self.provider.provider_id}
+            )
+
+    def send(self, message: AlertMessage) -> None:
+        for recipient in self.recipients:
+            self._send_single(recipient, message)
+        self._last_success = datetime.now(tz=timezone.utc)
+        self._last_error = None
+
+    def _send_single(self, recipient: str, message: AlertMessage) -> None:
+        url = f"{self.provider_base_url}/2010-04-01/Accounts/{self.account_sid}/Messages.json"
+        payload = parse.urlencode({
+            "To": recipient,
+            "From": self.from_number,
+            "Body": self._build_body(message),
+        }).encode("utf-8")
+        req = request.Request(url, data=payload, method="POST")
+        auth_header = base64.b64encode(f"{self.account_sid}:{self.auth_token}".encode("utf-8")).decode("ascii")
+        req.add_header("Authorization", f"Basic {auth_header}")
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+        try:
+            with self._opener(req, timeout=self.timeout) as response:
+                status = getattr(response, "status", response.getcode())
+                raw_body = response.read()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki SMS", extra={"recipient": recipient})
+            raise AlertDeliveryError(f"Błąd wysyłki SMS do {recipient}: {exc}") from exc
+
+        if status >= 400:
+            detail = raw_body.decode("utf-8", errors="ignore") if raw_body else ""
+            self._last_error = detail or str(status)
+            self.logger.error(
+                "Dostawca SMS zwrócił kod %s: %s",
+                status,
+                detail,
+                extra={"recipient": recipient, "provider": self.provider.provider_id if self.provider else None},
+            )
+            raise AlertDeliveryError(f"Dostawca SMS zwrócił kod {status}: {detail}")
+
+        if raw_body:
+            try:
+                decoded: Dict[str, object] = json.loads(raw_body)
+            except json.JSONDecodeError:  # pragma: no cover - brak body JSON nie jest błędem krytycznym
+                decoded = {"status": "unknown"}
+            error_msg = decoded.get("message") if isinstance(decoded, dict) else None
+            if error_msg:
+                self._last_error = str(error_msg)
+                self.logger.error(
+                    "Dostawca SMS zgłosił błąd: %s",
+                    error_msg,
+                    extra={"recipient": recipient, "provider": self.provider.provider_id if self.provider else None},
+                )
+                raise AlertDeliveryError(f"Dostawca SMS zgłosił błąd: {error_msg}")
+
+    def health_check(self) -> Dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: Dict[str, str] = {"status": status}
+        if self.provider is not None:
+            data["provider"] = self.provider.provider_id
+            data["country"] = self.provider.iso_country_code
+        if self._last_success:
+            data["last_success"] = self._last_success.isoformat()
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _build_body(self, message: AlertMessage) -> str:
+        context = "; ".join(f"{key}={value}" for key, value in sorted(message.context.items()))
+        return f"{message.title}: {message.body} [{context}]"
+
+
+__all__ = ["SMSChannel"]

--- a/bot_core/alerts/channels/telegram.py
+++ b/bot_core/alerts/channels/telegram.py
@@ -1,0 +1,99 @@
+"""Adapter kanału powiadomień dla Telegrama."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Protocol
+from urllib import request
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+
+
+class _HttpOpener(Protocol):
+    def __call__(self, req: request.Request, *, timeout: float) -> request.addinfourl:
+        ...
+
+
+def _default_opener(req: request.Request, *, timeout: float) -> request.addinfourl:
+    return request.urlopen(req, timeout=timeout)  # noqa: S310 - docelowo wywołujemy zaufane API
+
+
+@dataclass(slots=True)
+class TelegramChannel(AlertChannel):
+    """Publikuje alerty wykorzystując oficjalne API Telegram Bot."""
+
+    bot_token: str
+    chat_id: str
+    parse_mode: str = "MarkdownV2"
+    name: str = "telegram"
+    timeout: float = 10.0
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.telegram"))
+    _opener: _HttpOpener = field(default=_default_opener, repr=False)
+    _last_success: datetime | None = field(default=None, init=False, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+
+    def send(self, message: AlertMessage) -> None:
+        payload = {
+            "chat_id": self.chat_id,
+            "text": self._format_message(message),
+            "disable_web_page_preview": True,
+        }
+        if self.parse_mode:
+            payload["parse_mode"] = self.parse_mode
+
+        url = f"https://api.telegram.org/bot{self.bot_token}/sendMessage"
+        req = request.Request(url, data=json.dumps(payload).encode("utf-8"), headers={"Content-Type": "application/json"})
+
+        try:
+            with self._opener(req, timeout=self.timeout) as response:
+                status = getattr(response, "status", response.getcode())
+                data = response.read()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki do Telegrama")
+            raise AlertDeliveryError(f"Błąd wysyłki do Telegrama: {exc}") from exc
+
+        if status >= 400:
+            body = data.decode("utf-8", errors="ignore") if data else ""
+            self._last_error = body or str(status)
+            self.logger.error("Telegram zwrócił błąd HTTP %s: %s", status, body)
+            raise AlertDeliveryError(f"Telegram zwrócił błąd HTTP {status}: {body}")
+
+        try:
+            parsed: Dict[str, object] = json.loads(data) if data else {"ok": True}
+        except json.JSONDecodeError as exc:  # pragma: no cover - powinno się udać dla poprawnych odpowiedzi
+            self._last_error = str(exc)
+            raise AlertDeliveryError("Niepoprawna odpowiedź Telegrama") from exc
+
+        if not bool(parsed.get("ok", True)):
+            description = str(parsed.get("description", "Nieznany błąd"))
+            self._last_error = description
+            self.logger.error("Telegram odrzucił wiadomość: %s", description)
+            raise AlertDeliveryError(f"Telegram odrzucił wiadomość: {description}")
+
+        self._last_success = datetime.now(tz=timezone.utc)
+        self._last_error = None
+
+    def health_check(self) -> Dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: Dict[str, str] = {"status": status}
+        if self._last_success:
+            data["last_success"] = self._last_success.isoformat()
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _format_message(self, message: AlertMessage) -> str:
+        header = f"*{message.title}*" if self.parse_mode == "MarkdownV2" else message.title
+        context_lines = "\n".join(f"• {key}: {value}" for key, value in sorted(message.context.items()))
+        parts = [header, message.body]
+        if context_lines:
+            parts.append(context_lines)
+        parts.append(f"Kategoria: {message.category} | Poziom: {message.severity}")
+        return "\n\n".join(part for part in parts if part)
+
+
+__all__ = ["TelegramChannel"]
+

--- a/bot_core/alerts/channels/whatsapp.py
+++ b/bot_core/alerts/channels/whatsapp.py
@@ -1,0 +1,106 @@
+"""Adapter do wysyłki alertów przez WhatsApp Business API."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Protocol, Sequence
+from urllib import request
+
+from bot_core.alerts.base import AlertChannel, AlertDeliveryError, AlertMessage
+
+
+class _HttpOpener(Protocol):
+    def __call__(self, req: request.Request, *, timeout: float) -> request.addinfourl:
+        ...
+
+
+def _default_opener(req: request.Request, *, timeout: float) -> request.addinfourl:
+    return request.urlopen(req, timeout=timeout)  # noqa: S310 - korzystamy z zaufanego Graph API
+
+
+@dataclass(slots=True)
+class WhatsAppChannel(AlertChannel):
+    """Integracja z Graph API dla WhatsApp Business."""
+
+    phone_number_id: str
+    access_token: str
+    recipients: Sequence[str]
+    api_base_url: str = "https://graph.facebook.com"
+    api_version: str = "v16.0"
+    name: str = "whatsapp"
+    timeout: float = 10.0
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts.whatsapp"))
+    _opener: _HttpOpener = field(default=_default_opener, repr=False)
+    _last_success: datetime | None = field(default=None, init=False, repr=False)
+    _last_error: str | None = field(default=None, init=False, repr=False)
+
+    def send(self, message: AlertMessage) -> None:
+        url = (
+            f"{self.api_base_url.rstrip('/')}/{self.api_version}/{self.phone_number_id}/messages"
+        )
+        payload = {
+            "messaging_product": "whatsapp",
+            "type": "text",
+            "text": {"body": self._format_body(message)},
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.access_token}",
+        }
+
+        for recipient in self.recipients:
+            payload["to"] = recipient
+            req = request.Request(url, data=json.dumps(payload).encode("utf-8"), headers=headers)
+            self._send_request(req)
+
+        self._last_success = datetime.now(tz=timezone.utc)
+        self._last_error = None
+
+    def _send_request(self, req: request.Request) -> None:
+        try:
+            with self._opener(req, timeout=self.timeout) as response:
+                status = getattr(response, "status", response.getcode())
+                raw = response.read()
+        except Exception as exc:  # noqa: BLE001
+            self._last_error = str(exc)
+            self.logger.exception("Błąd wysyłki przez WhatsApp")
+            raise AlertDeliveryError(f"WhatsApp: nie udało się wysłać powiadomienia ({exc})") from exc
+
+        if status >= 400:
+            detail = raw.decode("utf-8", errors="ignore") if raw else ""
+            self._last_error = detail or str(status)
+            self.logger.error("WhatsApp zwrócił status %s: %s", status, detail)
+            raise AlertDeliveryError(f"WhatsApp zwrócił status {status}: {detail}")
+
+        if raw:
+            try:
+                parsed: Dict[str, object] = json.loads(raw)
+            except json.JSONDecodeError:  # pragma: no cover
+                parsed = {"status": "ok"}
+            if isinstance(parsed, dict) and parsed.get("error"):
+                error = parsed["error"]
+                self._last_error = str(error)
+                self.logger.error("WhatsApp zwrócił błąd aplikacyjny: %s", error)
+                raise AlertDeliveryError(f"WhatsApp zwrócił błąd aplikacyjny: {error}")
+
+    def health_check(self) -> Dict[str, str]:
+        status = "ok" if self._last_error is None else "error"
+        data: Dict[str, str] = {"status": status, "phone_number_id": self.phone_number_id}
+        if self._last_success:
+            data["last_success"] = self._last_success.isoformat()
+        if self._last_error:
+            data["last_error"] = self._last_error
+        return data
+
+    def _format_body(self, message: AlertMessage) -> str:
+        context = "\n".join(f"• {key}: {value}" for key, value in sorted(message.context.items()))
+        parts = [f"{message.title} ({message.severity.upper()})", message.body]
+        if context:
+            parts.append(context)
+        parts.append(f"Kategoria: {message.category}")
+        return "\n\n".join(part for part in parts if part)
+
+
+__all__ = ["WhatsAppChannel"]

--- a/bot_core/alerts/router.py
+++ b/bot_core/alerts/router.py
@@ -1,0 +1,64 @@
+"""Domyślna implementacja routera alertów."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, MutableSequence
+
+from bot_core.alerts.base import AlertChannel, AlertMessage, AlertRouter, AlertAuditLog, AlertDeliveryError
+
+
+@dataclass(slots=True)
+class DefaultAlertRouter(AlertRouter):
+    """Zarządza kanałami powiadomień i rejestruje zdarzenia w audycie."""
+
+    audit_log: AlertAuditLog
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("bot_core.alerts"))
+    stop_on_error: bool = False
+    channels: MutableSequence[AlertChannel] = field(default_factory=list)
+
+    def register(self, channel: AlertChannel) -> None:
+        if any(existing.name == channel.name for existing in self.channels):
+            raise ValueError(f"Kanał o nazwie '{channel.name}' został już zarejestrowany")
+        self.channels.append(channel)
+
+    def dispatch(self, message: AlertMessage) -> None:
+        failures: Dict[str, str] = {}
+        for channel in list(self.channels):
+            try:
+                channel.send(message)
+            except AlertDeliveryError as exc:  # pragma: no cover - defensive guard
+                self.logger.error("Nie udało się wysłać alertu", extra={"channel": channel.name, "error": str(exc)})
+                failures[channel.name] = str(exc)
+                if self.stop_on_error:
+                    raise
+            except Exception as exc:  # noqa: BLE001
+                error_msg = f"Nieznany błąd kanału {channel.name}: {exc}"
+                self.logger.exception(error_msg)
+                failures[channel.name] = str(exc)
+                if self.stop_on_error:
+                    raise AlertDeliveryError(error_msg) from exc
+            else:
+                self.audit_log.append(message, channel=channel.name)
+
+        if failures and not self.stop_on_error:
+            summary = ", ".join(f"{name}: {reason}" for name, reason in failures.items())
+            self.logger.warning("Część kanałów zgłosiła błędy: %s", summary)
+
+    def health_snapshot(self) -> Dict[str, Dict[str, str]]:
+        snapshot: Dict[str, Dict[str, str]] = {}
+        now = datetime.now(timezone.utc).isoformat()
+        for channel in self.channels:
+            data = {"checked_at": now}
+            try:
+                data.update(channel.health_check())
+            except Exception as exc:  # noqa: BLE001
+                self.logger.exception("Błąd podczas health-check kanału %s", channel.name)
+                data.update({"status": "error", "detail": str(exc)})
+            snapshot[channel.name] = data
+        return snapshot
+
+
+__all__ = ["DefaultAlertRouter"]
+

--- a/bot_core/config/__init__.py
+++ b/bot_core/config/__init__.py
@@ -1,0 +1,31 @@
+"""Warstwa konfiguracji aplikacji."""
+
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import (
+    CoreConfig,
+    EmailChannelSettings,
+    EnvironmentConfig,
+    InstrumentConfig,
+    InstrumentUniverseConfig,
+    MessengerChannelSettings,
+    RiskProfileConfig,
+    SMSProviderSettings,
+    SignalChannelSettings,
+    TelegramChannelSettings,
+    WhatsAppChannelSettings,
+)
+
+__all__ = [
+    "CoreConfig",
+    "EmailChannelSettings",
+    "EnvironmentConfig",
+    "InstrumentConfig",
+    "InstrumentUniverseConfig",
+    "MessengerChannelSettings",
+    "RiskProfileConfig",
+    "SMSProviderSettings",
+    "SignalChannelSettings",
+    "TelegramChannelSettings",
+    "WhatsAppChannelSettings",
+    "load_core_config",
+]

--- a/bot_core/config/loader.py
+++ b/bot_core/config/loader.py
@@ -1,0 +1,222 @@
+"""Ładowanie konfiguracji z plików YAML."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from bot_core.config.models import (
+    CoreConfig,
+    DailyTrendMomentumStrategyConfig,
+    EmailChannelSettings,
+    EnvironmentConfig,
+    InstrumentBackfillWindow,
+    InstrumentConfig,
+    InstrumentUniverseConfig,
+    MessengerChannelSettings,
+    RiskProfileConfig,
+    SMSProviderSettings,
+    SignalChannelSettings,
+    TelegramChannelSettings,
+    WhatsAppChannelSettings,
+)
+from bot_core.exchanges.base import Environment
+
+
+def _load_instrument_universes(raw: Mapping[str, Any]) -> Mapping[str, InstrumentUniverseConfig]:
+    universes: dict[str, InstrumentUniverseConfig] = {}
+    for name, entry in raw.get("instrument_universes", {}).items():
+        instruments: list[InstrumentConfig] = []
+        raw_instruments = entry.get("instruments", {})
+        for instrument_name, instrument_data in raw_instruments.items():
+            backfill_windows = tuple(
+                InstrumentBackfillWindow(
+                    interval=str(window["interval"]),
+                    lookback_days=int(window["lookback_days"]),
+                )
+                for window in instrument_data.get("backfill", ())
+            )
+            instruments.append(
+                InstrumentConfig(
+                    name=instrument_name,
+                    base_asset=str(instrument_data.get("base_asset", "")),
+                    quote_asset=str(instrument_data.get("quote_asset", "")),
+                    categories=tuple(instrument_data.get("categories", ())),
+                    exchange_symbols={
+                        str(exchange_name): str(symbol)
+                        for exchange_name, symbol in instrument_data.get("exchanges", {}).items()
+                    },
+                    backfill_windows=backfill_windows,
+                )
+            )
+        universes[name] = InstrumentUniverseConfig(
+            name=name,
+            description=str(entry.get("description", "")),
+            instruments=tuple(instruments),
+        )
+    return universes
+
+
+def _load_sms_providers(raw_alerts: Mapping[str, Any]) -> Mapping[str, SMSProviderSettings]:
+    providers: dict[str, SMSProviderSettings] = {}
+    for name, entry in raw_alerts.get("sms_providers", {}).items():
+        providers[name] = SMSProviderSettings(
+            name=name,
+            provider_key=str(entry["provider"]),
+            api_base_url=str(entry["api_base_url"]),
+            from_number=str(entry["from_number"]),
+            recipients=tuple(entry.get("recipients", ())),
+            allow_alphanumeric_sender=bool(entry.get("allow_alphanumeric_sender", False)),
+            sender_id=entry.get("sender_id"),
+            credential_key=entry.get("credential_key"),
+        )
+    return providers
+
+
+def _load_signal_channels(raw_alerts: Mapping[str, Any]) -> Mapping[str, SignalChannelSettings]:
+    channels: dict[str, SignalChannelSettings] = {}
+    for name, entry in raw_alerts.get("signal_channels", {}).items():
+        channels[name] = SignalChannelSettings(
+            name=name,
+            service_url=str(entry["service_url"]),
+            sender_number=str(entry["sender_number"]),
+            recipients=tuple(entry.get("recipients", ())),
+            credential_secret=entry.get("credential_secret"),
+            verify_tls=bool(entry.get("verify_tls", True)),
+        )
+    return channels
+
+
+def _load_whatsapp_channels(raw_alerts: Mapping[str, Any]) -> Mapping[str, WhatsAppChannelSettings]:
+    channels: dict[str, WhatsAppChannelSettings] = {}
+    for name, entry in raw_alerts.get("whatsapp_channels", {}).items():
+        channels[name] = WhatsAppChannelSettings(
+            name=name,
+            phone_number_id=str(entry["phone_number_id"]),
+            recipients=tuple(entry.get("recipients", ())),
+            token_secret=str(entry["token_secret"]),
+            api_base_url=str(entry.get("api_base_url", "https://graph.facebook.com")),
+            api_version=str(entry.get("api_version", "v16.0")),
+        )
+    return channels
+
+
+def _load_messenger_channels(raw_alerts: Mapping[str, Any]) -> Mapping[str, MessengerChannelSettings]:
+    channels: dict[str, MessengerChannelSettings] = {}
+    for name, entry in raw_alerts.get("messenger_channels", {}).items():
+        channels[name] = MessengerChannelSettings(
+            name=name,
+            page_id=str(entry["page_id"]),
+            recipients=tuple(entry.get("recipients", ())),
+            token_secret=str(entry["token_secret"]),
+            api_base_url=str(entry.get("api_base_url", "https://graph.facebook.com")),
+            api_version=str(entry.get("api_version", "v16.0")),
+        )
+    return channels
+
+
+def _load_strategies(raw: Mapping[str, Any]) -> Mapping[str, DailyTrendMomentumStrategyConfig]:
+    strategies: dict[str, DailyTrendMomentumStrategyConfig] = {}
+    for name, entry in raw.get("strategies", {}).items():
+        engine = str(entry.get("engine", ""))
+        if engine != "daily_trend_momentum":
+            continue
+        params = entry.get("parameters", {})
+        strategies[name] = DailyTrendMomentumStrategyConfig(
+            name=name,
+            fast_ma=int(params.get("fast_ma", 20)),
+            slow_ma=int(params.get("slow_ma", 100)),
+            breakout_lookback=int(params.get("breakout_lookback", 55)),
+            momentum_window=int(params.get("momentum_window", 20)),
+            atr_window=int(params.get("atr_window", 14)),
+            atr_multiplier=float(params.get("atr_multiplier", 2.0)),
+            min_trend_strength=float(params.get("min_trend_strength", 0.005)),
+            min_momentum=float(params.get("min_momentum", 0.0)),
+        )
+    return strategies
+
+
+def load_core_config(path: str | Path) -> CoreConfig:
+    """Wczytuje plik YAML i mapuje go na dataclasses."""
+
+    with Path(path).open("r", encoding="utf-8") as handle:
+        raw: dict[str, Any] = yaml.safe_load(handle) or {}
+
+    instrument_universes = _load_instrument_universes(raw)
+
+    environments = {
+        name: EnvironmentConfig(
+            name=name,
+            exchange=entry["exchange"],
+            environment=Environment(entry["environment"]),
+            keychain_key=entry["keychain_key"],
+            data_cache_path=entry["data_cache_path"],
+            risk_profile=entry["risk_profile"],
+            alert_channels=tuple(entry.get("alert_channels", ())),
+            ip_allowlist=tuple(entry.get("ip_allowlist", ())),
+            credential_purpose=str(entry.get("credential_purpose", "trading")),
+            instrument_universe=entry.get("instrument_universe"),
+        )
+        for name, entry in raw.get("environments", {}).items()
+    }
+
+    risk_profiles = {
+        name: RiskProfileConfig(
+            name=name,
+            max_daily_loss_pct=float(entry["max_daily_loss_pct"]),
+            max_position_pct=float(entry["max_position_pct"]),
+            target_volatility=float(entry["target_volatility"]),
+            max_leverage=float(entry["max_leverage"]),
+            stop_loss_atr_multiple=float(entry["stop_loss_atr_multiple"]),
+            max_open_positions=int(entry["max_open_positions"]),
+            hard_drawdown_pct=float(entry["hard_drawdown_pct"]),
+        )
+        for name, entry in raw.get("risk_profiles", {}).items()
+    }
+
+    strategies = _load_strategies(raw)
+    reporting = raw.get("reporting", {})
+    alerts = raw.get("alerts", {})
+    sms_providers = _load_sms_providers(alerts)
+    signal_channels = _load_signal_channels(alerts)
+    whatsapp_channels = _load_whatsapp_channels(alerts)
+    messenger_channels = _load_messenger_channels(alerts)
+    telegram_channels = {
+        name: TelegramChannelSettings(
+            name=name,
+            chat_id=str(entry["chat_id"]),
+            token_secret=str(entry["token_secret"]),
+            parse_mode=str(entry.get("parse_mode", "MarkdownV2")),
+        )
+        for name, entry in alerts.get("telegram_channels", {}).items()
+    }
+    email_channels = {
+        name: EmailChannelSettings(
+            name=name,
+            host=str(entry["host"]),
+            port=int(entry.get("port", 587)),
+            from_address=str(entry["from_address"]),
+            recipients=tuple(entry.get("recipients", ())),
+            credential_secret=entry.get("credential_secret"),
+            use_tls=bool(entry.get("use_tls", True)),
+        )
+        for name, entry in alerts.get("email_channels", {}).items()
+    }
+
+    return CoreConfig(
+        environments=environments,
+        risk_profiles=risk_profiles,
+        instrument_universes=instrument_universes,
+        strategies=strategies,
+        reporting=reporting,
+        sms_providers=sms_providers,
+        telegram_channels=telegram_channels,
+        email_channels=email_channels,
+        signal_channels=signal_channels,
+        whatsapp_channels=whatsapp_channels,
+        messenger_channels=messenger_channels,
+    )
+
+
+__all__ = ["load_core_config"]

--- a/bot_core/config/models.py
+++ b/bot_core/config/models.py
@@ -1,0 +1,188 @@
+"""Modele konfiguracji dla nowej architektury."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Sequence
+
+from bot_core.exchanges.base import Environment
+
+
+@dataclass(slots=True)
+class EnvironmentConfig:
+    """Konfiguracja środowiska (np. live, paper, testnet)."""
+
+    name: str
+    exchange: str
+    environment: Environment
+    keychain_key: str
+    data_cache_path: str
+    risk_profile: str
+    alert_channels: Sequence[str]
+    ip_allowlist: Sequence[str] = field(default_factory=tuple)
+    credential_purpose: str = "trading"
+    instrument_universe: str | None = None
+
+
+@dataclass(slots=True)
+class RiskProfileConfig:
+    """Parametry wykorzystywane do inicjalizacji profili ryzyka."""
+
+    name: str
+    max_daily_loss_pct: float
+    max_position_pct: float
+    target_volatility: float
+    max_leverage: float
+    stop_loss_atr_multiple: float
+    max_open_positions: int
+    hard_drawdown_pct: float
+
+
+@dataclass(slots=True)
+class InstrumentBackfillWindow:
+    """Definicja zakresu danych historycznych dla danego interwału."""
+
+    interval: str
+    lookback_days: int
+
+
+@dataclass(slots=True)
+class InstrumentConfig:
+    """Opis pojedynczego instrumentu w uniwersum."""
+
+    name: str
+    base_asset: str
+    quote_asset: str
+    categories: Sequence[str]
+    exchange_symbols: Mapping[str, str]
+    backfill_windows: Sequence[InstrumentBackfillWindow] = field(default_factory=tuple)
+
+
+@dataclass(slots=True)
+class InstrumentUniverseConfig:
+    """Zbiór instrumentów przypisany do środowisk."""
+
+    name: str
+    description: str
+    instruments: Sequence[InstrumentConfig]
+
+
+@dataclass(slots=True)
+class DailyTrendMomentumStrategyConfig:
+    """Konfiguracja strategii trend/momentum."""
+
+    name: str
+    fast_ma: int
+    slow_ma: int
+    breakout_lookback: int
+    momentum_window: int
+    atr_window: int
+    atr_multiplier: float
+    min_trend_strength: float
+    min_momentum: float
+
+
+@dataclass(slots=True)
+class SMSProviderSettings:
+    """Definicja lokalnego dostawcy SMS z konfiguracji."""
+
+    name: str
+    provider_key: str
+    api_base_url: str
+    from_number: str
+    recipients: Sequence[str]
+    allow_alphanumeric_sender: bool = False
+    sender_id: str | None = None
+    credential_key: str | None = None
+
+
+@dataclass(slots=True)
+class TelegramChannelSettings:
+    """Konfiguracja kanału Telegram."""
+
+    name: str
+    chat_id: str
+    token_secret: str
+    parse_mode: str = "MarkdownV2"
+
+
+@dataclass(slots=True)
+class EmailChannelSettings:
+    """Konfiguracja kanału e-mail."""
+
+    name: str
+    host: str
+    port: int
+    from_address: str
+    recipients: Sequence[str]
+    credential_secret: str | None = None
+    use_tls: bool = True
+
+
+@dataclass(slots=True)
+class SignalChannelSettings:
+    """Konfiguracja kanału Signal opartego o usługę signal-cli."""
+
+    name: str
+    service_url: str
+    sender_number: str
+    recipients: Sequence[str]
+    credential_secret: str | None = None
+    verify_tls: bool = True
+
+
+@dataclass(slots=True)
+class WhatsAppChannelSettings:
+    """Konfiguracja kanału WhatsApp wykorzystującego Graph API."""
+
+    name: str
+    phone_number_id: str
+    recipients: Sequence[str]
+    token_secret: str
+    api_base_url: str = "https://graph.facebook.com"
+    api_version: str = "v16.0"
+
+
+@dataclass(slots=True)
+class MessengerChannelSettings:
+    """Konfiguracja kanału Facebook Messenger."""
+
+    name: str
+    page_id: str
+    recipients: Sequence[str]
+    token_secret: str
+    api_base_url: str = "https://graph.facebook.com"
+    api_version: str = "v16.0"
+
+
+@dataclass(slots=True)
+class CoreConfig:
+    """Najwyższego poziomu konfiguracja aplikacji."""
+
+    environments: Mapping[str, EnvironmentConfig]
+    risk_profiles: Mapping[str, RiskProfileConfig]
+    instrument_universes: Mapping[str, InstrumentUniverseConfig]
+    strategies: Mapping[str, DailyTrendMomentumStrategyConfig]
+    reporting: Mapping[str, str]
+    sms_providers: Mapping[str, SMSProviderSettings]
+    telegram_channels: Mapping[str, TelegramChannelSettings]
+    email_channels: Mapping[str, EmailChannelSettings]
+    signal_channels: Mapping[str, SignalChannelSettings]
+    whatsapp_channels: Mapping[str, WhatsAppChannelSettings]
+    messenger_channels: Mapping[str, MessengerChannelSettings]
+
+
+__all__ = [
+    "EnvironmentConfig",
+    "RiskProfileConfig",
+    "InstrumentBackfillWindow",
+    "InstrumentConfig",
+    "InstrumentUniverseConfig",
+    "DailyTrendMomentumStrategyConfig",
+    "SMSProviderSettings",
+    "TelegramChannelSettings",
+    "EmailChannelSettings",
+    "SignalChannelSettings",
+    "WhatsAppChannelSettings",
+    "MessengerChannelSettings",
+    "CoreConfig",
+]

--- a/bot_core/data/__init__.py
+++ b/bot_core/data/__init__.py
@@ -1,0 +1,13 @@
+"""Warstwa danych rynkowych."""
+
+from bot_core.data.base import CacheStorage, DataSource, OHLCVRequest, OHLCVResponse
+from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+
+__all__ = [
+    "CacheStorage",
+    "CachedOHLCVSource",
+    "DataSource",
+    "OHLCVRequest",
+    "OHLCVResponse",
+    "PublicAPIDataSource",
+]

--- a/bot_core/data/base.py
+++ b/bot_core/data/base.py
@@ -1,0 +1,55 @@
+"""Warstwa abstrakcji dla źródeł danych rynkowych."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Iterable, Mapping, MutableMapping, Protocol, Sequence
+
+
+@dataclass(slots=True)
+class OHLCVRequest:
+    """Parametry pobierania danych OHLCV z publicznych API."""
+
+    symbol: str
+    interval: str
+    start: int
+    end: int
+    limit: int | None = None
+
+
+@dataclass(slots=True)
+class OHLCVResponse:
+    """Ujednolicone dane świec w UTC."""
+
+    columns: Sequence[str]
+    rows: Sequence[Sequence[float]]
+
+
+class DataSource(abc.ABC):
+    """Bazowy interfejs źródeł danych."""
+
+    @abc.abstractmethod
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        """Pobiera i normalizuje dane OHLCV."""
+
+    @abc.abstractmethod
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:
+        """Pozwala na wstępne zapełnienie cache (np. przy starcie aplikacji)."""
+
+
+class CacheStorage(Protocol):
+    """Minimalny kontrakt lokalnego magazynu danych (np. Parquet/SQLite)."""
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        ...
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        ...
+
+    def metadata(self) -> MutableMapping[str, str]:
+        ...
+
+    def latest_timestamp(self, key: str) -> float | None:
+        """Zwraca znacznik czasu ostatniej świecy zapisanej w cache."""
+
+        ...

--- a/bot_core/data/ohlcv/__init__.py
+++ b/bot_core/data/ohlcv/__init__.py
@@ -1,0 +1,13 @@
+"""Moduły związane z danymi OHLCV."""
+
+from bot_core.data.ohlcv.backfill import BackfillSummary, OHLCVBackfillService
+from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+from bot_core.data.ohlcv.sqlite_storage import SQLiteCacheStorage
+
+__all__ = [
+    "BackfillSummary",
+    "CachedOHLCVSource",
+    "OHLCVBackfillService",
+    "PublicAPIDataSource",
+    "SQLiteCacheStorage",
+]

--- a/bot_core/data/ohlcv/backfill.py
+++ b/bot_core/data/ohlcv/backfill.py
@@ -1,0 +1,179 @@
+"""Proces backfillu OHLCV łączący publiczne API i lokalny cache."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Sequence
+
+from bot_core.data.base import CacheStorage, OHLCVRequest
+from bot_core.data.ohlcv.cache import CachedOHLCVSource
+
+_LOGGER = logging.getLogger(__name__)
+
+_INTERVAL_TO_MILLISECONDS: dict[str, int] = {
+    "1m": 60_000,
+    "3m": 3 * 60_000,
+    "5m": 5 * 60_000,
+    "15m": 15 * 60_000,
+    "30m": 30 * 60_000,
+    "1h": 60 * 60_000,
+    "2h": 2 * 60 * 60_000,
+    "4h": 4 * 60 * 60_000,
+    "6h": 6 * 60 * 60_000,
+    "8h": 8 * 60 * 60_000,
+    "12h": 12 * 60 * 60_000,
+    "1d": 24 * 60 * 60_000,
+    "3d": 3 * 24 * 60 * 60_000,
+    "1w": 7 * 24 * 60 * 60_000,
+    "1M": 30 * 24 * 60 * 60_000,
+}
+
+
+@dataclass(slots=True)
+class BackfillSummary:
+    """Raport końcowy z procesu synchronizacji OHLCV."""
+
+    symbol: str
+    interval: str
+    requested_start: int
+    requested_end: int
+    fetched_candles: int
+    skipped_candles: int
+
+
+class OHLCVBackfillService:
+    """Synchronizuje lokalny cache z publicznymi danymi giełdowymi."""
+
+    def __init__(self, source: CachedOHLCVSource, *, chunk_limit: int = 1000) -> None:
+        if chunk_limit <= 0:
+            raise ValueError("chunk_limit musi być dodatni")
+        self._source = source
+        self._storage: CacheStorage = source.storage
+        self._chunk_limit = chunk_limit
+
+    def _interval_milliseconds(self, interval: str) -> int:
+        try:
+            return _INTERVAL_TO_MILLISECONDS[interval]
+        except KeyError as exc:  # pragma: no cover - walidacja w czasie runtime
+            raise ValueError(f"Nieobsługiwany interwał: {interval}") from exc
+
+    def _latest_cached_timestamp(self, symbol: str, interval: str) -> float | None:
+        key = self._source._cache_key(symbol, interval)  # pylint: disable=protected-access
+        try:
+            return self._storage.latest_timestamp(key)
+        except AttributeError:  # pragma: no cover - zabezpieczenie pod inne storage
+            try:
+                rows = self._storage.read(key)["rows"]
+            except KeyError:
+                return None
+            if not rows:
+                return None
+            return float(rows[-1][0])
+        except KeyError:
+            return None
+
+    def _count_cached_rows(self, symbol: str, interval: str) -> int:
+        key = self._source._cache_key(symbol, interval)  # pylint: disable=protected-access
+        try:
+            rows = self._storage.read(key)["rows"]
+        except KeyError:
+            return 0
+        return len(rows)
+
+    def synchronize(
+        self,
+        *,
+        symbols: Sequence[str],
+        interval: str,
+        start: int,
+        end: int,
+    ) -> list[BackfillSummary]:
+        """Aktualizuje cache dla listy symboli i zwraca raport."""
+
+        if start > end:
+            raise ValueError("Parametr start nie może być większy niż end")
+
+        interval_ms = self._interval_milliseconds(interval)
+        summaries: list[BackfillSummary] = []
+
+        for symbol in symbols:
+            existing_rows = self._count_cached_rows(symbol, interval)
+            latest_cached = self._latest_cached_timestamp(symbol, interval)
+            effective_start = start
+            if latest_cached is not None:
+                effective_start = max(start, int(latest_cached) + interval_ms)
+
+            if effective_start > end:
+                summaries.append(
+                    BackfillSummary(
+                        symbol=symbol,
+                        interval=interval,
+                        requested_start=start,
+                        requested_end=end,
+                        fetched_candles=0,
+                        skipped_candles=existing_rows,
+                    )
+                )
+                _LOGGER.info(
+                    "Symbol %s (%s) jest aktualny do %s – pomijam backfill.",
+                    symbol,
+                    interval,
+                    latest_cached,
+                )
+                continue
+
+            next_start = effective_start
+            last_progress = -1.0
+
+            while next_start <= end:
+                window_end = min(end, next_start + interval_ms * (self._chunk_limit - 1))
+                request = OHLCVRequest(
+                    symbol=symbol,
+                    interval=interval,
+                    start=next_start,
+                    end=window_end,
+                    limit=self._chunk_limit,
+                )
+                response = self._source.fetch_ohlcv(request)
+                if not response.rows:
+                    _LOGGER.warning(
+                        "Brak danych OHLCV dla %s (%s) w przedziale %s-%s.",
+                        symbol,
+                        interval,
+                        next_start,
+                        window_end,
+                    )
+                    break
+
+                newest_timestamp = float(response.rows[-1][0])
+                if newest_timestamp <= last_progress:
+                    _LOGGER.debug(
+                        "Zatrzymuję backfill %s (%s) – brak postępu (ostatni=%s).",
+                        symbol,
+                        interval,
+                        newest_timestamp,
+                    )
+                    break
+
+                last_progress = newest_timestamp
+                next_start = int(newest_timestamp) + interval_ms
+
+                if newest_timestamp >= end:
+                    break
+
+            updated_rows = self._count_cached_rows(symbol, interval)
+            summaries.append(
+                BackfillSummary(
+                    symbol=symbol,
+                    interval=interval,
+                    requested_start=start,
+                    requested_end=end,
+                    fetched_candles=max(0, updated_rows - existing_rows),
+                    skipped_candles=existing_rows,
+                )
+            )
+
+        return summaries
+
+
+__all__ = ["OHLCVBackfillService", "BackfillSummary"]

--- a/bot_core/data/ohlcv/cache.py
+++ b/bot_core/data/ohlcv/cache.py
@@ -1,0 +1,119 @@
+"""Warstwa odpowiedzialna za backfill i lokalny cache OHLCV."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from bot_core.data.base import CacheStorage, DataSource, OHLCVRequest, OHLCVResponse
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_COLUMNS: tuple[str, ...] = (
+    "open_time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+)
+
+
+@dataclass(slots=True)
+class CachedOHLCVSource(DataSource):
+    """Łączy publiczne API z lokalnym cache, zapewniając minimalne hit-rate API."""
+
+    storage: CacheStorage
+    upstream: DataSource
+
+    def _cache_key(self, symbol: str, interval: str) -> str:
+        return f"{symbol}::{interval}"
+
+    def _merge_rows(
+        self,
+        cached_rows: Sequence[Sequence[float]],
+        upstream_rows: Sequence[Sequence[float]],
+    ) -> list[Sequence[float]]:
+        combined: dict[float, Sequence[float]] = {float(row[0]): row for row in cached_rows}
+        for row in upstream_rows:
+            if not row:
+                continue
+            combined[float(row[0])] = row
+        return [combined[key] for key in sorted(combined)]
+
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        """Pobiera dane OHLCV łącząc cache oraz świeże dane z API."""
+
+        cache_key = self._cache_key(request.symbol, request.interval)
+        try:
+            cached_payload = self.storage.read(cache_key)
+        except KeyError:
+            cached_payload = {"rows": [], "columns": _DEFAULT_COLUMNS}
+        cached_rows: Sequence[Sequence[float]] = cached_payload.get("rows", [])
+        columns = tuple(cached_payload.get("columns", ()))
+
+        upstream_response = self.upstream.fetch_ohlcv(request)
+        rows = cached_rows
+        if upstream_response.rows:
+            rows = self._merge_rows(cached_rows, upstream_response.rows)
+            # Aktualizacja cache: zapisujemy całą serię, aby kolejne zapytania były szybkie.
+            selected_columns = columns or tuple(upstream_response.columns or _DEFAULT_COLUMNS)
+            self.storage.write(
+                cache_key,
+                {
+                    "columns": list(selected_columns),
+                    "rows": rows,
+                },
+            )
+            columns = selected_columns
+        if not columns:
+            columns = _DEFAULT_COLUMNS
+
+        filtered = [
+            row
+            for row in rows
+            if request.start <= float(row[0]) <= request.end
+        ]
+        if request.limit is not None:
+            filtered = filtered[: request.limit]
+
+        return OHLCVResponse(columns=columns, rows=filtered)
+
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:
+        """Aktualizuje metadane cache, ułatwiając audyt i monitoring."""
+
+        metadata = self.storage.metadata()
+        metadata["symbols"] = ",".join(sorted(set(symbols)))
+        metadata["intervals"] = ",".join(sorted(set(intervals)))
+        _LOGGER.info("Cache OHLCV gotowe dla %s symboli i %s interwałów.", len(set(symbols)), len(set(intervals)))
+
+
+@dataclass(slots=True)
+class PublicAPIDataSource(DataSource):
+    """Adapter korzystający bezpośrednio z publicznych endpointów giełdy."""
+
+    exchange_adapter: "ExchangeAdapter"
+
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        rows = self.exchange_adapter.fetch_ohlcv(
+            request.symbol,
+            request.interval,
+            start=request.start,
+            end=request.end,
+            limit=request.limit,
+        )
+        return OHLCVResponse(columns=_DEFAULT_COLUMNS, rows=rows)
+
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:
+        # Publiczne API nie wymaga przygotowania cache – metoda pozostaje dla zgodności interfejsu.
+        _LOGGER.debug(
+            "Pomijam warm_cache dla PublicAPIDataSource (symbole=%s, interwały=%s)",
+            list(symbols),
+            list(intervals),
+        )
+
+
+# Aby uniknąć cyklicznych importów, importujemy w runtime.
+from bot_core.exchanges.base import ExchangeAdapter  # noqa: E402  pylint: disable=wrong-import-position
+
+__all__ = ["CachedOHLCVSource", "PublicAPIDataSource"]

--- a/bot_core/data/ohlcv/sqlite_storage.py
+++ b/bot_core/data/ohlcv/sqlite_storage.py
@@ -1,0 +1,151 @@
+"""Implementacja magazynu OHLCV opartego o SQLite."""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import MutableMapping
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from bot_core.data.base import CacheStorage
+
+_COLUMNS = ("open_time", "open", "high", "low", "close", "volume")
+
+
+class _SQLiteMetadata(MutableMapping[str, str]):
+    """Lekki adapter słownika mapujący na tabelę metadata."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._connection = connection
+
+    def __getitem__(self, key: str) -> str:
+        cursor = self._connection.execute("SELECT value FROM metadata WHERE key = ?", (key,))
+        row = cursor.fetchone()
+        if row is None:
+            raise KeyError(key)
+        return str(row[0])
+
+    def __setitem__(self, key: str, value: str) -> None:
+        with self._connection:
+            self._connection.execute(
+                "INSERT INTO metadata(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (key, value),
+            )
+
+    def __delitem__(self, key: str) -> None:
+        with self._connection:
+            affected = self._connection.execute("DELETE FROM metadata WHERE key = ?", (key,)).rowcount
+        if affected == 0:
+            raise KeyError(key)
+
+    def __iter__(self):
+        cursor = self._connection.execute("SELECT key FROM metadata")
+        return (row[0] for row in cursor.fetchall())
+
+    def __len__(self) -> int:
+        cursor = self._connection.execute("SELECT COUNT(1) FROM metadata")
+        value = cursor.fetchone()
+        return int(value[0] if value else 0)
+
+
+class SQLiteCacheStorage(CacheStorage):
+    """Przechowuje dane OHLCV w lokalnej bazie SQLite."""
+
+    def __init__(self, database_path: str | Path) -> None:
+        path = Path(database_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(path, detect_types=sqlite3.PARSE_DECLTYPES)
+        self._connection.execute("PRAGMA journal_mode=WAL")
+        self._connection.execute("PRAGMA synchronous=NORMAL")
+        self._initialize()
+
+    def _initialize(self) -> None:
+        with self._connection:
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ohlcv (
+                    symbol TEXT NOT NULL,
+                    interval TEXT NOT NULL,
+                    open_time INTEGER NOT NULL,
+                    open REAL NOT NULL,
+                    high REAL NOT NULL,
+                    low REAL NOT NULL,
+                    close REAL NOT NULL,
+                    volume REAL NOT NULL,
+                    PRIMARY KEY(symbol, interval, open_time)
+                )
+                """
+            )
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+                """
+            )
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        symbol, interval = key.split("::", maxsplit=1)
+        cursor = self._connection.execute(
+            """
+            SELECT open_time, open, high, low, close, volume
+            FROM ohlcv
+            WHERE symbol = ? AND interval = ?
+            ORDER BY open_time
+            """,
+            (symbol, interval),
+        )
+        rows = [[float(col) for col in row] for row in cursor.fetchall()]
+        return {"columns": _COLUMNS, "rows": rows}
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        symbol, interval = key.split("::", maxsplit=1)
+        rows = payload.get("rows", [])
+        if not rows:
+            return
+        with self._connection:
+            self._connection.executemany(
+                """
+                INSERT INTO ohlcv(symbol, interval, open_time, open, high, low, close, volume)
+                VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(symbol, interval, open_time) DO UPDATE SET
+                    open = excluded.open,
+                    high = excluded.high,
+                    low = excluded.low,
+                    close = excluded.close,
+                    volume = excluded.volume
+                """,
+                [
+                    (
+                        symbol,
+                        interval,
+                        float(row[0]),
+                        float(row[1]),
+                        float(row[2]),
+                        float(row[3]),
+                        float(row[4]),
+                        float(row[5]),
+                    )
+                    for row in rows
+                ],
+            )
+
+    def metadata(self) -> MutableMapping[str, str]:
+        return _SQLiteMetadata(self._connection)
+
+    def latest_timestamp(self, key: str) -> float | None:
+        symbol, interval = key.split("::", maxsplit=1)
+        cursor = self._connection.execute(
+            """
+            SELECT MAX(open_time) FROM ohlcv
+            WHERE symbol = ? AND interval = ?
+            """,
+            (symbol, interval),
+        )
+        row = cursor.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return float(row[0])
+
+
+__all__ = ["SQLiteCacheStorage"]

--- a/bot_core/exchanges/__init__.py
+++ b/bot_core/exchanges/__init__.py
@@ -1,0 +1,29 @@
+"""Pakiet adapterów giełdowych."""
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
+from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
+from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
+
+__all__ = [
+    "AccountSnapshot",
+    "BinanceFuturesAdapter",
+    "BinanceSpotAdapter",
+    "Environment",
+    "ExchangeAdapter",
+    "ExchangeCredentials",
+    "KrakenFuturesAdapter",
+    "KrakenSpotAdapter",
+    "OrderRequest",
+    "OrderResult",
+    "ZondaSpotAdapter",
+]

--- a/bot_core/exchanges/base.py
+++ b/bot_core/exchanges/base.py
@@ -1,0 +1,121 @@
+"""Abstrakcyjne interfejsy adapterów giełdowych dla nowej architektury bota."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable, Mapping, Optional, Protocol, Sequence
+
+
+class Environment(str, Enum):
+    """Wspiera rozdzielenie środowisk (live, paper, testnet)."""
+
+    LIVE = "live"
+    PAPER = "paper"
+    TESTNET = "testnet"
+
+
+@dataclass(slots=True)
+class ExchangeCredentials:
+    """Przekrojowa reprezentacja kluczy API w modelu najmniejszych uprawnień."""
+
+    key_id: str
+    secret: Optional[str] = None
+    passphrase: Optional[str] = None
+    environment: Environment = Environment.LIVE
+    permissions: Sequence[str] = ()
+
+
+@dataclass(slots=True)
+class AccountSnapshot:
+    """Podstawowy model danych konta używany przez silnik ryzyka."""
+
+    balances: Mapping[str, float]
+    total_equity: float
+    available_margin: float
+    maintenance_margin: float
+
+
+@dataclass(slots=True)
+class OrderRequest:
+    """Znormalizowany model zlecenia przekazywany do modułu egzekucji."""
+
+    symbol: str
+    side: str
+    quantity: float
+    order_type: str
+    price: Optional[float] = None
+    time_in_force: Optional[str] = None
+    client_order_id: Optional[str] = None
+
+
+@dataclass(slots=True)
+class OrderResult:
+    """Standardowa odpowiedź adaptera giełdowego."""
+
+    order_id: str
+    status: str
+    filled_quantity: float
+    avg_price: Optional[float]
+    raw_response: Mapping[str, Any]
+
+
+class ExchangeAdapter(abc.ABC):
+    """Bazowy interfejs wszystkich adapterów giełdowych."""
+
+    name: str
+
+    def __init__(self, credentials: ExchangeCredentials) -> None:
+        self._credentials = credentials
+
+    @property
+    def credentials(self) -> ExchangeCredentials:
+        """Udostępnia referencję do aktualnych poświadczeń."""
+
+        return self._credentials
+
+    @abc.abstractmethod
+    def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:
+        """Ustawia specyficzne wymagania sieciowe (np. IP allowlisting)."""
+
+    @abc.abstractmethod
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        """Pobiera bieżące informacje o kapitale, marginesie i saldach."""
+
+    @abc.abstractmethod
+    def fetch_symbols(self) -> Iterable[str]:
+        """Zwraca listę obsługiwanych instrumentów w formacie wewnętrznym."""
+
+    @abc.abstractmethod
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Sequence[float]]:
+        """Pobiera świece OHLCV w UTC na potrzeby warstwy danych."""
+
+    @abc.abstractmethod
+    def place_order(self, request: OrderRequest) -> OrderResult:
+        """Składa zlecenie w imieniu strategii."""
+
+    @abc.abstractmethod
+    def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> None:
+        """Anuluje zlecenie po identyfikatorze."""
+
+    @abc.abstractmethod
+    def stream_public_data(self, *, channels: Sequence[str]) -> Protocol:
+        """Udostępnia strumień danych publicznych (websocket/REST poll)."""
+
+    @abc.abstractmethod
+    def stream_private_data(self, *, channels: Sequence[str]) -> Protocol:
+        """Udostępnia strumień zdarzeń prywatnych (zlecenia, fills)."""
+
+
+class ExchangeAdapterFactory(Protocol):
+    """Prosty kontrakt dla fabryk adapterów (używany w konfiguracji)."""
+
+    def __call__(self, credentials: ExchangeCredentials, **kwargs: Any) -> ExchangeAdapter:
+        ...

--- a/bot_core/exchanges/binance/__init__.py
+++ b/bot_core/exchanges/binance/__init__.py
@@ -1,0 +1,6 @@
+"""Adaptery Binance."""
+
+from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+
+__all__ = ["BinanceFuturesAdapter", "BinanceSpotAdapter"]

--- a/bot_core/exchanges/binance/futures.py
+++ b/bot_core/exchanges/binance/futures.py
@@ -1,0 +1,306 @@
+"""Adapter REST dla kontraktów terminowych Binance (USD-M)."""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import time
+from hashlib import sha256
+from typing import Iterable, Mapping, Optional, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_HEADERS = {"User-Agent": "bot-core/1.0 (+https://github.com/)"}
+
+
+def _determine_public_base(environment: Environment) -> str:
+    """Zwraca bazowy adres REST dla danych publicznych kontraktów USD-M."""
+
+    if environment is Environment.TESTNET or environment is Environment.PAPER:
+        return "https://testnet.binancefuture.com"
+    return "https://fapi.binance.com"
+
+
+def _determine_trading_base(environment: Environment) -> str:
+    """Zwraca bazowy adres REST dla wywołań podpisanych kontraktów USD-M."""
+
+    if environment is Environment.TESTNET or environment is Environment.PAPER:
+        return "https://testnet.binancefuture.com"
+    return "https://fapi.binance.com"
+
+
+def _stringify_params(params: Mapping[str, object]) -> list[tuple[str, str]]:
+    normalized: list[tuple[str, str]] = []
+    for key, value in params.items():
+        if isinstance(value, bool):
+            normalized.append((key, "true" if value else "false"))
+        elif value is None:
+            continue
+        else:
+            normalized.append((key, str(value)))
+    return normalized
+
+
+def _to_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+class BinanceFuturesAdapter(ExchangeAdapter):
+    """Adapter REST dla rynku terminowego Binance (USD-M)."""
+
+    name: str = "binance_futures"
+
+    def __init__(
+        self,
+        credentials: ExchangeCredentials,
+        *,
+        environment: Environment | None = None,
+    ) -> None:
+        super().__init__(credentials)
+        self._environment = environment or credentials.environment
+        self._public_base = _determine_public_base(self._environment)
+        self._trading_base = _determine_trading_base(self._environment)
+        self._permission_set = frozenset(perm.lower() for perm in self._credentials.permissions)
+        self._ip_allowlist: tuple[str, ...] = ()
+
+    def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:
+        if ip_allowlist is None:
+            self._ip_allowlist = ()
+        else:
+            self._ip_allowlist = tuple(ip_allowlist)
+        _LOGGER.info("Ustawiono allowlistę IP dla Binance Futures: %s", self._ip_allowlist)
+
+    def _public_request(
+        self,
+        path: str,
+        params: Optional[Mapping[str, object]] = None,
+        *,
+        method: str = "GET",
+    ) -> dict[str, object] | list[object]:
+        query = f"?{urlencode(_stringify_params(params or {}))}" if params else ""
+        url = f"{self._public_base}{path}{query}"
+        data = None
+        headers = dict(_DEFAULT_HEADERS)
+        if method in {"POST", "PUT"} and params:
+            data = urlencode(_stringify_params(params)).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request = Request(url, headers=headers, data=data, method=method)
+        return self._execute_request(request)
+
+    def _signed_request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        params: Optional[Mapping[str, object]] = None,
+    ) -> dict[str, object] | list[object]:
+        if not self._credentials.secret:
+            raise RuntimeError("Do podpisanych endpointów wymagany jest secret klucza API Binance.")
+
+        timestamp_ms = int(time.time() * 1000)
+        base_params = dict(params or {})
+        base_params.setdefault("timestamp", timestamp_ms)
+        payload_items = _stringify_params(base_params)
+        query_string = urlencode(payload_items)
+        signature = hmac.new(
+            self._credentials.secret.encode("utf-8"),
+            query_string.encode("utf-8"),
+            sha256,
+        ).hexdigest()
+        signed_query = f"{query_string}&signature={signature}"
+
+        url = f"{self._trading_base}{path}"
+        headers = dict(_DEFAULT_HEADERS)
+        headers["X-MBX-APIKEY"] = self._credentials.key_id
+
+        if method in {"POST", "PUT"}:
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+            data = signed_query.encode("utf-8")
+            request = Request(url, headers=headers, data=data, method=method)
+        else:
+            separator = "?" if "?" not in url else "&"
+            request = Request(f"{url}{separator}{signed_query}", headers=headers, method=method)
+        return self._execute_request(request)
+
+    @staticmethod
+    def _execute_request(request: Request) -> dict[str, object] | list[object]:
+        try:
+            with urlopen(request, timeout=15) as response:  # nosec: B310 - zaufany endpoint
+                payload = response.read()
+        except HTTPError as exc:  # pragma: no cover - zależne od API
+            _LOGGER.error("Błąd HTTP podczas komunikacji z Binance Futures: %s", exc)
+            raise RuntimeError(f"Binance Futures API zwróciło błąd HTTP: {exc}") from exc
+        except URLError as exc:  # pragma: no cover - zależne od sieci
+            _LOGGER.error("Błąd sieci podczas komunikacji z Binance Futures: %s", exc)
+            raise RuntimeError("Nie udało się połączyć z API Binance Futures") from exc
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:  # pragma: no cover - błąd po stronie API
+            _LOGGER.error("Niepoprawna odpowiedź JSON z Binance Futures: %s", exc)
+            raise RuntimeError("Niepoprawna odpowiedź JSON od API Binance Futures") from exc
+        return data
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        if not ({"read", "trade"} & self._permission_set):
+            raise PermissionError("Poświadczenia nie pozwalają na odczyt danych konta Binance Futures.")
+
+        payload = self._signed_request("/fapi/v2/account")
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("Niepoprawna odpowiedź konta z Binance Futures")
+
+        assets = payload.get("assets", [])
+        balances: dict[str, float] = {}
+        available_margin = _to_float(payload.get("totalAvailableBalance"), 0.0)
+        maintenance_margin = _to_float(payload.get("totalMaintMargin"), 0.0)
+
+        if isinstance(assets, list):
+            for entry in assets:
+                if not isinstance(entry, Mapping):
+                    continue
+                asset = entry.get("asset")
+                wallet_balance = _to_float(entry.get("walletBalance"), 0.0)
+                if isinstance(asset, str):
+                    balances[asset] = wallet_balance
+
+        total_equity = _to_float(payload.get("totalMarginBalance"), 0.0)
+        if total_equity == 0.0:
+            wallet = _to_float(payload.get("totalWalletBalance"), 0.0)
+            unrealized = _to_float(payload.get("totalUnrealizedProfit"), 0.0)
+            total_equity = wallet + unrealized
+
+        return AccountSnapshot(
+            balances=balances,
+            total_equity=total_equity,
+            available_margin=available_margin,
+            maintenance_margin=maintenance_margin,
+        )
+
+    def fetch_symbols(self) -> Iterable[str]:
+        payload = self._public_request("/fapi/v1/exchangeInfo")
+        if not isinstance(payload, Mapping) or "symbols" not in payload:
+            raise RuntimeError("Niepoprawna odpowiedź exchangeInfo z Binance Futures")
+
+        symbols_raw = payload.get("symbols")
+        if not isinstance(symbols_raw, list):
+            raise RuntimeError("Pole 'symbols' w odpowiedzi Binance Futures ma niepoprawny format")
+
+        active: list[str] = []
+        for entry in symbols_raw:
+            if not isinstance(entry, Mapping):
+                continue
+            status = entry.get("status")
+            symbol = entry.get("symbol")
+            if status != "TRADING" or not isinstance(symbol, str):
+                continue
+            active.append(symbol)
+        return active
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Sequence[float]]:
+        params: dict[str, object] = {"symbol": symbol, "interval": interval}
+        if start is not None:
+            params["startTime"] = int(start)
+        if end is not None:
+            params["endTime"] = int(end)
+        if limit is not None:
+            params["limit"] = int(limit)
+
+        payload = self._public_request("/fapi/v1/klines", params=params)
+        if not isinstance(payload, list):
+            raise RuntimeError("Odpowiedź klines z Binance Futures ma nieoczekiwany format")
+
+        candles: list[Sequence[float]] = []
+        for entry in payload:
+            if not isinstance(entry, list) or len(entry) < 6:
+                continue
+            open_time = float(entry[0])
+            open_price = float(entry[1])
+            high = float(entry[2])
+            low = float(entry[3])
+            close = float(entry[4])
+            volume = float(entry[5])
+            candles.append([open_time, open_price, high, low, close, volume])
+        return candles
+
+    def place_order(self, request: OrderRequest) -> OrderResult:
+        if "trade" not in self._permission_set:
+            raise PermissionError("Aktualne poświadczenia nie mają uprawnień tradingowych.")
+
+        params: dict[str, object] = {
+            "symbol": request.symbol,
+            "side": request.side.upper(),
+            "type": request.order_type.upper(),
+            "quantity": request.quantity,
+        }
+        if request.price is not None:
+            params["price"] = request.price
+        if request.time_in_force is not None:
+            params["timeInForce"] = request.time_in_force
+        if request.client_order_id is not None:
+            params["newClientOrderId"] = request.client_order_id
+
+        payload = self._signed_request("/fapi/v1/order", method="POST", params=params)
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("Odpowiedź z endpointu futures order ma niepoprawny format")
+
+        payload_dict = dict(payload)
+        order_id = str(payload_dict.get("orderId"))
+        status = str(payload_dict.get("status", "UNKNOWN"))
+        filled_qty = _to_float(payload_dict.get("executedQty", 0.0))
+        avg_price_field = payload_dict.get("avgPrice", payload_dict.get("price"))
+        avg_price = _to_float(avg_price_field) if avg_price_field not in (None, "0", 0, 0.0) else None
+
+        return OrderResult(
+            order_id=order_id,
+            status=status,
+            filled_quantity=filled_qty,
+            avg_price=avg_price,
+            raw_response=payload_dict,
+        )
+
+    def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> None:
+        if "trade" not in self._permission_set:
+            raise PermissionError("Aktualne poświadczenia nie mają uprawnień tradingowych.")
+        if not symbol:
+            raise ValueError("Anulowanie na Binance Futures wymaga podania symbolu.")
+
+        params: dict[str, object] = {"orderId": order_id, "symbol": symbol}
+        response = self._signed_request("/fapi/v1/order", method="DELETE", params=params)
+        if isinstance(response, Mapping):
+            response_map = dict(response)
+            status = response_map.get("status")
+            if status in {"CANCELED", "PENDING_CANCEL", "NEW"}:
+                return
+            raise RuntimeError(f"Nieoczekiwana odpowiedź anulowania z Binance Futures: {response_map}")
+        raise RuntimeError("Niepoprawna odpowiedź anulowania z Binance Futures")
+
+    def stream_public_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Stream publiczny futures zostanie dodany w kolejnej iteracji.")
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Stream prywatny futures zostanie dodany w kolejnej iteracji.")
+
+
+__all__ = ["BinanceFuturesAdapter"]

--- a/bot_core/exchanges/binance/spot.py
+++ b/bot_core/exchanges/binance/spot.py
@@ -1,0 +1,326 @@
+"""Adapter REST dla rynku spot Binance do obsługi danych publicznych i prywatnych."""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import time
+from hashlib import sha256
+from typing import Iterable, Mapping, Optional, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_HEADERS = {"User-Agent": "bot-core/1.0 (+https://github.com/)"}
+
+
+def _to_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _determine_public_base(environment: Environment) -> str:
+    """Zwraca właściwy punkt końcowy REST dla danych publicznych."""
+
+    # Binance nie udostępnia pełnych danych historycznych na testnecie,
+    # dlatego zarówno środowisko PAPER, jak i TESTNET wykorzystują publiczny endpoint produkcyjny.
+    return "https://api.binance.com"
+
+
+def _determine_trading_base(environment: Environment) -> str:
+    """Zwraca punkt końcowy dla operacji wymagających podpisu."""
+
+    if environment is Environment.TESTNET or environment is Environment.PAPER:
+        # Oficjalny testnet Binance udostępnia podpisane endpointy pod domeną testnet.binance.vision.
+        return "https://testnet.binance.vision"
+    return "https://api.binance.com"
+
+
+def _stringify_params(params: Mapping[str, object]) -> list[tuple[str, str]]:
+    """Konwertuje wartości parametrów na tekst wymagany przez API Binance."""
+
+    normalized: list[tuple[str, str]] = []
+    for key, value in params.items():
+        if isinstance(value, bool):
+            normalized.append((key, "true" if value else "false"))
+        elif value is None:
+            continue
+        else:
+            normalized.append((key, str(value)))
+    return normalized
+
+
+class BinanceSpotAdapter(ExchangeAdapter):
+    """Adapter dla rynku spot Binance z obsługą danych publicznych i podpisanych."""
+
+    __slots__ = (
+        "_environment",
+        "_public_base",
+        "_trading_base",
+        "_ip_allowlist",
+        "_permission_set",
+    )
+
+    name: str = "binance_spot"
+
+    def __init__(self, credentials: ExchangeCredentials, *, environment: Environment | None = None) -> None:
+        super().__init__(credentials)
+        self._environment = environment or credentials.environment
+        self._public_base = _determine_public_base(self._environment)
+        self._trading_base = _determine_trading_base(self._environment)
+        self._ip_allowlist: tuple[str, ...] = ()
+        self._permission_set = frozenset(perm.lower() for perm in self._credentials.permissions)
+
+    def _public_request(
+        self,
+        path: str,
+        params: Optional[Mapping[str, object]] = None,
+        *,
+        method: str = "GET",
+    ) -> dict[str, object] | list[object]:
+        query = f"?{urlencode(_stringify_params(params or {}))}" if params else ""
+        url = f"{self._public_base}{path}{query}"
+        data = None
+        headers = dict(_DEFAULT_HEADERS)
+        if method in {"POST", "PUT"} and params:
+            data = urlencode(_stringify_params(params)).encode("utf-8")
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        request = Request(url, headers=headers, data=data, method=method)
+        return self._execute_request(request)
+
+    def _signed_request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        params: Optional[Mapping[str, object]] = None,
+    ) -> dict[str, object] | list[object]:
+        if not self._credentials.secret:
+            raise RuntimeError("Do podpisanych endpointów wymagany jest secret klucza API Binance.")
+
+        timestamp_ms = int(time.time() * 1000)
+        base_params = dict(params or {})
+        base_params.setdefault("timestamp", timestamp_ms)
+        payload_items = _stringify_params(base_params)
+        query_string = urlencode(payload_items)
+        signature = hmac.new(
+            self._credentials.secret.encode("utf-8"),
+            query_string.encode("utf-8"),
+            sha256,
+        ).hexdigest()
+        signed_query = f"{query_string}&signature={signature}"
+
+        url = f"{self._trading_base}{path}"
+        headers = dict(_DEFAULT_HEADERS)
+        headers["X-MBX-APIKEY"] = self._credentials.key_id
+
+        data: Optional[bytes]
+        if method in {"POST", "PUT"}:
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+            data = signed_query.encode("utf-8")
+            request = Request(url, headers=headers, data=data, method=method)
+        else:
+            separator = "?" if "?" not in url else "&"
+            request = Request(f"{url}{separator}{signed_query}", headers=headers, method=method)
+            data = None
+
+        return self._execute_request(request)
+
+    @staticmethod
+    def _execute_request(request: Request) -> dict[str, object] | list[object]:
+        try:
+            with urlopen(request, timeout=15) as response:  # nosec: B310 - endpoint zaufany
+                payload = response.read()
+        except HTTPError as exc:  # pragma: no cover - zależne od API i środowiska sieciowego
+            _LOGGER.error("Błąd HTTP podczas komunikacji z Binance: %s", exc)
+            raise RuntimeError(f"Binance API zwróciło błąd HTTP: {exc}") from exc
+        except URLError as exc:  # pragma: no cover - zależne od sieci
+            _LOGGER.error("Błąd sieci podczas komunikacji z Binance: %s", exc)
+            raise RuntimeError("Nie udało się połączyć z API Binance") from exc
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:  # pragma: no cover - niepoprawne JSON to błąd API
+            _LOGGER.error("Niepoprawna odpowiedź JSON od Binance: %s", exc)
+            raise RuntimeError("Niepoprawna odpowiedź JSON od API Binance") from exc
+        return data
+
+    def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:
+        """Zachowuje konfigurację allowlisty, aby risk engine mógł ją audytować."""
+
+        if ip_allowlist is None:
+            self._ip_allowlist = ()
+        else:
+            self._ip_allowlist = tuple(ip_allowlist)
+        _LOGGER.info("Ustawiono allowlistę IP dla Binance: %s", self._ip_allowlist)
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        """Pobiera podstawowe dane o stanie rachunku do oceny limitów ryzyka."""
+
+        if not ({"read", "trade"} & self._permission_set):
+            raise PermissionError("Poświadczenia nie pozwalają na odczyt danych konta Binance.")
+
+        payload = self._signed_request("/api/v3/account")
+        if not isinstance(payload, dict):
+            raise RuntimeError("Niepoprawna odpowiedź konta z Binance")
+
+        balances_section = payload.get("balances", [])
+        balances: dict[str, float] = {}
+        available_margin = 0.0
+        if isinstance(balances_section, list):
+            for entry in balances_section:
+                if not isinstance(entry, Mapping):
+                    continue
+                asset = entry.get("asset")
+                free = _to_float(entry.get("free", 0.0))
+                locked = _to_float(entry.get("locked", 0.0))
+                if not isinstance(asset, str):
+                    continue
+                balances[asset] = free + locked
+                available_margin += free
+
+        total_equity = sum(balances.values())
+        maintenance_margin = _to_float(
+            payload.get("maintMarginBalance", payload.get("totalMarginBalance", 0.0))
+        )
+
+        return AccountSnapshot(
+            balances=balances,
+            total_equity=total_equity,
+            available_margin=available_margin,
+            maintenance_margin=maintenance_margin,
+        )
+
+    def fetch_symbols(self) -> Iterable[str]:
+        """Pobiera listę aktywnych symboli spot z Binance."""
+
+        payload = self._public_request("/api/v3/exchangeInfo")
+        if not isinstance(payload, dict) or "symbols" not in payload:
+            raise RuntimeError("Niepoprawna odpowiedź exchangeInfo z Binance")
+
+        symbols_section = payload.get("symbols")
+        if not isinstance(symbols_section, list):
+            raise RuntimeError("Pole 'symbols' w odpowiedzi Binance ma niepoprawny format")
+
+        active_symbols: list[str] = []
+        for entry in symbols_section:
+            if not isinstance(entry, dict):
+                continue
+            status = entry.get("status")
+            symbol = entry.get("symbol")
+            if status != "TRADING" or not isinstance(symbol, str):
+                continue
+            active_symbols.append(symbol)
+        return active_symbols
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Sequence[float]]:
+        """Pobiera świece OHLCV w formacie zgodnym z modułem danych."""
+
+        params: dict[str, object] = {"symbol": symbol, "interval": interval}
+        if start is not None:
+            params["startTime"] = int(start)
+        if end is not None:
+            params["endTime"] = int(end)
+        if limit is not None:
+            params["limit"] = int(limit)
+
+        payload = self._public_request("/api/v3/klines", params=params)
+        if not isinstance(payload, list):
+            raise RuntimeError("Odpowiedź klines z Binance ma nieoczekiwany format")
+
+        candles: list[Sequence[float]] = []
+        for entry in payload:
+            if not isinstance(entry, list) or len(entry) < 6:
+                continue
+            open_time = float(entry[0])
+            open_price = float(entry[1])
+            high = float(entry[2])
+            low = float(entry[3])
+            close = float(entry[4])
+            volume = float(entry[5])
+            candles.append([open_time, open_price, high, low, close, volume])
+        return candles
+
+    def place_order(self, request: OrderRequest) -> OrderResult:
+        """Składa podpisane zlecenie typu limit/market na rynku spot."""
+
+        if "trade" not in self._permission_set:
+            raise PermissionError("Aktualne poświadczenia nie mają uprawnień tradingowych.")
+
+        params: dict[str, object] = {
+            "symbol": request.symbol,
+            "side": request.side.upper(),
+            "type": request.order_type.upper(),
+            "quantity": request.quantity,
+        }
+        if request.price is not None:
+            params["price"] = request.price
+        if request.time_in_force is not None:
+            params["timeInForce"] = request.time_in_force
+        if request.client_order_id is not None:
+            params["newClientOrderId"] = request.client_order_id
+
+        payload = self._signed_request("/api/v3/order", method="POST", params=params)
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("Odpowiedź z endpointu order ma niepoprawny format")
+
+        payload_dict = dict(payload)
+
+        order_id = str(payload_dict.get("orderId"))
+        status = str(payload_dict.get("status", "UNKNOWN"))
+        filled_qty = _to_float(payload_dict.get("executedQty", 0.0))
+        raw_price = payload_dict.get("price")
+        avg_price = _to_float(raw_price) if raw_price not in (None, "0", 0, 0.0) else None
+
+        return OrderResult(
+            order_id=order_id,
+            status=status,
+            filled_quantity=filled_qty,
+            avg_price=avg_price,
+            raw_response=payload_dict,
+        )
+
+    def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> None:
+        if "trade" not in self._permission_set:
+            raise PermissionError("Aktualne poświadczenia nie mają uprawnień tradingowych.")
+        params: dict[str, object] = {"orderId": order_id}
+        if symbol:
+            params["symbol"] = symbol
+        response = self._signed_request("/api/v3/order", method="DELETE", params=params)
+        if isinstance(response, Mapping):
+            response_map = dict(response)
+            if response_map.get("status") in {"CANCELED", "PENDING_CANCEL"}:
+                return
+        # Jeśli API zwróciło błąd, `urlopen` podniesie wyjątek HTTPError; jeśli odpowiedź jest dziwna,
+        # sygnalizujemy to wyjątkiem, aby egzekucja mogła przejść w tryb bezpieczny.
+            raise RuntimeError(f"Nieoczekiwana odpowiedź anulowania z Binance: {response_map}")
+        raise RuntimeError("Niepoprawna odpowiedź anulowania z Binance")
+
+    def stream_public_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Stream danych publicznych zostanie dodany w przyszłym etapie.")
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Stream danych prywatnych zostanie dodany w przyszłym etapie.")
+
+
+__all__ = ["BinanceSpotAdapter"]

--- a/bot_core/exchanges/kraken/__init__.py
+++ b/bot_core/exchanges/kraken/__init__.py
@@ -1,0 +1,6 @@
+"""Adaptery giełdowe dla Kraken Spot oraz Futures."""
+
+from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
+from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
+
+__all__ = ["KrakenSpotAdapter", "KrakenFuturesAdapter"]

--- a/bot_core/exchanges/kraken/futures.py
+++ b/bot_core/exchanges/kraken/futures.py
@@ -1,0 +1,312 @@
+"""Adapter REST dla Kraken Futures zgodny z interfejsem ``ExchangeAdapter``."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping, Sequence
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+
+_API_PREFIX = "/derivatives/api/v3"
+_BASE_ORIGINS: Mapping[Environment, str] = {
+    Environment.LIVE: "https://futures.kraken.com",
+    Environment.PAPER: "https://futures.kraken.com",
+    Environment.TESTNET: "https://demo-futures.kraken.com",
+}
+
+_INTERVAL_MAPPING: Mapping[str, int] = {
+    "1m": 1,
+    "5m": 5,
+    "15m": 15,
+    "1h": 60,
+    "4h": 240,
+    "1d": 1440,
+}
+
+
+@dataclass(slots=True)
+class _RequestContext:
+    path: str
+    method: str
+    params: Mapping[str, Any]
+    body: Mapping[str, Any] | None = None
+
+
+class KrakenFuturesAdapter(ExchangeAdapter):
+    """Obsługuje publiczne i prywatne endpointy Kraken Futures."""
+
+    name = "kraken_futures"
+
+    def __init__(self, credentials: ExchangeCredentials, *, environment: Environment) -> None:
+        super().__init__(credentials)
+        self._environment = environment
+        try:
+            self._origin = _BASE_ORIGINS[environment]
+        except KeyError as exc:  # pragma: no cover - brak konfiguracji w testach
+            raise ValueError(f"Nieobsługiwane środowisko Kraken Futures: {environment}") from exc
+        self._permission_set = frozenset(str(perm).lower() for perm in credentials.permissions)
+        self._ip_allowlist: Sequence[str] | None = None
+        self._http_timeout = 20
+
+    # ------------------------------------------------------------------
+    # Konfiguracja sieci
+    # ------------------------------------------------------------------
+    def configure_network(self, *, ip_allowlist: Sequence[str] | None = None) -> None:  # type: ignore[override]
+        self._ip_allowlist = tuple(ip_allowlist) if ip_allowlist else None
+
+    # ------------------------------------------------------------------
+    # Dane konta i publiczne API
+    # ------------------------------------------------------------------
+    def fetch_account_snapshot(self) -> AccountSnapshot:  # type: ignore[override]
+        if "read" not in self._permission_set:
+            raise PermissionError("Poświadczenia Kraken Futures nie mają uprawnień do odczytu.")
+
+        context = _RequestContext(path="/accounts", method="GET", params={})
+        payload = self._private_request(context)
+        accounts = payload.get("accounts", {}) if isinstance(payload, Mapping) else {}
+        futures = accounts.get("futures", {}) if isinstance(accounts, Mapping) else {}
+
+        balances: MutableMapping[str, float] = {}
+        raw_balances = futures.get("balances") if isinstance(futures, Mapping) else None
+        if isinstance(raw_balances, Mapping):
+            for asset, info in raw_balances.items():
+                if isinstance(info, Mapping):
+                    amount = info.get("balance") or info.get("available")
+                else:
+                    amount = info
+                try:
+                    balances[str(asset)] = float(amount) if amount is not None else 0.0
+                except (TypeError, ValueError):
+                    continue
+
+        total_equity = _to_float(futures.get("accountValue"))
+        available_margin = _to_float(futures.get("availableMargin"))
+        maintenance_margin = _to_float(futures.get("maintenanceMargin"))
+        if maintenance_margin == 0.0:
+            maintenance_margin = _to_float(futures.get("initialMargin"))
+
+        return AccountSnapshot(
+            balances=dict(balances),
+            total_equity=total_equity,
+            available_margin=available_margin,
+            maintenance_margin=maintenance_margin,
+        )
+
+    def fetch_symbols(self) -> Sequence[str]:  # type: ignore[override]
+        payload = self._public_request("/instruments", params={})
+        instruments = payload.get("instruments") if isinstance(payload, Mapping) else None
+        symbols: list[str] = []
+        if isinstance(instruments, Sequence):
+            for item in instruments:
+                symbol = item.get("symbol") if isinstance(item, Mapping) else None
+                if isinstance(symbol, str):
+                    symbols.append(symbol)
+        return sorted(set(symbols))
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: int | None = None,
+        end: int | None = None,
+        limit: int | None = None,
+    ) -> Sequence[Sequence[float]]:  # type: ignore[override]
+        resolution = _INTERVAL_MAPPING.get(interval)
+        if resolution is None:
+            raise ValueError(f"Nieobsługiwany interwał {interval!r} dla Kraken Futures")
+
+        params: MutableMapping[str, Any] = {"symbol": symbol, "resolution": resolution}
+        if start is not None:
+            params["from"] = int(start)
+        if end is not None:
+            params["to"] = int(end)
+
+        payload = self._public_request("/ohlc", params=params)
+        candles: list[Sequence[float]] = []
+        series = payload.get("series") if isinstance(payload, Mapping) else None
+        if isinstance(series, Sequence):
+            for entry in series:
+                if not isinstance(entry, Mapping):
+                    continue
+                data = entry.get("data")
+                if isinstance(data, Sequence):
+                    for candle in data:
+                        if isinstance(candle, Sequence) and len(candle) >= 6:
+                            ts, o, h, l, c, v = candle[:6]
+                            candles.append([float(ts), float(o), float(h), float(l), float(c), float(v)])
+                break
+        if limit is not None:
+            candles = candles[:limit]
+        return candles
+
+    # ------------------------------------------------------------------
+    # Operacje tradingowe
+    # ------------------------------------------------------------------
+    def place_order(self, request: OrderRequest) -> OrderResult:  # type: ignore[override]
+        if "trade" not in self._permission_set:
+            raise PermissionError("Poświadczenia Kraken Futures nie mają uprawnień tradingowych.")
+
+        order_type = request.order_type.lower()
+        if order_type == "market":
+            api_order_type = "mkt"
+        elif order_type == "limit":
+            api_order_type = "lmt"
+        else:
+            raise ValueError(f"Nieobsługiwany typ zlecenia Kraken Futures: {request.order_type}")
+
+        body: MutableMapping[str, Any] = {
+            "orderType": api_order_type,
+            "symbol": request.symbol,
+            "side": request.side.lower(),
+            "size": f"{request.quantity:.8f}",
+        }
+        if api_order_type == "lmt":
+            if request.price is None:
+                raise ValueError("Zlecenie limit na Kraken Futures wymaga ceny.")
+            body["limitPrice"] = f"{request.price:.2f}"
+        if request.time_in_force:
+            tif = request.time_in_force.upper()
+            if tif not in {"GTC", "IOC", "FOK"}:
+                raise ValueError(f"Nieobsługiwane time in force '{tif}' dla Kraken Futures")
+            body["timeInForce"] = tif
+        if request.client_order_id:
+            body["cliOrdId"] = request.client_order_id
+
+        context = _RequestContext(path="/orders", method="POST", params={}, body=body)
+        payload = self._private_request(context)
+
+        send_status = payload.get("sendStatus") if isinstance(payload, Mapping) else None
+        order_id = ""
+        if isinstance(send_status, Mapping):
+            order_id = str(send_status.get("order_id") or send_status.get("orderId") or "")
+            events = send_status.get("orderEvents")
+        else:
+            events = None
+        filled_quantity = 0.0
+        avg_price: float | None = None
+        if isinstance(events, Sequence):
+            for event in events:
+                if not isinstance(event, Mapping):
+                    continue
+                if event.get("type") == "fill":
+                    filled_quantity += _to_float(event.get("fill_size"))
+                    avg_price = _to_float(event.get("price"))
+        status = "NEW"
+        if isinstance(send_status, Mapping):
+            status = str(send_status.get("status") or "NEW").upper()
+
+        return OrderResult(
+            order_id=order_id,
+            status=status,
+            filled_quantity=filled_quantity,
+            avg_price=avg_price,
+            raw_response=send_status if isinstance(send_status, Mapping) else {},
+        )
+
+    def cancel_order(self, order_id: str, *, symbol: str | None = None) -> None:  # type: ignore[override]
+        if "trade" not in self._permission_set:
+            raise PermissionError("Poświadczenia Kraken Futures nie mają uprawnień tradingowych.")
+
+        context = _RequestContext(path=f"/orders/{order_id}", method="DELETE", params={})
+        payload = self._private_request(context)
+        result = payload.get("cancelStatus") if isinstance(payload, Mapping) else None
+        if not isinstance(result, Mapping) or str(result.get("status")).lower() != "cancelled":
+            raise RuntimeError(f"Kraken Futures nie potwierdził anulowania zlecenia: {payload}")
+
+    # ------------------------------------------------------------------
+    # Streaming (do implementacji w dalszym etapie)
+    # ------------------------------------------------------------------
+    def stream_public_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Streaming Kraken Futures zostanie dodany w przyszłym etapie.")
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Streaming prywatny Kraken Futures zostanie dodany w przyszłym etapie.")
+
+    # ------------------------------------------------------------------
+    # Wewnętrzne narzędzia HTTP/podpisy
+    # ------------------------------------------------------------------
+    def _public_request(self, path: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        url = f"{self._origin}{_API_PREFIX}{path}"
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        request = Request(url, headers={"User-Agent": "bot-core/kraken-futures"})
+        with urlopen(request, timeout=self._http_timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        _ensure_success(payload)
+        return payload
+
+    def _private_request(self, context: _RequestContext) -> Mapping[str, Any]:
+        if not self.credentials.secret:
+            raise PermissionError("Poświadczenia Kraken Futures wymagają sekretu do wywołań prywatnych.")
+
+        path = _normalize_path(context.path)
+        query = f"?{urlencode(context.params)}" if context.params else ""
+        url = f"{self._origin}{_API_PREFIX}{path}{query}"
+        body_bytes = b""
+        if context.body is not None:
+            body_bytes = json.dumps(
+                context.body,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+        nonce = str(int(time.time() * 1000))
+        message = nonce.encode("utf-8") + path.encode("utf-8") + query.encode("utf-8") + body_bytes
+        sha_digest = hashlib.sha256(message).digest()
+        decoded_secret = base64.b64decode(self.credentials.secret)
+        mac = hmac.new(decoded_secret, sha_digest, hashlib.sha256)
+        signature = base64.b64encode(mac.digest()).decode("utf-8")
+
+        headers = {
+            "User-Agent": "bot-core/kraken-futures",
+            "Content-Type": "application/json",
+            "APIKey": self.credentials.key_id,
+            "Authent": signature,
+            "Nonce": nonce,
+        }
+        request = Request(url, data=body_bytes if body_bytes else None, headers=headers, method=context.method)
+        with urlopen(request, timeout=self._http_timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        _ensure_success(payload)
+        return payload
+
+
+def _normalize_path(path: str) -> str:
+    path = path.strip()
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path
+
+
+def _to_float(value: Any) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _ensure_success(payload: Mapping[str, Any]) -> None:
+    result = payload.get("result") if isinstance(payload, Mapping) else None
+    if isinstance(result, str) and result.lower() == "success":
+        return
+    if "error" in payload and not payload.get("error"):
+        return
+    if result is None and "sendStatus" in payload:
+        return
+    raise RuntimeError(f"Kraken Futures API zwróciło błąd: {payload}")
+
+
+__all__ = ["KrakenFuturesAdapter"]

--- a/bot_core/exchanges/kraken/spot.py
+++ b/bot_core/exchanges/kraken/spot.py
@@ -1,0 +1,263 @@
+"""Adapter REST dla Kraken Spot zgodny z interfejsem `ExchangeAdapter`."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping, Sequence
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+
+
+_BASE_URLS: Mapping[Environment, str] = {
+    Environment.LIVE: "https://api.kraken.com",
+    Environment.PAPER: "https://api.kraken.com",
+    Environment.TESTNET: "https://api.kraken.com",
+}
+
+
+_INTERVAL_MAPPING: Mapping[str, int] = {
+    "1m": 1,
+    "5m": 5,
+    "15m": 15,
+    "30m": 30,
+    "1h": 60,
+    "4h": 240,
+    "1d": 1440,
+}
+
+
+@dataclass(slots=True)
+class _RequestContext:
+    path: str
+    params: Mapping[str, Any]
+
+
+class KrakenSpotAdapter(ExchangeAdapter):
+    """Implementacja publicznych i prywatnych endpointów Kraken Spot."""
+
+    name = "kraken_spot"
+
+    def __init__(self, credentials: ExchangeCredentials, *, environment: Environment) -> None:
+        super().__init__(credentials)
+        self._environment = environment
+        try:
+            self._base_url = _BASE_URLS[environment]
+        except KeyError as exc:  # pragma: no cover - brak konfiguracji
+            raise ValueError(f"Nieobsługiwane środowisko Kraken: {environment}") from exc
+        self._http_timeout = 15
+        self._permission_set = set(credentials.permissions)
+        self._ip_allowlist: Sequence[str] | None = None
+        self._last_nonce = 0
+
+    # ------------------------------------------------------------------
+    # Konfiguracja sieciowa
+    # ------------------------------------------------------------------
+    def configure_network(self, *, ip_allowlist: Sequence[str] | None = None) -> None:  # type: ignore[override]
+        self._ip_allowlist = tuple(ip_allowlist) if ip_allowlist else None
+
+    # ------------------------------------------------------------------
+    # Dane konta i publiczne API
+    # ------------------------------------------------------------------
+    def fetch_account_snapshot(self) -> AccountSnapshot:  # type: ignore[override]
+        if "read" not in self._permission_set:
+            raise PermissionError("Poświadczenia Kraken nie mają uprawnień do odczytu.")
+        balances_payload = self._private_request(_RequestContext(path="/0/private/Balance", params={}))
+        trade_balance_payload = self._private_request(
+            _RequestContext(path="/0/private/TradeBalance", params={"asset": "ZUSD"})
+        )
+
+        balances_data = balances_payload.get("result", {}) if isinstance(balances_payload, Mapping) else {}
+        balances: MutableMapping[str, float] = {}
+        for asset, amount in balances_data.items():
+            try:
+                balances[asset] = float(amount)
+            except (TypeError, ValueError):
+                continue
+
+        trade_data = trade_balance_payload.get("result", {}) if isinstance(trade_balance_payload, Mapping) else {}
+        total_equity = float(trade_data.get("eb", trade_data.get("e", 0.0)) or 0.0)
+        available_margin = float(trade_data.get("mf", 0.0) or 0.0)
+        maintenance_margin = float(trade_data.get("m", 0.0) or 0.0)
+
+        return AccountSnapshot(
+            balances=dict(balances),
+            total_equity=total_equity,
+            available_margin=available_margin,
+            maintenance_margin=maintenance_margin,
+        )
+
+    def fetch_symbols(self) -> Sequence[str]:  # type: ignore[override]
+        payload = self._public_request("/0/public/AssetPairs", params={})
+        result = payload.get("result", {}) if isinstance(payload, Mapping) else {}
+        symbols: list[str] = []
+        for value in result.values():
+            if isinstance(value, Mapping):
+                altname = value.get("altname") or value.get("wsname")
+                if isinstance(altname, str):
+                    symbols.append(altname)
+        return sorted(set(symbols))
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: int | None = None,
+        end: int | None = None,
+        limit: int | None = None,
+    ) -> Sequence[Sequence[float]]:  # type: ignore[override]
+        minutes = _INTERVAL_MAPPING.get(interval)
+        if minutes is None:
+            raise ValueError(f"Nieobsługiwany interwał {interval!r} dla Kraken Spot")
+
+        params: MutableMapping[str, Any] = {"pair": symbol, "interval": minutes}
+        if start:
+            params["since"] = int(start)
+        payload = self._public_request("/0/public/OHLC", params=params)
+        result = payload.get("result", {}) if isinstance(payload, Mapping) else {}
+        candles = []
+        for values in result.values():
+            if isinstance(values, Sequence):
+                for candle in values:
+                    if isinstance(candle, Sequence) and len(candle) >= 6:
+                        ts, o, h, l, c, v = candle[:6]
+                        candles.append([float(ts), float(o), float(h), float(l), float(c), float(v)])
+                break
+        if limit is not None:
+            candles = candles[:limit]
+        return candles
+
+    # ------------------------------------------------------------------
+    # Operacje tradingowe
+    # ------------------------------------------------------------------
+    def place_order(self, request: OrderRequest) -> OrderResult:  # type: ignore[override]
+        if "trade" not in self._permission_set:
+            raise PermissionError("Poświadczenia Kraken nie mają uprawnień tradingowych.")
+
+        params: MutableMapping[str, Any] = {
+            "pair": request.symbol,
+            "type": request.side.lower(),
+            "volume": f"{request.quantity:.10f}",
+        }
+
+        order_type = request.order_type.lower()
+        if order_type == "market":
+            params["ordertype"] = "market"
+        elif order_type == "limit":
+            if request.price is None:
+                raise ValueError("Zlecenie limit na Kraken wymaga ceny.")
+            params["ordertype"] = "limit"
+            params["price"] = f"{request.price:.10f}"
+        else:
+            raise ValueError(f"Nieobsługiwany typ zlecenia dla Kraken Spot: {request.order_type}")
+
+        if request.time_in_force:
+            tif = request.time_in_force.upper()
+            if tif not in {"GTC", "IOC", "GTD"}:
+                raise ValueError(f"Nieobsługiwane time in force '{tif}' dla Kraken Spot")
+            params["timeinforce"] = tif
+        if request.client_order_id:
+            params["userref"] = request.client_order_id
+
+        payload = self._private_request(_RequestContext(path="/0/private/AddOrder", params=params))
+        result = payload.get("result", {}) if isinstance(payload, Mapping) else {}
+        txid_seq = result.get("txid") if isinstance(result, Mapping) else None
+        txid: str | None = None
+        if isinstance(txid_seq, Sequence) and txid_seq:
+            first = txid_seq[0]
+            if isinstance(first, str):
+                txid = first
+        return OrderResult(
+            order_id=txid or "",
+            status="NEW",
+            filled_quantity=0.0,
+            avg_price=None,
+            raw_response=result if isinstance(result, Mapping) else {},
+        )
+
+    def cancel_order(self, order_id: str, *, symbol: str | None = None) -> None:  # type: ignore[override]
+        if "trade" not in self._permission_set:
+            raise PermissionError("Poświadczenia Kraken nie mają uprawnień tradingowych.")
+        params: Mapping[str, Any] = {"txid": order_id}
+        payload = self._private_request(_RequestContext(path="/0/private/CancelOrder", params=params))
+        result = payload.get("result", {}) if isinstance(payload, Mapping) else {}
+        if not isinstance(result, Mapping) or int(result.get("count", 0)) < 1:
+            raise RuntimeError(f"Kraken nie potwierdził anulowania zlecenia: {payload}")
+
+    # ------------------------------------------------------------------
+    # Streaming (do implementacji w dalszych etapach)
+    # ------------------------------------------------------------------
+    def stream_public_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Streaming publiczny Kraken zostanie dodany w przyszłym etapie.")
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Streaming prywatny Kraken zostanie dodany w przyszłym etapie.")
+
+    # ------------------------------------------------------------------
+    # Wewnętrzne narzędzia HTTP/podpisy
+    # ------------------------------------------------------------------
+    def _public_request(self, path: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        url = f"{self._base_url}{path}"
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        request = Request(url, headers={"User-Agent": "bot-core/kraken-spot"})
+        with urlopen(request, timeout=self._http_timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        self._ensure_no_error(payload)
+        return payload
+
+    def _private_request(self, context: _RequestContext) -> Mapping[str, Any]:
+        if not self.credentials.secret:
+            raise PermissionError("Poświadczenia Kraken wymagają sekretu do wywołań prywatnych.")
+
+        nonce = self._generate_nonce()
+        sorted_items = [(key, context.params[key]) for key in sorted(context.params.keys())]
+        post_items = [("nonce", nonce)] + [(k, v) for k, v in sorted_items]
+        encoded = urlencode(post_items)
+        data = encoded.encode("utf-8")
+
+        encoded_params = urlencode(sorted_items)
+        message = (nonce + encoded_params).encode("utf-8")
+        sha_digest = hashlib.sha256(message).digest()
+        decoded_secret = base64.b64decode(self.credentials.secret)
+        mac = hmac.new(decoded_secret, (context.path.encode("utf-8") + sha_digest), hashlib.sha512)
+        signature = base64.b64encode(mac.digest()).decode("utf-8")
+
+        headers = {
+            "User-Agent": "bot-core/kraken-spot",
+            "API-Key": self.credentials.key_id,
+            "API-Sign": signature,
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        request = Request(f"{self._base_url}{context.path}", data=data, headers=headers)
+        with urlopen(request, timeout=self._http_timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        self._ensure_no_error(payload)
+        return payload
+
+    def _ensure_no_error(self, payload: Mapping[str, Any]) -> None:
+        errors = payload.get("error") if isinstance(payload, Mapping) else None
+        if errors:
+            raise RuntimeError(f"Kraken API zwróciło błąd: {errors}")
+
+    def _generate_nonce(self) -> str:
+        candidate = int(time.time() * 1000)
+        if candidate <= self._last_nonce:
+            candidate = self._last_nonce + 1
+        self._last_nonce = candidate
+        return str(candidate)
+
+
+__all__ = ["KrakenSpotAdapter"]

--- a/bot_core/exchanges/zonda/__init__.py
+++ b/bot_core/exchanges/zonda/__init__.py
@@ -1,0 +1,5 @@
+"""Adaptery giełdy Zonda."""
+
+from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
+
+__all__ = ["ZondaSpotAdapter"]

--- a/bot_core/exchanges/zonda/spot.py
+++ b/bot_core/exchanges/zonda/spot.py
@@ -1,0 +1,348 @@
+"""Adapter REST dla rynku spot Zonda (dawniej BitBay)."""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from hashlib import sha512
+import hmac
+from typing import Iterable, Mapping, Optional, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_API_BASE_URL = "https://api.zonda.exchange/rest"
+_DEFAULT_HEADERS = {"User-Agent": "bot-core/1.0 (+https://github.com/)"}
+
+
+def _normalize_interval(interval: str) -> int:
+    """Konwertuje interwał tekstowy na sekundy wymagane przez API świec."""
+
+    mapping = {
+        "1m": 60,
+        "3m": 180,
+        "5m": 300,
+        "15m": 900,
+        "30m": 1_800,
+        "1h": 3_600,
+        "4h": 14_400,
+        "6h": 21_600,
+        "12h": 43_200,
+        "1d": 86_400,
+        "1w": 604_800,
+    }
+    key = interval.strip().lower()
+    if key.endswith("min"):
+        key = key[:-3] + "m"
+    if key.endswith("h") and key[:-1].isdigit():
+        key = key
+    if key.endswith("d") and key[:-1].isdigit():
+        key = key
+    if key.endswith("w") and key[:-1].isdigit():
+        key = key
+    if key not in mapping and key.endswith("m") and key[:-1].isdigit():
+        mapping[key] = int(key[:-1]) * 60
+    try:
+        return mapping[key]
+    except KeyError as exc:  # pragma: no cover - walidacja zostanie wychwycona w testach integracyjnych
+        raise ValueError(f"Nieobsługiwany interwał Zonda: {interval}") from exc
+
+
+def _to_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _json_body(payload: Mapping[str, object] | None) -> str:
+    if not payload:
+        return ""
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+
+@dataclass(slots=True)
+class _OrderPayload:
+    order_id: str
+    status: str
+    filled_quantity: float
+    avg_price: Optional[float]
+    raw: Mapping[str, object]
+
+
+class ZondaSpotAdapter(ExchangeAdapter):
+    """Adapter REST obsługujący podstawowe operacje tradingowe Zonda."""
+
+    __slots__ = (
+        "_environment",
+        "_base_url",
+        "_ip_allowlist",
+        "_permission_set",
+    )
+
+    name: str = "zonda_spot"
+
+    def __init__(self, credentials: ExchangeCredentials, *, environment: Environment | None = None) -> None:
+        super().__init__(credentials)
+        self._environment = environment or credentials.environment
+        self._base_url = _API_BASE_URL
+        self._ip_allowlist: tuple[str, ...] = ()
+        self._permission_set = frozenset(perm.lower() for perm in credentials.permissions)
+
+    # ------------------------------------------------------------------
+    # Pomocnicze metody HTTP
+    def _build_url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self._base_url}{path}"
+
+    def _execute_request(self, request: Request) -> dict[str, object] | list[object]:
+        try:
+            with urlopen(request, timeout=15) as response:  # nosec: B310 - kontrolowany endpoint
+                payload = response.read()
+        except HTTPError as exc:  # pragma: no cover - zależne od sieci
+            _LOGGER.error("Zonda zwróciła błąd HTTP: %s", exc)
+            raise RuntimeError(f"Zonda API zwróciła błąd HTTP: {exc}") from exc
+        except URLError as exc:  # pragma: no cover - zależne od sieci
+            _LOGGER.error("Błąd sieci podczas komunikacji z Zonda: %s", exc)
+            raise RuntimeError("Nie udało się połączyć z API Zonda") from exc
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:  # pragma: no cover
+            _LOGGER.error("Niepoprawna odpowiedź JSON od Zonda: %s", exc)
+            raise RuntimeError("Niepoprawna odpowiedź API Zonda") from exc
+        return data
+
+    def _public_request(
+        self,
+        path: str,
+        *,
+        params: Optional[Mapping[str, object]] = None,
+        method: str = "GET",
+    ) -> dict[str, object] | list[object]:
+        query = f"?{urlencode(params or {})}" if params else ""
+        request = Request(self._build_url(path) + query, headers=dict(_DEFAULT_HEADERS), method=method)
+        return self._execute_request(request)
+
+    def _signed_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Mapping[str, object]] = None,
+        data: Optional[Mapping[str, object]] = None,
+    ) -> dict[str, object] | list[object]:
+        if not self._credentials.secret:
+            raise RuntimeError("Poświadczenia Zonda wymagają secret do podpisywania żądań prywatnych.")
+
+        body = _json_body(data)
+        timestamp = str(int(time.time() * 1000))
+        payload = f"{timestamp}{method.upper()}{path}{body}"
+        signature = hmac.new(
+            self._credentials.secret.encode("utf-8"),
+            payload.encode("utf-8"),
+            sha512,
+        ).hexdigest()
+
+        headers = dict(_DEFAULT_HEADERS)
+        headers.update(
+            {
+                "API-Key": self._credentials.key_id,
+                "API-Hash": signature,
+                "Request-Timestamp": timestamp,
+            }
+        )
+
+        if params:
+            query = f"?{urlencode(params)}"
+        else:
+            query = ""
+
+        data_bytes: Optional[bytes] = None
+        if body:
+            data_bytes = body.encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = Request(
+            self._build_url(path) + query,
+            headers=headers,
+            data=data_bytes,
+            method=method,
+        )
+        return self._execute_request(request)
+
+    # ------------------------------------------------------------------
+    # Interfejs ExchangeAdapter
+    def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:
+        self._ip_allowlist = tuple(ip_allowlist or ())
+        if self._ip_allowlist:
+            _LOGGER.info("Zonda allowlist IP ustawiony na: %s", self._ip_allowlist)
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        if "read" not in self._permission_set and "trade" not in self._permission_set:
+            raise PermissionError("Poświadczenia Zonda nie mają uprawnień do odczytu sald.")
+
+        response = self._signed_request("POST", "/trading/balance")
+        if not isinstance(response, Mapping):
+            raise RuntimeError("Niepoprawna odpowiedź balansu z Zonda")
+
+        balances_section = response.get("balances", [])
+        balances: dict[str, float] = {}
+        available_total = 0.0
+        total_equity = 0.0
+        if isinstance(balances_section, list):
+            for entry in balances_section:
+                if not isinstance(entry, Mapping):
+                    continue
+                currency = entry.get("currency") or entry.get("code")
+                available = _to_float(entry.get("available"))
+                locked = _to_float(entry.get("locked") or entry.get("reserved"))
+                if isinstance(currency, str):
+                    balances[currency] = available + locked
+                    available_total += available
+                    total_equity += available + locked
+
+        return AccountSnapshot(
+            balances=balances,
+            total_equity=total_equity,
+            available_margin=available_total,
+            maintenance_margin=0.0,
+        )
+
+    def fetch_symbols(self) -> Iterable[str]:
+        response = self._public_request("/trading/ticker")
+        if not isinstance(response, Mapping):
+            raise RuntimeError("Niepoprawna odpowiedź ticker z Zonda")
+        items = response.get("items")
+        if isinstance(items, Mapping):
+            return [str(symbol) for symbol in items.keys()]
+        raise RuntimeError("Brak sekcji 'items' w odpowiedzi ticker Zonda")
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Sequence[float]]:
+        resolution = _normalize_interval(interval)
+        params: dict[str, object] = {}
+        if start is not None:
+            params["from"] = int(start // 1000)
+        if end is not None:
+            params["to"] = int(end // 1000)
+        if limit is not None:
+            params["limit"] = int(limit)
+
+        path = f"/trading/candle/history/{symbol}/{resolution}"
+        response = self._public_request(path, params=params)
+        if not isinstance(response, Mapping):
+            raise RuntimeError("Niepoprawna odpowiedź świec z Zonda")
+        items = response.get("items")
+        if not isinstance(items, list):
+            raise RuntimeError("Sekcja 'items' odpowiedzi świec Zonda ma niepoprawny format")
+
+        candles: list[Sequence[float]] = []
+        for entry in items:
+            if not isinstance(entry, Mapping):
+                continue
+            timestamp = int(_to_float(entry.get("time"))) * 1000
+            open_price = _to_float(entry.get("open"))
+            close_price = _to_float(entry.get("close"))
+            high_price = _to_float(entry.get("high"))
+            low_price = _to_float(entry.get("low"))
+            volume = _to_float(entry.get("volume"))
+            candles.append([float(timestamp), open_price, high_price, low_price, close_price, volume])
+        return candles
+
+    def _parse_order_payload(self, response: Mapping[str, object]) -> _OrderPayload:
+        order_payload: Mapping[str, object]
+        if "order" in response and isinstance(response["order"], Mapping):
+            order_payload = response["order"]  # type: ignore[assignment]
+        elif "offer" in response and isinstance(response["offer"], Mapping):
+            order_payload = response["offer"]  # type: ignore[assignment]
+        else:
+            order_payload = response
+
+        order_id = str(order_payload.get("id") or order_payload.get("orderId") or order_payload.get("offerId") or "")
+        status = str(order_payload.get("status", "UNKNOWN"))
+        filled = _to_float(
+            order_payload.get("filled")
+            or order_payload.get("filledAmount")
+            or order_payload.get("executed")
+            or order_payload.get("amountFilled")
+        )
+        avg_price_raw = (
+            order_payload.get("avgPrice")
+            or order_payload.get("averagePrice")
+            or order_payload.get("price")
+        )
+        avg_price = _to_float(avg_price_raw) if avg_price_raw is not None else None
+        return _OrderPayload(
+            order_id=order_id,
+            status=status.upper(),
+            filled_quantity=filled,
+            avg_price=avg_price,
+            raw=order_payload,
+        )
+
+    def place_order(self, request: OrderRequest) -> OrderResult:
+        if "trade" not in self._permission_set:
+            raise PermissionError("Poświadczenia Zonda nie mają uprawnień tradingowych.")
+
+        payload: dict[str, object] = {
+            "market": request.symbol,
+            "side": request.side.lower(),
+            "type": request.order_type.lower(),
+            "amount": str(request.quantity),
+        }
+        if request.price is not None:
+            payload["price"] = str(request.price)
+        if request.time_in_force:
+            payload["timeInForce"] = request.time_in_force
+        if request.client_order_id:
+            payload["clientOrderId"] = request.client_order_id
+
+        response = self._signed_request("POST", "/trading/offer", data=payload)
+        if not isinstance(response, Mapping):
+            raise RuntimeError("Niepoprawna odpowiedź zlecenia z Zonda")
+        order = self._parse_order_payload(response)
+        return OrderResult(
+            order_id=order.order_id,
+            status=order.status,
+            filled_quantity=order.filled_quantity,
+            avg_price=order.avg_price,
+            raw_response=dict(response),
+        )
+
+    def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> None:
+        del symbol
+        response = self._signed_request("DELETE", f"/trading/order/{order_id}")
+        if isinstance(response, Mapping):
+            order = self._parse_order_payload(response)
+            if order.status in {"CANCELLED", "CANCELED", "REJECTED"}:
+                return
+        raise RuntimeError(f"Nieoczekiwana odpowiedź anulowania Zonda: {response}")
+
+    def stream_public_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Streaming Zonda zostanie dodany w przyszłym etapie.")
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # type: ignore[override]
+        raise NotImplementedError("Streaming prywatny Zonda zostanie dodany w przyszłym etapie.")
+
+
+__all__ = ["ZondaSpotAdapter"]

--- a/bot_core/execution/__init__.py
+++ b/bot_core/execution/__init__.py
@@ -1,0 +1,19 @@
+"""Moduł egzekucji zleceń."""
+
+from bot_core.execution.base import ExecutionContext, ExecutionService, RetryPolicy
+from bot_core.execution.paper import (  # noqa: F401 - eksport publiczny
+    InsufficientBalanceError,
+    LedgerEntry,
+    MarketMetadata,
+    PaperTradingExecutionService,
+)
+
+__all__ = [
+    "ExecutionContext",
+    "ExecutionService",
+    "RetryPolicy",
+    "PaperTradingExecutionService",
+    "MarketMetadata",
+    "LedgerEntry",
+    "InsufficientBalanceError",
+]

--- a/bot_core/execution/base.py
+++ b/bot_core/execution/base.py
@@ -1,0 +1,44 @@
+"""Interfejs modułu egzekucji z obsługą retry i sanity-check."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Mapping, Protocol
+
+from bot_core.exchanges.base import OrderRequest, OrderResult
+
+
+@dataclass(slots=True)
+class ExecutionContext:
+    """Parametry wykonania przekazywane z warstwy strategii/ryzyka."""
+
+    portfolio_id: str
+    risk_profile: str
+    environment: str
+    metadata: Mapping[str, str]
+
+
+class ExecutionService(abc.ABC):
+    """Abstrakcyjny interfejs modułu egzekucji."""
+
+    @abc.abstractmethod
+    def execute(self, request: OrderRequest, context: ExecutionContext) -> OrderResult:
+        """Realizuje zlecenie z pełną obsługą retry/backoff."""
+
+    @abc.abstractmethod
+    def cancel(self, order_id: str, context: ExecutionContext) -> None:
+        """Anuluje zlecenie, uwzględniając wymogi giełdy."""
+
+    @abc.abstractmethod
+    def flush(self) -> None:
+        """Pozwala zakończyć proces (np. wysłać zaległe anulacje)."""
+
+
+class RetryPolicy(Protocol):
+    """Kontrakt polityki retry/backoff."""
+
+    def on_error(self, attempt: int, error: Exception) -> float:
+        ...
+
+
+__all__ = ["ExecutionContext", "ExecutionService", "RetryPolicy"]

--- a/bot_core/execution/paper.py
+++ b/bot_core/execution/paper.py
@@ -1,0 +1,317 @@
+"""Silnik paper trading odzwierciedlający koszty i poślizg."""
+from __future__ import annotations
+
+import itertools
+import logging
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from bot_core.execution.base import ExecutionContext, ExecutionService
+from bot_core.exchanges.base import OrderRequest, OrderResult
+from bot_core.observability.metrics import MetricsRegistry, get_global_metrics_registry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class MarketMetadata:
+    """Parametry rynku wykorzystywane przez symulator paper tradingu."""
+
+    base_asset: str
+    quote_asset: str
+    min_quantity: float = 0.0
+    min_notional: float = 0.0
+    step_size: Optional[float] = None
+    tick_size: Optional[float] = None
+
+
+@dataclass(slots=True)
+class LedgerEntry:
+    """Pojedynczy wpis audytowy."""
+
+    timestamp: float
+    order_id: str
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    fee: float
+    fee_asset: str
+    status: str
+
+    def to_mapping(self) -> Mapping[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "order_id": self.order_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "quantity": self.quantity,
+            "price": self.price,
+            "fee": self.fee,
+            "fee_asset": self.fee_asset,
+            "status": self.status,
+        }
+
+
+class InsufficientBalanceError(RuntimeError):
+    """Rzucany, gdy na rachunku brakuje środków na realizację zlecenia."""
+
+
+class PaperTradingExecutionService(ExecutionService):
+    """Symulator giełdy realizujący zlecenia natychmiast z kosztem prowizji i poślizgu."""
+
+    def __init__(
+        self,
+        markets: Mapping[str, MarketMetadata],
+        *,
+        initial_balances: Optional[Mapping[str, float]] = None,
+        maker_fee: float = 0.0004,
+        taker_fee: float = 0.0006,
+        slippage_bps: float = 5.0,
+        time_source: Optional[Callable[[], float]] = None,
+        metrics: MetricsRegistry | None = None,
+    ) -> None:
+        if not markets:
+            raise ValueError("Wymagana jest co najmniej jedna definicja rynku.")
+        self._markets: Dict[str, MarketMetadata] = dict(markets)
+        self._balances: MutableMapping[str, float] = {asset: float(value) for asset, value in (initial_balances or {}).items()}
+        self._maker_fee = max(0.0, maker_fee)
+        self._taker_fee = max(0.0, taker_fee)
+        self._slippage_bps = max(0.0, slippage_bps)
+        self._time = time_source or time.time
+        self._order_counter = itertools.count(1)
+        self._ledger: List[LedgerEntry] = []
+        self._metrics = metrics or get_global_metrics_registry()
+        self._metric_orders_total = self._metrics.counter(
+            "paper_orders_total", "Liczba zleceń zrealizowanych w symulatorze paper tradingu."
+        )
+        self._metric_orders_rejected = self._metrics.counter(
+            "paper_orders_rejected_total", "Liczba zleceń odrzuconych przez symulator paper tradingu."
+        )
+        self._metric_traded_notional = self._metrics.counter(
+            "paper_traded_notional_total", "Skumulowany notional obrotu w symulatorze paper tradingu."
+        )
+        self._metric_latency = self._metrics.histogram(
+            "paper_execution_latency_seconds",
+            "Czas realizacji zleceń w symulatorze paper tradingu (sekundy).",
+            buckets=(0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0),
+        )
+
+    # --- API ExecutionService -------------------------------------------------
+    def execute(self, request: OrderRequest, context: ExecutionContext) -> OrderResult:
+        symbol = request.symbol
+        market = self._markets.get(symbol)
+        if market is None:
+            raise KeyError(f"Brak konfiguracji rynku dla symbolu {symbol}")
+
+        side = request.side.lower()
+        if side not in {"buy", "sell"}:
+            raise ValueError("Obsługiwane są wyłącznie zlecenia kupna lub sprzedaży.")
+
+        if request.quantity <= 0:
+            raise ValueError("Wielkość zlecenia musi być dodatnia.")
+
+        self._validate_lot_size(request.quantity, market)
+
+        start_time = self._time()
+        try:
+            result, filled_notional = self._execute_internal(request, context, market, side)
+        except InsufficientBalanceError:
+            self._metric_orders_rejected.inc(labels={"symbol": symbol, "reason": "insufficient_balance"})
+            elapsed = max(0.0, self._time() - start_time)
+            self._metric_latency.observe(elapsed, labels={"symbol": symbol, "status": "rejected"})
+            raise
+        except Exception:
+            self._metric_orders_rejected.inc(labels={"symbol": symbol, "reason": "error"})
+            elapsed = max(0.0, self._time() - start_time)
+            self._metric_latency.observe(elapsed, labels={"symbol": symbol, "status": "error"})
+            raise
+
+        elapsed = max(0.0, self._time() - start_time)
+        self._metric_orders_total.inc(labels={"symbol": symbol, "side": side})
+        self._metric_latency.observe(elapsed, labels={"symbol": symbol, "status": "filled"})
+        self._metric_traded_notional.inc(filled_notional, labels={"symbol": symbol, "side": side})
+        return result
+
+    def _execute_internal(
+        self,
+        request: OrderRequest,
+        context: ExecutionContext,
+        market: MarketMetadata,
+        side: str,
+    ) -> tuple[OrderResult, float]:
+        reference_price = self._determine_reference_price(request)
+        notional = reference_price * request.quantity
+        if notional < market.min_notional:
+            raise ValueError(
+                f"Notional {notional:.8f} jest mniejszy niż minimalna wartość {market.min_notional:.8f} dla {request.symbol}."
+            )
+
+        fill_price = self._apply_slippage(reference_price, side)
+        fee_rate = self._taker_fee if request.order_type.lower() == "market" else self._maker_fee
+        fee = request.quantity * fill_price * fee_rate
+
+        if side == "buy":
+            self._process_buy(request.symbol, market, request.quantity, fill_price, fee)
+        else:
+            self._process_sell(request.symbol, market, request.quantity, fill_price, fee)
+
+        order_id = f"paper-{next(self._order_counter)}"
+        result = OrderResult(
+            order_id=order_id,
+            status="filled",
+            filled_quantity=request.quantity,
+            avg_price=fill_price,
+            raw_response={
+                "environment": context.environment,
+                "risk_profile": context.risk_profile,
+                "portfolio_id": context.portfolio_id,
+                "fee": fee,
+                "fee_asset": market.quote_asset,
+            },
+        )
+        self._ledger.append(
+            LedgerEntry(
+                timestamp=self._time(),
+                order_id=order_id,
+                symbol=request.symbol,
+                side=side,
+                quantity=request.quantity,
+                price=fill_price,
+                fee=fee,
+                fee_asset=market.quote_asset,
+                status=result.status,
+            )
+        )
+        _LOGGER.debug(
+            "Paper trade %s %s qty=%s price=%s fee=%s (env=%s)",
+            side,
+            request.symbol,
+            request.quantity,
+            fill_price,
+            fee,
+            context.environment,
+        )
+        filled_notional = fill_price * request.quantity
+        return result, filled_notional
+
+    def cancel(self, order_id: str, context: ExecutionContext) -> None:  # noqa: ARG002 - wymagane przez interfejs
+        # Zlecenia w trybie paper trading są realizowane natychmiast – rejestrujemy jedynie próbę anulacji.
+        self._ledger.append(
+            LedgerEntry(
+                timestamp=self._time(),
+                order_id=order_id,
+                symbol="*",
+                side="cancel",
+                quantity=0.0,
+                price=0.0,
+                fee=0.0,
+                fee_asset="",
+                status="cancelled",
+            )
+        )
+        _LOGGER.info("Zarejestrowano anulację %s w symulatorze paper trading (brak otwartych zleceń).", order_id)
+
+    def flush(self) -> None:
+        # Symulator realizuje zlecenia natychmiast – flush nie musi nic robić.
+        _LOGGER.debug("PaperTradingExecutionService.flush() – brak zaległych operacji.")
+
+    # --- Funkcje pomocnicze ---------------------------------------------------
+    def _determine_reference_price(self, request: OrderRequest) -> float:
+        if request.price is None or request.price <= 0:
+            raise ValueError("Do symulacji wymagane jest podanie ceny referencyjnej w polu price.")
+        return request.price
+
+    def _apply_slippage(self, price: float, side: str) -> float:
+        if self._slippage_bps <= 0:
+            return price
+        adjustment = price * (self._slippage_bps / 10_000.0)
+        if side == "buy":
+            return price + adjustment
+        return max(0.0, price - adjustment)
+
+    def _validate_lot_size(self, quantity: float, market: MarketMetadata) -> None:
+        if quantity < market.min_quantity:
+            raise ValueError(
+                f"Wielkość zlecenia {quantity:.8f} jest mniejsza niż minimalna {market.min_quantity:.8f}."
+            )
+        if market.step_size:
+            remainder = (quantity / market.step_size) - round(quantity / market.step_size)
+            if abs(remainder) > 1e-8:
+                raise ValueError(
+                    f"Wielkość {quantity:.8f} nie spełnia kroku {market.step_size:.8f} dla rynku {market.base_asset}/{market.quote_asset}."
+                )
+
+    def _process_buy(
+        self,
+        symbol: str,
+        market: MarketMetadata,
+        quantity: float,
+        price: float,
+        fee: float,
+    ) -> None:
+        cost = quantity * price + fee
+        quote_balance = self._balances.get(market.quote_asset, 0.0)
+        if quote_balance + 1e-12 < cost:
+            raise InsufficientBalanceError(
+                f"Brak środków {market.quote_asset}. Dostępne {quote_balance:.8f}, wymagane {cost:.8f}."
+            )
+        self._balances[market.quote_asset] = quote_balance - cost
+        self._balances[market.base_asset] = self._balances.get(market.base_asset, 0.0) + quantity
+        _LOGGER.debug(
+            "BUY %s: -%s %s, +%s %s (fee=%s)",
+            symbol,
+            cost,
+            market.quote_asset,
+            quantity,
+            market.base_asset,
+            fee,
+        )
+
+    def _process_sell(
+        self,
+        symbol: str,
+        market: MarketMetadata,
+        quantity: float,
+        price: float,
+        fee: float,
+    ) -> None:
+        base_balance = self._balances.get(market.base_asset, 0.0)
+        if base_balance + 1e-12 < quantity:
+            raise InsufficientBalanceError(
+                f"Brak pozycji {market.base_asset}. Dostępne {base_balance:.8f}, wymagane {quantity:.8f}."
+            )
+        proceed = quantity * price - fee
+        if proceed < 0:
+            proceed = 0.0
+        self._balances[market.base_asset] = base_balance - quantity
+        self._balances[market.quote_asset] = self._balances.get(market.quote_asset, 0.0) + proceed
+        _LOGGER.debug(
+            "SELL %s: -%s %s, +%s %s (fee=%s)",
+            symbol,
+            quantity,
+            market.base_asset,
+            proceed,
+            market.quote_asset,
+            fee,
+        )
+
+    # --- Funkcje obserwowalne -------------------------------------------------
+    def balances(self) -> Mapping[str, float]:
+        """Zwraca bieżące saldo konta paper trading."""
+
+        return dict(self._balances)
+
+    def ledger(self) -> Iterable[Mapping[str, object]]:
+        """Zwraca kopię wpisów audytowych (do raportów compliance)."""
+
+        return [entry.to_mapping() for entry in self._ledger]
+
+
+__all__ = [
+    "PaperTradingExecutionService",
+    "MarketMetadata",
+    "LedgerEntry",
+    "InsufficientBalanceError",
+]

--- a/bot_core/observability/__init__.py
+++ b/bot_core/observability/__init__.py
@@ -1,0 +1,16 @@
+"""Pakiet narzędzi obserwowalności (metryki, eksport)."""
+from bot_core.observability.metrics import (
+    CounterMetric,
+    GaugeMetric,
+    HistogramMetric,
+    MetricsRegistry,
+    get_global_metrics_registry,
+)
+
+__all__ = [
+    "CounterMetric",
+    "GaugeMetric",
+    "HistogramMetric",
+    "MetricsRegistry",
+    "get_global_metrics_registry",
+]

--- a/bot_core/observability/metrics.py
+++ b/bot_core/observability/metrics.py
@@ -1,0 +1,244 @@
+"""Prosta rejestracja metryk kompatybilna z formatem Prometheusa."""
+from __future__ import annotations
+
+import math
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Mapping, MutableMapping, Sequence, Tuple
+
+LabelTuple = Tuple[Tuple[str, str], ...]
+
+
+def _normalize_labels(labels: Mapping[str, str] | None) -> LabelTuple:
+    if not labels:
+        return ()
+    normalized = tuple(sorted((str(k), str(v)) for k, v in labels.items()))
+    return normalized
+
+
+def _format_labels(labels: LabelTuple) -> str:
+    if not labels:
+        return ""
+    parts = [f'{key}="{value}"' for key, value in labels]
+    return "{" + ",".join(parts) + "}"
+
+
+@dataclass(slots=True)
+class Metric:
+    """Bazowy typ metryki przechowujący opis i nazwę."""
+
+    name: str
+    description: str
+
+    def render(self) -> Iterable[str]:  # pragma: no cover - implementowane w klasach potomnych
+        raise NotImplementedError
+
+
+@dataclass(slots=True)
+class CounterMetric(Metric):
+    """Licznik tylko rosnący."""
+
+    _values: MutableMapping[LabelTuple, float] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    def inc(self, amount: float = 1.0, *, labels: Mapping[str, str] | None = None) -> None:
+        if amount < 0:
+            raise ValueError("Liczniki można zwiększać wyłącznie o wartości nieujemne.")
+        key = _normalize_labels(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def value(self, *, labels: Mapping[str, str] | None = None) -> float:
+        key = _normalize_labels(labels)
+        with self._lock:
+            return self._values.get(key, 0.0)
+
+    def render(self) -> Iterable[str]:
+        lines = [f"# HELP {self.name} {self.description}", f"# TYPE {self.name} counter"]
+        with self._lock:
+            for labels, value in sorted(self._values.items()):
+                lines.append(f"{self.name}{_format_labels(labels)} {value}")
+        return lines
+
+
+@dataclass(slots=True)
+class GaugeMetric(Metric):
+    """Metryka typu gauge pozwalająca ustawiać i zwiększać wartości."""
+
+    _values: MutableMapping[LabelTuple, float] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    def set(self, value: float, *, labels: Mapping[str, str] | None = None) -> None:
+        key = _normalize_labels(labels)
+        with self._lock:
+            self._values[key] = float(value)
+
+    def inc(self, amount: float = 1.0, *, labels: Mapping[str, str] | None = None) -> None:
+        key = _normalize_labels(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def dec(self, amount: float = 1.0, *, labels: Mapping[str, str] | None = None) -> None:
+        self.inc(-amount, labels=labels)
+
+    def value(self, *, labels: Mapping[str, str] | None = None) -> float:
+        key = _normalize_labels(labels)
+        with self._lock:
+            return self._values.get(key, 0.0)
+
+    def render(self) -> Iterable[str]:
+        lines = [f"# HELP {self.name} {self.description}", f"# TYPE {self.name} gauge"]
+        with self._lock:
+            for labels, value in sorted(self._values.items()):
+                lines.append(f"{self.name}{_format_labels(labels)} {value}")
+        return lines
+
+
+@dataclass(slots=True)
+class HistogramState:
+    counts: MutableMapping[float, int] = field(default_factory=dict)
+    sum: float = 0.0
+    count: int = 0
+
+
+@dataclass(slots=True)
+class HistogramMetric(Metric):
+    """Metryka histogramu zgodna z formatem Prometheusa."""
+
+    buckets: Tuple[float, ...]
+    _values: MutableMapping[LabelTuple, HistogramState] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    def __post_init__(self) -> None:
+        if not self.buckets:
+            raise ValueError("Histogram wymaga co najmniej jednego koszyka.")
+        ordered = []
+        last = -math.inf
+        for boundary in self.buckets:
+            if boundary <= last:
+                raise ValueError("Granice histogramu muszą być rosnące.")
+            ordered.append(float(boundary))
+            last = boundary
+        self.buckets = tuple(ordered)
+
+    def observe(self, value: float, *, labels: Mapping[str, str] | None = None) -> None:
+        key = _normalize_labels(labels)
+        with self._lock:
+            state = self._values.get(key)
+            if state is None:
+                counts = {boundary: 0 for boundary in self.buckets}
+                counts[math.inf] = 0
+                state = HistogramState(counts=counts)
+                self._values[key] = state
+            state.count += 1
+            state.sum += value
+            for boundary in self.buckets:
+                if value <= boundary:
+                    state.counts[boundary] += 1
+            state.counts[math.inf] += 1
+
+    def snapshot(self, *, labels: Mapping[str, str] | None = None) -> HistogramState:
+        key = _normalize_labels(labels)
+        with self._lock:
+            state = self._values.get(key)
+            if state is None:
+                counts = {boundary: 0 for boundary in self.buckets}
+                counts[math.inf] = 0
+                return HistogramState(counts=counts)
+            # Tworzymy kopię, by uniknąć modyfikacji przez odbiorcę.
+            counts_copy = dict(state.counts)
+            return HistogramState(counts=counts_copy, sum=state.sum, count=state.count)
+
+    def render(self) -> Iterable[str]:
+        lines = [f"# HELP {self.name} {self.description}", f"# TYPE {self.name} histogram"]
+        with self._lock:
+            for labels, state in sorted(self._values.items()):
+                cumulative = 0
+                for boundary in self.buckets:
+                    cumulative += state.counts.get(boundary, 0)
+                    bucket_labels = dict(labels)
+                    bucket_labels["le"] = str(boundary)
+                    lines.append(f"{self.name}_bucket{_format_labels(_normalize_labels(bucket_labels))} {cumulative}")
+                cumulative += state.counts.get(math.inf, 0)
+                inf_labels = dict(labels)
+                inf_labels["le"] = "+Inf"
+                lines.append(f"{self.name}_bucket{_format_labels(_normalize_labels(inf_labels))} {cumulative}")
+                lines.append(f"{self.name}_sum{_format_labels(labels)} {state.sum}")
+                lines.append(f"{self.name}_count{_format_labels(labels)} {state.count}")
+        return lines
+
+
+class MetricsRegistry:
+    """Rejestr przechowujący metryki i umożliwiający eksport."""
+
+    def __init__(self) -> None:
+        self._metrics: Dict[str, Metric] = {}
+        self._lock = threading.Lock()
+
+    def counter(self, name: str, description: str) -> CounterMetric:
+        with self._lock:
+            metric = self._metrics.get(name)
+            if metric is None:
+                metric = CounterMetric(name=name, description=description)
+                self._metrics[name] = metric
+            elif not isinstance(metric, CounterMetric):
+                raise TypeError(f"Metryka {name} istnieje, ale nie jest licznikiem.")
+            return metric
+
+    def gauge(self, name: str, description: str) -> GaugeMetric:
+        with self._lock:
+            metric = self._metrics.get(name)
+            if metric is None:
+                metric = GaugeMetric(name=name, description=description)
+                self._metrics[name] = metric
+            elif not isinstance(metric, GaugeMetric):
+                raise TypeError(f"Metryka {name} istnieje, ale nie jest gauge.")
+            return metric
+
+    def histogram(self, name: str, description: str, buckets: Sequence[float]) -> HistogramMetric:
+        with self._lock:
+            metric = self._metrics.get(name)
+            if metric is None:
+                metric = HistogramMetric(name=name, description=description, buckets=tuple(buckets))
+                self._metrics[name] = metric
+            elif not isinstance(metric, HistogramMetric):
+                raise TypeError(f"Metryka {name} istnieje, ale nie jest histogramem.")
+            return metric
+
+    def render_prometheus(self) -> str:
+        lines: list[str] = []
+        with self._lock:
+            for metric in self._metrics.values():
+                lines.extend(metric.render())
+        return "\n".join(lines) + "\n"
+
+    def get(self, name: str) -> Metric:
+        with self._lock:
+            try:
+                return self._metrics[name]
+            except KeyError as exc:  # pragma: no cover - defensywne dla błędnej konfiguracji
+                raise KeyError(f"Metryka {name} nie istnieje w rejestrze") from exc
+
+
+_GLOBAL_REGISTRY: MetricsRegistry | None = None
+_REGISTRY_LOCK = threading.Lock()
+
+
+def get_global_metrics_registry() -> MetricsRegistry:
+    """Zwraca singleton rejestru metryk dla całej aplikacji."""
+
+    global _GLOBAL_REGISTRY
+    if _GLOBAL_REGISTRY is None:
+        with _REGISTRY_LOCK:
+            if _GLOBAL_REGISTRY is None:
+                _GLOBAL_REGISTRY = MetricsRegistry()
+    return _GLOBAL_REGISTRY
+
+
+__all__ = [
+    "MetricsRegistry",
+    "CounterMetric",
+    "GaugeMetric",
+    "HistogramMetric",
+    "get_global_metrics_registry",
+]

--- a/bot_core/risk/__init__.py
+++ b/bot_core/risk/__init__.py
@@ -1,0 +1,21 @@
+"""Warstwa ryzyka."""
+
+from bot_core.risk.base import RiskCheckResult, RiskEngine, RiskProfile, RiskRepository
+from bot_core.risk.engine import InMemoryRiskRepository, ThresholdRiskEngine
+from bot_core.risk.profiles.aggressive import AggressiveProfile
+from bot_core.risk.profiles.balanced import BalancedProfile
+from bot_core.risk.profiles.conservative import ConservativeProfile
+from bot_core.risk.profiles.manual import ManualProfile
+
+__all__ = [
+    "AggressiveProfile",
+    "BalancedProfile",
+    "ConservativeProfile",
+    "InMemoryRiskRepository",
+    "ManualProfile",
+    "RiskCheckResult",
+    "RiskEngine",
+    "RiskProfile",
+    "RiskRepository",
+    "ThresholdRiskEngine",
+]

--- a/bot_core/risk/base.py
+++ b/bot_core/risk/base.py
@@ -1,0 +1,100 @@
+"""Interfejs silnika zarządzania ryzykiem oraz profili."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping, Protocol
+
+from bot_core.exchanges.base import AccountSnapshot, OrderRequest
+
+
+@dataclass(slots=True)
+class RiskCheckResult:
+    """Wynik kontroli ryzyka."""
+
+    allowed: bool
+    reason: str | None = None
+    adjustments: Mapping[str, float] | None = None
+
+
+class RiskProfile(abc.ABC):
+    """Każdy profil musi dostarczać zestaw limitów i procedur kontroli."""
+
+    name: str
+
+    @abc.abstractmethod
+    def max_positions(self) -> int:
+        ...
+
+    @abc.abstractmethod
+    def max_leverage(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def drawdown_limit(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def daily_loss_limit(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def max_position_exposure(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def target_volatility(self) -> float:
+        ...
+
+    @abc.abstractmethod
+    def stop_loss_atr_multiple(self) -> float:
+        ...
+
+
+class RiskEngine(abc.ABC):
+    """Silnik ryzyka odpowiada za enforce limitów i pre-trade checks."""
+
+    @abc.abstractmethod
+    def register_profile(self, profile: RiskProfile) -> None:
+        ...
+
+    @abc.abstractmethod
+    def apply_pre_trade_checks(
+        self,
+        request: OrderRequest,
+        *,
+        account: AccountSnapshot,
+        profile_name: str,
+    ) -> RiskCheckResult:
+        ...
+
+    @abc.abstractmethod
+    def on_fill(
+        self,
+        *,
+        profile_name: str,
+        symbol: str,
+        side: str,
+        position_value: float,
+        pnl: float,
+        timestamp: datetime | None = None,
+    ) -> None:
+        ...
+
+    @abc.abstractmethod
+    def should_liquidate(self, *, profile_name: str) -> bool:
+        ...
+
+
+class RiskRepository(Protocol):
+    """Kontrakt dla repozytoriów stanu ryzyka (np. SQLite, Parquet)."""
+
+    def load(self, profile: str) -> Mapping[str, object] | None:
+        ...
+
+    def store(self, profile: str, state: Mapping[str, object]) -> None:
+        ...
+
+
+__all__ = ["RiskCheckResult", "RiskProfile", "RiskEngine", "RiskRepository"]

--- a/bot_core/risk/engine.py
+++ b/bot_core/risk/engine.py
@@ -1,0 +1,340 @@
+"""Implementacja silnika ryzyka egzekwującego limity profili."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Callable, Dict, Mapping, MutableMapping
+
+from bot_core.exchanges.base import AccountSnapshot, OrderRequest
+from bot_core.risk.base import RiskCheckResult, RiskEngine, RiskProfile, RiskRepository
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class PositionState:
+    """Stan pojedynczej pozycji wykorzystywany przez silnik ryzyka."""
+
+    side: str
+    notional: float
+
+    def to_mapping(self) -> Mapping[str, object]:
+        return {"side": self.side, "notional": self.notional}
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, object]) -> "PositionState":
+        side = str(data.get("side", "long"))
+        notional = float(data.get("notional", 0.0))
+        return cls(side=side, notional=max(0.0, notional))
+
+
+@dataclass(slots=True)
+class RiskState:
+    """Stan profilu wykorzystywany do egzekwowania limitów."""
+
+    profile: str
+    current_day: date
+    start_of_day_equity: float = 0.0
+    last_equity: float = 0.0
+    daily_realized_pnl: float = 0.0
+    peak_equity: float = 0.0
+    force_liquidation: bool = False
+    positions: Dict[str, PositionState] = field(default_factory=dict)
+
+    def gross_notional(self) -> float:
+        return sum(position.notional for position in self.positions.values())
+
+    def active_positions(self) -> int:
+        return sum(1 for position in self.positions.values() if position.notional > 0.0)
+
+    def to_mapping(self) -> Mapping[str, object]:
+        return {
+            "profile": self.profile,
+            "current_day": self.current_day.isoformat(),
+            "start_of_day_equity": self.start_of_day_equity,
+            "daily_realized_pnl": self.daily_realized_pnl,
+            "peak_equity": self.peak_equity,
+            "force_liquidation": self.force_liquidation,
+            "last_equity": self.last_equity,
+            "positions": {symbol: position.to_mapping() for symbol, position in self.positions.items()},
+        }
+
+    @classmethod
+    def from_mapping(cls, profile: str, data: Mapping[str, object]) -> "RiskState":
+        day_str = str(data.get("current_day", date.today().isoformat()))
+        parsed_day = datetime.fromisoformat(day_str).date()
+        positions_raw = data.get("positions", {})
+        positions: Dict[str, PositionState] = {}
+        if isinstance(positions_raw, Mapping):
+            for symbol, raw in positions_raw.items():
+                if isinstance(raw, Mapping):
+                    positions[str(symbol)] = PositionState.from_mapping(raw)
+        return cls(
+            profile=profile,
+            current_day=parsed_day,
+            start_of_day_equity=float(data.get("start_of_day_equity", 0.0)),
+            daily_realized_pnl=float(data.get("daily_realized_pnl", 0.0)),
+            peak_equity=float(data.get("peak_equity", 0.0)),
+            force_liquidation=bool(data.get("force_liquidation", False)),
+            last_equity=float(data.get("last_equity", 0.0)),
+            positions=positions,
+        )
+
+    def reset_for_new_day(self, *, equity: float, day: date) -> None:
+        self.current_day = day
+        self.start_of_day_equity = equity
+        self.daily_realized_pnl = 0.0
+        self.force_liquidation = False
+        self.last_equity = equity
+
+    def update_peak_equity(self, equity: float) -> None:
+        self.peak_equity = max(self.peak_equity, equity)
+        self.last_equity = equity
+
+    def daily_loss_pct(self) -> float:
+        if self.start_of_day_equity <= 0:
+            return 0.0
+        loss = min(0.0, self.daily_realized_pnl)
+        return abs(loss) / self.start_of_day_equity
+
+    def drawdown_pct(self, current_equity: float) -> float:
+        if self.peak_equity <= 0:
+            return 0.0
+        drawdown_value = self.peak_equity - current_equity
+        if drawdown_value <= 0:
+            return 0.0
+        return drawdown_value / self.peak_equity
+
+    def update_position(self, symbol: str, side: str, notional: float) -> None:
+        if notional <= 0:
+            self.positions.pop(symbol, None)
+            return
+        self.positions[symbol] = PositionState(side=side, notional=notional)
+
+
+class InMemoryRiskRepository(RiskRepository):
+    """Najprostsze repozytorium używane do testów i trybu offline."""
+
+    def __init__(self) -> None:
+        self._storage: Dict[str, MutableMapping[str, object]] = {}
+
+    def load(self, profile: str) -> Mapping[str, object] | None:
+        return self._storage.get(profile)
+
+    def store(self, profile: str, state: Mapping[str, object]) -> None:
+        self._storage[profile] = dict(state)
+
+
+class ThresholdRiskEngine(RiskEngine):
+    """Silnik egzekwujący limity dzienne, ekspozycji i dźwigni."""
+
+    def __init__(
+        self,
+        repository: RiskRepository | None = None,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._repository = repository or InMemoryRiskRepository()
+        self._clock = clock or datetime.utcnow
+        self._profiles: Dict[str, RiskProfile] = {}
+        self._states: Dict[str, RiskState] = {}
+
+    def register_profile(self, profile: RiskProfile) -> None:
+        self._profiles[profile.name] = profile
+        state = self._repository.load(profile.name)
+        if state is None:
+            today = self._clock().date()
+            self._states[profile.name] = RiskState(profile=profile.name, current_day=today)
+            self._repository.store(profile.name, self._states[profile.name].to_mapping())
+        else:
+            self._states[profile.name] = RiskState.from_mapping(profile.name, state)
+        _LOGGER.info("Zarejestrowano profil ryzyka %s", profile.name)
+
+    def apply_pre_trade_checks(
+        self,
+        request: OrderRequest,
+        *,
+        account: AccountSnapshot,
+        profile_name: str,
+    ) -> RiskCheckResult:
+        profile = self._profiles.get(profile_name)
+        if profile is None:
+            raise KeyError(f"Profil ryzyka {profile_name} nie został zarejestrowany")
+
+        state = self._states.get(profile_name)
+        if state is None:
+            raise KeyError(f"Brak stanu ryzyka dla profilu {profile_name}")
+
+        now = self._clock()
+        current_day = now.date()
+        if state.current_day != current_day:
+            state.reset_for_new_day(equity=account.total_equity, day=current_day)
+            _LOGGER.info("Reset dziennego licznika PnL dla profilu %s", profile_name)
+
+        state.update_peak_equity(account.total_equity)
+
+        drawdown = state.drawdown_pct(account.total_equity)
+        daily_loss = state.daily_loss_pct()
+
+        force_reason: str | None = None
+        if profile.drawdown_limit() > 0 and drawdown >= profile.drawdown_limit():
+            state.force_liquidation = True
+            force_reason = "Przekroczono limit obsunięcia portfela."
+
+        if profile.daily_loss_limit() > 0 and daily_loss >= profile.daily_loss_limit():
+            state.force_liquidation = True
+            force_reason = "Przekroczono dzienny limit straty."
+
+        price = request.price
+        if price is None or price <= 0:
+            self._persist_state(profile_name)
+            return RiskCheckResult(
+                allowed=False,
+                reason=(
+                    "Brak ceny referencyjnej uniemożliwia obliczenie ekspozycji. Podaj midpoint z orderbooka lub cenę limit."
+                ),
+            )
+
+        symbol = request.symbol
+        position = state.positions.get(symbol)
+        is_buy = request.side.lower() == "buy"
+        notional = abs(request.quantity) * price
+        current_notional = position.notional if position else 0.0
+        current_side = position.side if position else ("long" if is_buy else "short")
+
+        if position:
+            if position.side == "long" and not is_buy and notional > current_notional:
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason=(
+                        "Zlecenie sprzedaży przekracza wielkość istniejącej pozycji. Zamknij pozycję przed odwróceniem kierunku."
+                    ),
+                )
+            if position.side == "short" and is_buy and notional > current_notional:
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason=(
+                        "Zlecenie kupna przekracza wielkość krótkiej pozycji. Zamknij pozycję przed odwróceniem kierunku."
+                    ),
+                )
+
+        if is_buy:
+            if current_side == "long":
+                new_notional = current_notional + notional
+            else:
+                new_notional = max(current_notional - notional, 0.0)
+        else:
+            if current_side == "short":
+                new_notional = current_notional + notional
+            else:
+                new_notional = max(current_notional - notional, 0.0)
+
+        is_reducing = new_notional < current_notional
+
+        is_new_position = current_notional == 0.0 and new_notional > 0.0 and not is_reducing
+
+        if state.force_liquidation and not is_reducing:
+            self._persist_state(profile_name)
+            return RiskCheckResult(
+                allowed=False,
+                reason=(
+                    (force_reason + " Dozwolone są wyłącznie transakcje redukujące ekspozycję.")
+                    if force_reason
+                    else "Profil w trybie awaryjnym – dozwolone są wyłącznie transakcje redukujące ekspozycję."
+                ),
+            )
+
+        if is_new_position:
+            if state.active_positions() >= profile.max_positions():
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Limit liczby równoległych pozycji został osiągnięty.",
+                )
+
+        max_position_pct = profile.max_position_exposure()
+        if not is_reducing and max_position_pct > 0:
+            max_notional = max_position_pct * account.total_equity
+            if max_notional <= 0:
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Kapitał konta jest zbyt niski do otwierania nowych pozycji.",
+                )
+            if new_notional > max_notional:
+                allowed_notional = max_notional
+                allowed_quantity = max(0.0, allowed_notional - current_notional) / price
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Wielkość zlecenia przekracza limit ekspozycji na instrument.",
+                    adjustments={"max_quantity": max(0.0, allowed_quantity)},
+                )
+
+        max_leverage = profile.max_leverage()
+        if not is_reducing and max_leverage > 0:
+            gross_without_symbol = state.gross_notional() - current_notional
+            max_total_notional = max_leverage * account.total_equity
+            if max_total_notional <= 0:
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Kapitał konta nie pozwala na otwieranie pozycji przy zadanej dźwigni.",
+                )
+            new_gross = gross_without_symbol + new_notional
+            if new_gross > max_total_notional:
+                remaining_notional = max(0.0, max_total_notional - gross_without_symbol)
+                allowed_quantity = remaining_notional / price
+                self._persist_state(profile_name)
+                return RiskCheckResult(
+                    allowed=False,
+                    reason="Przekroczono maksymalną dźwignię portfela.",
+                    adjustments={"max_quantity": max(0.0, allowed_quantity)},
+                )
+
+        self._persist_state(profile_name)
+
+        return RiskCheckResult(allowed=True)
+
+    def on_fill(
+        self,
+        *,
+        profile_name: str,
+        symbol: str,
+        side: str,
+        position_value: float,
+        pnl: float,
+        timestamp: datetime | None = None,
+    ) -> None:
+        profile = self._profiles.get(profile_name)
+        if profile is None:
+            raise KeyError(f"Profil ryzyka {profile_name} nie został zarejestrowany")
+
+        state = self._states.get(profile_name)
+        if state is None:
+            raise KeyError(f"Brak stanu ryzyka dla profilu {profile_name}")
+
+        now = timestamp or self._clock()
+        current_day = now.date()
+        if state.current_day != current_day:
+            state.reset_for_new_day(equity=state.last_equity, day=current_day)
+
+        state.daily_realized_pnl += pnl
+        state.update_position(symbol, side=side, notional=max(0.0, position_value))
+        self._persist_state(profile_name)
+
+    def should_liquidate(self, *, profile_name: str) -> bool:
+        state = self._states.get(profile_name)
+        if state is None:
+            raise KeyError(f"Brak stanu ryzyka dla profilu {profile_name}")
+        return state.force_liquidation
+
+    def _persist_state(self, profile_name: str) -> None:
+        state = self._states[profile_name]
+        self._repository.store(profile_name, state.to_mapping())
+
+
+__all__ = ["InMemoryRiskRepository", "ThresholdRiskEngine", "RiskState", "PositionState"]

--- a/bot_core/risk/profiles/__init__.py
+++ b/bot_core/risk/profiles/__init__.py
@@ -1,0 +1,13 @@
+"""Profile ryzyka."""
+
+from bot_core.risk.profiles.aggressive import AggressiveProfile
+from bot_core.risk.profiles.balanced import BalancedProfile
+from bot_core.risk.profiles.conservative import ConservativeProfile
+from bot_core.risk.profiles.manual import ManualProfile
+
+__all__ = [
+    "AggressiveProfile",
+    "BalancedProfile",
+    "ConservativeProfile",
+    "ManualProfile",
+]

--- a/bot_core/risk/profiles/aggressive.py
+++ b/bot_core/risk/profiles/aggressive.py
@@ -1,0 +1,44 @@
+"""Profil agresywny zgodny z wymaganiami klienta."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bot_core.risk.base import RiskProfile
+
+
+@dataclass(slots=True)
+class AggressiveProfile(RiskProfile):
+    """Profil o wysokiej tolerancji ryzyka."""
+
+    name: str = "aggressive"
+    _max_positions: int = 10
+    _max_leverage: float = 5.0
+    _drawdown_limit: float = 0.20
+    _daily_loss_limit: float = 0.03
+    _max_position_pct: float = 0.10
+    _target_volatility: float = 0.19
+    _stop_loss_atr_multiple: float = 2.0
+
+    def max_positions(self) -> int:
+        return self._max_positions
+
+    def max_leverage(self) -> float:
+        return self._max_leverage
+
+    def drawdown_limit(self) -> float:
+        return self._drawdown_limit
+
+    def daily_loss_limit(self) -> float:
+        return self._daily_loss_limit
+
+    def max_position_exposure(self) -> float:
+        return self._max_position_pct
+
+    def target_volatility(self) -> float:
+        return self._target_volatility
+
+    def stop_loss_atr_multiple(self) -> float:
+        return self._stop_loss_atr_multiple
+
+
+__all__ = ["AggressiveProfile"]

--- a/bot_core/risk/profiles/balanced.py
+++ b/bot_core/risk/profiles/balanced.py
@@ -1,0 +1,44 @@
+"""Profil zbalansowany będący ustawieniem domyślnym."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bot_core.risk.base import RiskProfile
+
+
+@dataclass(slots=True)
+class BalancedProfile(RiskProfile):
+    """Profil o średniej tolerancji ryzyka."""
+
+    name: str = "balanced"
+    _max_positions: int = 5
+    _max_leverage: float = 3.0
+    _drawdown_limit: float = 0.10
+    _daily_loss_limit: float = 0.015
+    _max_position_pct: float = 0.05
+    _target_volatility: float = 0.11
+    _stop_loss_atr_multiple: float = 1.5
+
+    def max_positions(self) -> int:
+        return self._max_positions
+
+    def max_leverage(self) -> float:
+        return self._max_leverage
+
+    def drawdown_limit(self) -> float:
+        return self._drawdown_limit
+
+    def daily_loss_limit(self) -> float:
+        return self._daily_loss_limit
+
+    def max_position_exposure(self) -> float:
+        return self._max_position_pct
+
+    def target_volatility(self) -> float:
+        return self._target_volatility
+
+    def stop_loss_atr_multiple(self) -> float:
+        return self._stop_loss_atr_multiple
+
+
+__all__ = ["BalancedProfile"]

--- a/bot_core/risk/profiles/conservative.py
+++ b/bot_core/risk/profiles/conservative.py
@@ -1,0 +1,44 @@
+"""Profil konserwatywny zgodny z wymaganiami klienta."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bot_core.risk.base import RiskProfile
+
+
+@dataclass(slots=True)
+class ConservativeProfile(RiskProfile):
+    """Profil o niskiej tolerancji ryzyka."""
+
+    name: str = "conservative"
+    _max_positions: int = 3
+    _max_leverage: float = 2.0
+    _drawdown_limit: float = 0.05
+    _daily_loss_limit: float = 0.01
+    _max_position_pct: float = 0.03
+    _target_volatility: float = 0.07
+    _stop_loss_atr_multiple: float = 1.0
+
+    def max_positions(self) -> int:
+        return self._max_positions
+
+    def max_leverage(self) -> float:
+        return self._max_leverage
+
+    def drawdown_limit(self) -> float:
+        return self._drawdown_limit
+
+    def daily_loss_limit(self) -> float:
+        return self._daily_loss_limit
+
+    def max_position_exposure(self) -> float:
+        return self._max_position_pct
+
+    def target_volatility(self) -> float:
+        return self._target_volatility
+
+    def stop_loss_atr_multiple(self) -> float:
+        return self._stop_loss_atr_multiple
+
+
+__all__ = ["ConservativeProfile"]

--- a/bot_core/risk/profiles/manual.py
+++ b/bot_core/risk/profiles/manual.py
@@ -1,0 +1,65 @@
+"""Profil ręczny pozwalający na własne limity."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bot_core.risk.base import RiskProfile
+
+
+@dataclass(slots=True, init=False)
+class ManualProfile(RiskProfile):
+    """Profil konfigurowany przez użytkownika."""
+
+    name: str
+    _max_positions: int
+    _max_leverage: float
+    _drawdown_limit: float
+    _daily_loss_limit: float
+    _max_position_pct: float
+    _target_volatility: float
+    _stop_loss_atr_multiple: float
+
+    def __init__(
+        self,
+        *,
+        name: str = "manual",
+        max_positions: int,
+        max_leverage: float,
+        drawdown_limit: float,
+        daily_loss_limit: float,
+        max_position_pct: float,
+        target_volatility: float,
+        stop_loss_atr_multiple: float,
+    ) -> None:
+        self.name = name
+        self._max_positions = max_positions
+        self._max_leverage = max_leverage
+        self._drawdown_limit = drawdown_limit
+        self._daily_loss_limit = daily_loss_limit
+        self._max_position_pct = max_position_pct
+        self._target_volatility = target_volatility
+        self._stop_loss_atr_multiple = stop_loss_atr_multiple
+
+    def max_positions(self) -> int:
+        return self._max_positions
+
+    def max_leverage(self) -> float:
+        return self._max_leverage
+
+    def drawdown_limit(self) -> float:
+        return self._drawdown_limit
+
+    def daily_loss_limit(self) -> float:
+        return self._daily_loss_limit
+
+    def max_position_exposure(self) -> float:
+        return self._max_position_pct
+
+    def target_volatility(self) -> float:
+        return self._target_volatility
+
+    def stop_loss_atr_multiple(self) -> float:
+        return self._stop_loss_atr_multiple
+
+
+__all__ = ["ManualProfile"]

--- a/bot_core/runtime/__init__.py
+++ b/bot_core/runtime/__init__.py
@@ -1,0 +1,12 @@
+"""Infrastruktura runtime nowej architektury bota."""
+
+from bot_core.runtime.bootstrap import BootstrapContext, bootstrap_environment
+from bot_core.runtime.session import InstrumentConfig, PositionSizer, TradingSession
+
+__all__ = [
+    "BootstrapContext",
+    "bootstrap_environment",
+    "InstrumentConfig",
+    "PositionSizer",
+    "TradingSession",
+]

--- a/bot_core/runtime/__init__.py
+++ b/bot_core/runtime/__init__.py
@@ -1,10 +1,17 @@
 """Infrastruktura runtime nowej architektury bota."""
 
-from bot_core.runtime.bootstrap import BootstrapContext, bootstrap_environment
+from bot_core.runtime.bootstrap import (
+    BootstrapContext,
+    InstrumentUniverse,
+    UniverseInstrument,
+    bootstrap_environment,
+)
 from bot_core.runtime.session import InstrumentConfig, PositionSizer, TradingSession
 
 __all__ = [
     "BootstrapContext",
+    "InstrumentUniverse",
+    "UniverseInstrument",
     "bootstrap_environment",
     "InstrumentConfig",
     "PositionSizer",

--- a/bot_core/runtime/bootstrap.py
+++ b/bot_core/runtime/bootstrap.py
@@ -1,0 +1,376 @@
+"""Procedury rozruchowe spinające konfigurację z modułami runtime."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, MutableMapping, Sequence
+
+from bot_core.alerts import (
+    DefaultAlertRouter,
+    EmailChannel,
+    InMemoryAlertAuditLog,
+    MessengerChannel,
+    SMSChannel,
+    SignalChannel,
+    TelegramChannel,
+    WhatsAppChannel,
+    get_sms_provider,
+)
+from bot_core.alerts.base import AlertChannel
+from bot_core.alerts.channels.providers import SmsProviderConfig
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import (
+    CoreConfig,
+    EmailChannelSettings,
+    EnvironmentConfig,
+    MessengerChannelSettings,
+    RiskProfileConfig,
+    SMSProviderSettings,
+    SignalChannelSettings,
+    TelegramChannelSettings,
+    WhatsAppChannelSettings,
+)
+from bot_core.exchanges.base import Environment, ExchangeAdapter, ExchangeAdapterFactory, ExchangeCredentials
+from bot_core.exchanges.binance import BinanceFuturesAdapter, BinanceSpotAdapter
+from bot_core.exchanges.kraken import KrakenFuturesAdapter, KrakenSpotAdapter
+from bot_core.exchanges.zonda import ZondaSpotAdapter
+from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.profiles.manual import ManualProfile
+from bot_core.security import SecretManager, SecretStorageError
+
+_DEFAULT_ADAPTERS: Mapping[str, ExchangeAdapterFactory] = {
+    "binance_spot": BinanceSpotAdapter,
+    "binance_futures": BinanceFuturesAdapter,
+    "kraken_spot": KrakenSpotAdapter,
+    "kraken_futures": KrakenFuturesAdapter,
+    "zonda_spot": ZondaSpotAdapter,
+}
+
+
+@dataclass(slots=True)
+class BootstrapContext:
+    """Zawiera wszystkie komponenty zainicjalizowane dla danego środowiska."""
+
+    core_config: CoreConfig
+    environment: EnvironmentConfig
+    credentials: ExchangeCredentials
+    adapter: ExchangeAdapter
+    risk_engine: ThresholdRiskEngine
+    alert_router: DefaultAlertRouter
+    alert_channels: Mapping[str, AlertChannel]
+    audit_log: InMemoryAlertAuditLog
+
+
+def bootstrap_environment(
+    environment_name: str,
+    *,
+    config_path: str | Path,
+    secret_manager: SecretManager,
+    adapter_factories: Mapping[str, ExchangeAdapterFactory] | None = None,
+) -> BootstrapContext:
+    """Tworzy kompletny kontekst uruchomieniowy dla wskazanego środowiska."""
+
+    core_config = load_core_config(config_path)
+    if environment_name not in core_config.environments:
+        raise KeyError(f"Środowisko '{environment_name}' nie istnieje w konfiguracji")
+
+    environment = core_config.environments[environment_name]
+    risk_profile_config = _resolve_risk_profile(core_config.risk_profiles, environment.risk_profile)
+
+    risk_engine = ThresholdRiskEngine()
+    profile = ManualProfile(
+        name=risk_profile_config.name,
+        max_positions=risk_profile_config.max_open_positions,
+        max_leverage=risk_profile_config.max_leverage,
+        drawdown_limit=risk_profile_config.hard_drawdown_pct,
+        daily_loss_limit=risk_profile_config.max_daily_loss_pct,
+        max_position_pct=risk_profile_config.max_position_pct,
+        target_volatility=risk_profile_config.target_volatility,
+        stop_loss_atr_multiple=risk_profile_config.stop_loss_atr_multiple,
+    )
+    risk_engine.register_profile(profile)
+
+    credentials = secret_manager.load_exchange_credentials(
+        environment.keychain_key,
+        expected_environment=environment.environment,
+        purpose=environment.credential_purpose,
+    )
+
+    factories = dict(_DEFAULT_ADAPTERS)
+    if adapter_factories:
+        factories.update(adapter_factories)
+    adapter = _instantiate_adapter(environment.exchange, credentials, factories, environment.environment)
+    adapter.configure_network(ip_allowlist=environment.ip_allowlist or None)
+
+    alert_channels, alert_router, audit_log = _build_alert_channels(
+        core_config=core_config,
+        environment=environment,
+        secret_manager=secret_manager,
+    )
+
+    return BootstrapContext(
+        core_config=core_config,
+        environment=environment,
+        credentials=credentials,
+        adapter=adapter,
+        risk_engine=risk_engine,
+        alert_router=alert_router,
+        alert_channels=alert_channels,
+        audit_log=audit_log,
+    )
+
+
+def _instantiate_adapter(
+    exchange_name: str,
+    credentials: ExchangeCredentials,
+    factories: Mapping[str, ExchangeAdapterFactory],
+    environment: Environment,
+) -> ExchangeAdapter:
+    try:
+        factory = factories[exchange_name]
+    except KeyError as exc:
+        raise KeyError(f"Brak fabryki adaptera dla giełdy '{exchange_name}'") from exc
+    return factory(credentials, environment=environment)
+
+
+def _resolve_risk_profile(
+    profiles: Mapping[str, RiskProfileConfig],
+    profile_name: str,
+) -> RiskProfileConfig:
+    try:
+        return profiles[profile_name]
+    except KeyError as exc:
+        raise KeyError(f"Profil ryzyka '{profile_name}' nie istnieje w konfiguracji") from exc
+
+
+def _build_alert_channels(
+    *,
+    core_config: CoreConfig,
+    environment: EnvironmentConfig,
+    secret_manager: SecretManager,
+) -> tuple[Mapping[str, AlertChannel], DefaultAlertRouter, InMemoryAlertAuditLog]:
+    audit_log = InMemoryAlertAuditLog()
+    router = DefaultAlertRouter(audit_log=audit_log)
+    channels: MutableMapping[str, AlertChannel] = {}
+
+    for entry in environment.alert_channels:
+        channel_type, _, channel_key = entry.partition(":")
+        channel_type = channel_type.strip().lower()
+        channel_key = channel_key.strip() or "default"
+
+        if channel_type == "telegram":
+            channel = _build_telegram_channel(core_config.telegram_channels, channel_key, secret_manager)
+        elif channel_type == "email":
+            channel = _build_email_channel(core_config.email_channels, channel_key, secret_manager)
+        elif channel_type == "sms":
+            channel = _build_sms_channel(core_config.sms_providers, channel_key, secret_manager)
+        elif channel_type == "signal":
+            channel = _build_signal_channel(core_config.signal_channels, channel_key, secret_manager)
+        elif channel_type == "whatsapp":
+            channel = _build_whatsapp_channel(core_config.whatsapp_channels, channel_key, secret_manager)
+        elif channel_type == "messenger":
+            channel = _build_messenger_channel(core_config.messenger_channels, channel_key, secret_manager)
+        else:
+            raise KeyError(f"Nieobsługiwany typ kanału alertów: {channel_type}")
+
+        router.register(channel)
+        channels[channel.name] = channel
+
+    return channels, router, audit_log
+
+
+def _build_telegram_channel(
+    definitions: Mapping[str, TelegramChannelSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> TelegramChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji kanału Telegram '{channel_key}'") from exc
+
+    token = secret_manager.load_secret_value(settings.token_secret, purpose="alerts:telegram")
+
+    return TelegramChannel(
+        bot_token=token,
+        chat_id=settings.chat_id,
+        parse_mode=settings.parse_mode,
+        name=f"telegram:{channel_key}",
+    )
+
+
+def _build_email_channel(
+    definitions: Mapping[str, EmailChannelSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> EmailChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji kanału e-mail '{channel_key}'") from exc
+
+    username = None
+    password = None
+    if settings.credential_secret:
+        raw_secret = secret_manager.load_secret_value(settings.credential_secret, purpose="alerts:email")
+        try:
+            parsed = json.loads(raw_secret) if raw_secret else {}
+        except json.JSONDecodeError as exc:  # pragma: no cover - uszkodzony sekret to błąd konfiguracji
+            raise SecretStorageError(
+                "Sekret dla kanału e-mail musi zawierać poprawny JSON z polami 'username' i 'password'."
+            ) from exc
+        username = parsed.get("username")
+        password = parsed.get("password")
+
+    return EmailChannel(
+        host=settings.host,
+        port=settings.port,
+        from_address=settings.from_address,
+        recipients=settings.recipients,
+        username=username,
+        password=password,
+        use_tls=settings.use_tls,
+        name=f"email:{channel_key}",
+    )
+
+
+def _build_sms_channel(
+    definitions: Mapping[str, SMSProviderSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> SMSChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji dostawcy SMS '{channel_key}'") from exc
+
+    if not settings.credential_key:
+        raise SecretStorageError(
+            f"Konfiguracja dostawcy SMS '{channel_key}' musi wskazywać 'credential_key'."
+        )
+
+    raw_secret = secret_manager.load_secret_value(settings.credential_key, purpose="alerts:sms")
+    try:
+        payload = json.loads(raw_secret)
+    except json.JSONDecodeError as exc:  # pragma: no cover - uszkodzone dane w magazynie
+        raise SecretStorageError(
+            "Sekret dostawcy SMS powinien zawierać JSON z polami 'account_sid' i 'auth_token'."
+        ) from exc
+
+    account_sid = payload.get("account_sid")
+    auth_token = payload.get("auth_token")
+    if not account_sid or not auth_token:
+        raise SecretStorageError(
+            "Sekret dostawcy SMS musi zawierać pola 'account_sid' oraz 'auth_token'."
+        )
+
+    provider_config = _resolve_sms_provider(settings)
+    sender = (
+        settings.sender_id
+        if settings.allow_alphanumeric_sender and settings.sender_id
+        else settings.from_number
+    )
+    if not sender:
+        raise SecretStorageError(
+            f"Konfiguracja dostawcy SMS '{channel_key}' wymaga pola 'from_number' lub 'sender_id'."
+        )
+
+    recipients: Sequence[str] = tuple(settings.recipients)
+    if not recipients:
+        raise SecretStorageError(
+            f"Konfiguracja dostawcy SMS '{channel_key}' wymaga co najmniej jednego odbiorcy."
+        )
+
+    return SMSChannel(
+        account_sid=str(account_sid),
+        auth_token=str(auth_token),
+        from_number=sender,
+        recipients=recipients,
+        provider=provider_config,
+        name=f"sms:{channel_key}",
+    )
+
+
+def _build_signal_channel(
+    definitions: Mapping[str, SignalChannelSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> SignalChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji kanału Signal '{channel_key}'") from exc
+
+    token: str | None = None
+    if settings.credential_secret:
+        token = secret_manager.load_secret_value(settings.credential_secret, purpose="alerts:signal")
+
+    return SignalChannel(
+        service_url=settings.service_url,
+        sender_number=settings.sender_number,
+        recipients=settings.recipients,
+        auth_token=token,
+        verify_tls=settings.verify_tls,
+        name=f"signal:{channel_key}",
+    )
+
+
+def _build_whatsapp_channel(
+    definitions: Mapping[str, WhatsAppChannelSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> WhatsAppChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji kanału WhatsApp '{channel_key}'") from exc
+
+    token = secret_manager.load_secret_value(settings.token_secret, purpose="alerts:whatsapp")
+
+    return WhatsAppChannel(
+        phone_number_id=settings.phone_number_id,
+        access_token=token,
+        recipients=settings.recipients,
+        api_base_url=settings.api_base_url,
+        api_version=settings.api_version,
+        name=f"whatsapp:{channel_key}",
+    )
+
+
+def _build_messenger_channel(
+    definitions: Mapping[str, MessengerChannelSettings],
+    channel_key: str,
+    secret_manager: SecretManager,
+) -> MessengerChannel:
+    try:
+        settings = definitions[channel_key]
+    except KeyError as exc:
+        raise KeyError(f"Brak definicji kanału Messenger '{channel_key}'") from exc
+
+    token = secret_manager.load_secret_value(settings.token_secret, purpose="alerts:messenger")
+
+    return MessengerChannel(
+        page_id=settings.page_id,
+        access_token=token,
+        recipients=settings.recipients,
+        api_base_url=settings.api_base_url,
+        api_version=settings.api_version,
+        name=f"messenger:{channel_key}",
+    )
+
+
+def _resolve_sms_provider(settings: SMSProviderSettings) -> SmsProviderConfig:
+    base = get_sms_provider(settings.provider_key)
+    return SmsProviderConfig(
+        provider_id=base.provider_id,
+        display_name=base.display_name,
+        api_base_url=settings.api_base_url or base.api_base_url,
+        iso_country_code=base.iso_country_code,
+        supports_alphanumeric_sender=settings.allow_alphanumeric_sender,
+        notes=base.notes,
+        max_sender_length=base.max_sender_length,
+    )
+
+
+__all__ = ["BootstrapContext", "bootstrap_environment"]

--- a/bot_core/runtime/session.py
+++ b/bot_core/runtime/session.py
@@ -1,0 +1,307 @@
+"""Orkiestrator łączący strategię, ryzyko, egzekucję i alerty."""
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from bot_core.alerts.base import AlertMessage
+from bot_core.alerts.router import DefaultAlertRouter
+from bot_core.execution.base import ExecutionContext, ExecutionService
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeAdapter, OrderRequest, OrderResult
+from bot_core.risk.base import RiskEngine, RiskProfile
+from bot_core.strategies.base import MarketSnapshot, StrategyEngine, StrategySignal
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class InstrumentConfig:
+    """Minimalna wiedza o instrumencie potrzebna do zarządzania pozycją."""
+
+    symbol: str
+    base_asset: str
+    quote_asset: str
+    min_quantity: float = 0.0
+    min_notional: float = 0.0
+    step_size: float | None = None
+
+
+@dataclass(slots=True)
+class PlannedOrder:
+    """Rezultat procesu wyznaczania wielkości pozycji."""
+
+    quantity: float
+    notional: float
+    stop_price: float | None
+
+
+class PositionSizer:
+    """Odpowiada za wyznaczenie wielkości pozycji zgodnie z profilem ryzyka."""
+
+    def __init__(self, profile: RiskProfile) -> None:
+        self._profile = profile
+
+    def size(
+        self,
+        *,
+        signal: StrategySignal,
+        snapshot: MarketSnapshot,
+        account: AccountSnapshot,
+        instrument: InstrumentConfig,
+    ) -> tuple[PlannedOrder | None, str | None]:
+        price = snapshot.close
+        if price <= 0:
+            return None, "Brak poprawnej ceny rynkowej – pomijam sygnał."
+
+        max_position_pct = max(0.0, self._profile.max_position_exposure())
+        if max_position_pct <= 0:
+            return None, "Profil ryzyka nie zezwala na otwieranie pozycji."
+
+        confidence = max(0.0, min(signal.confidence, 1.0))
+        min_confidence = 0.1
+        effective_confidence = max(min_confidence, confidence) if confidence > 0 else 0.0
+        if effective_confidence <= 0:
+            return None, "Sygnał o zerowej pewności został odrzucony."
+
+        max_notional = max_position_pct * account.total_equity
+        if max_notional <= 0:
+            return None, "Kapitał dostępny na koncie jest zbyt niski do otwarcia pozycji."
+
+        target_notional = max_notional * effective_confidence
+        quantity = target_notional / price
+
+        stop_price = signal.metadata.get("stop_price") if signal.metadata else None
+        if isinstance(stop_price, (int, float)) and stop_price > 0:
+            risk_per_unit = abs(price - float(stop_price))
+            daily_limit_pct = max(0.0, self._profile.daily_loss_limit())
+            if risk_per_unit > 0 and daily_limit_pct > 0:
+                # Zachowujemy połowę bufora dziennej straty na inne pozycje.
+                risk_budget = daily_limit_pct * account.total_equity * 0.5
+                if risk_budget > 0:
+                    max_qty_from_stop = risk_budget / risk_per_unit
+                    quantity = min(quantity, max_qty_from_stop)
+        else:
+            stop_price = None
+
+        side = signal.side.lower()
+        balances = dict(account.balances)
+
+        if side == "buy":
+            available_quote = balances.get(instrument.quote_asset, account.available_margin)
+            if available_quote is None:
+                available_quote = account.available_margin
+            max_by_cash = (available_quote / price) if price > 0 else 0.0
+            quantity = min(quantity, max_by_cash)
+            if quantity <= 0:
+                return None, "Brak środków w walucie kwotowanej do otwarcia pozycji."
+        elif side == "sell":
+            available_base = balances.get(instrument.base_asset, 0.0)
+            quantity = min(quantity, available_base)
+            if quantity <= 0:
+                return None, "Brak dostępnej ilości aktywa bazowego do sprzedaży."
+        else:
+            return None, "Obsługiwane są wyłącznie sygnały kupna lub sprzedaży."
+
+        if instrument.min_quantity and quantity < instrument.min_quantity:
+            return None, "Wielkość pozycji jest mniejsza niż minimalna ilość kontraktowa."
+
+        if instrument.min_notional and quantity * price < instrument.min_notional:
+            return None, "Notional pozycji jest niższy od minimalnego limitu giełdy."
+
+        if instrument.step_size:
+            if instrument.step_size <= 0:
+                return None, "Niepoprawny krok wielkości pozycji."
+            steps = math.floor(quantity / instrument.step_size)
+            quantity = steps * instrument.step_size
+
+        quantity = max(0.0, quantity)
+        if quantity <= 0:
+            return None, "Po zaokrągleniu wielkość pozycji spadła do zera."
+
+        notional = quantity * price
+        return PlannedOrder(quantity=quantity, notional=notional, stop_price=stop_price), None
+
+
+class TradingSession:
+    """Wiąże strategię, silnik ryzyka oraz moduł egzekucji w jednolity cykl."""
+
+    def __init__(
+        self,
+        *,
+        strategy: StrategyEngine,
+        strategy_name: str,
+        adapter: ExchangeAdapter,
+        risk_engine: RiskEngine,
+        risk_profile: RiskProfile,
+        execution: ExecutionService,
+        alert_router: DefaultAlertRouter,
+        instruments: Mapping[str, InstrumentConfig],
+        environment: Environment,
+        portfolio_id: str,
+        context_metadata: Mapping[str, str] | None = None,
+        position_sizer: PositionSizer | None = None,
+    ) -> None:
+        self._strategy = strategy
+        self._strategy_name = strategy_name
+        self._adapter = adapter
+        self._risk_engine = risk_engine
+        self._risk_profile = risk_profile
+        self._execution = execution
+        self._alert_router = alert_router
+        self._instruments = dict(instruments)
+        self._environment = environment
+        self._portfolio_id = portfolio_id
+        self._position_sizer = position_sizer or PositionSizer(risk_profile)
+        self._context_metadata = dict(context_metadata or {})
+        self._liquidation_alerted = False
+        self._execution_context = ExecutionContext(
+            portfolio_id=portfolio_id,
+            risk_profile=risk_profile.name,
+            environment=environment.value,
+            metadata={"strategy": strategy_name, **self._context_metadata},
+        )
+
+    def process_snapshot(self, snapshot: MarketSnapshot) -> Sequence[OrderResult]:
+        """Przetwarza pojedynczy pakiet danych i realizuje sygnały strategii."""
+
+        results: list[OrderResult] = []
+
+        signals = list(self._strategy.on_data(snapshot))
+        if not signals:
+            return results
+
+        if self._risk_engine.should_liquidate(profile_name=self._risk_profile.name):
+            if not self._liquidation_alerted:
+                self._dispatch_alert(
+                    category="risk",
+                    severity="critical",
+                    title="Profil w trybie awaryjnym",
+                    body=(
+                        "Silnik ryzyka wymaga natychmiastowej redukcji ekspozycji."
+                        " Pomijam nowe sygnały, dopóki profil pozostaje w trybie force-liquidation."
+                    ),
+                    context={"profile": self._risk_profile.name},
+                )
+                self._liquidation_alerted = True
+            return results
+
+        self._liquidation_alerted = False
+
+        account = self._adapter.fetch_account_snapshot()
+
+        for signal in signals:
+            instrument = self._instruments.get(signal.symbol)
+            if instrument is None:
+                _LOGGER.warning("Brak metadanych instrumentu dla %s", signal.symbol)
+                self._dispatch_alert(
+                    category="trade",
+                    severity="warning",
+                    title="Pominięto sygnał",
+                    body=f"Brak metadanych instrumentu {signal.symbol} uniemożliwia przygotowanie zlecenia.",
+                    context={"symbol": signal.symbol, "strategy": self._strategy_name},
+                )
+                continue
+
+            plan, rejection_reason = self._position_sizer.size(
+                signal=signal, snapshot=snapshot, account=account, instrument=instrument
+            )
+
+            if plan is None:
+                if rejection_reason:
+                    self._dispatch_alert(
+                        category="trade",
+                        severity="warning",
+                        title="Sygnał odrzucony przez sizer",
+                        body=rejection_reason,
+                        context={"symbol": signal.symbol, "strategy": self._strategy_name},
+                    )
+                continue
+
+            order_request = OrderRequest(
+                symbol=signal.symbol,
+                side=signal.side,
+                quantity=plan.quantity,
+                order_type="market",
+                price=snapshot.close,
+            )
+
+            risk_result = self._risk_engine.apply_pre_trade_checks(
+                order_request,
+                account=account,
+                profile_name=self._risk_profile.name,
+            )
+
+            if not risk_result.allowed:
+                self._dispatch_alert(
+                    category="risk",
+                    severity="warning",
+                    title="Kontrola ryzyka odrzuciła zlecenie",
+                    body=risk_result.reason or "Brak szczegółów od silnika ryzyka.",
+                    context={
+                        "symbol": signal.symbol,
+                        "strategy": self._strategy_name,
+                        "profile": self._risk_profile.name,
+                    },
+                )
+                continue
+
+            result = self._execution.execute(order_request, self._execution_context)
+            fill_price = result.avg_price if result.avg_price is not None else snapshot.close
+            position_value = result.filled_quantity * fill_price
+            try:
+                self._risk_engine.on_fill(
+                    profile_name=self._risk_profile.name,
+                    symbol=signal.symbol,
+                    side=signal.side,
+                    position_value=position_value,
+                    pnl=0.0,
+                )
+            except Exception:  # pragma: no cover - silnik ryzyka nie powinien rzucać wyjątku
+                _LOGGER.exception("Błąd aktualizacji stanu ryzyka po realizacji zlecenia")
+
+            self._dispatch_alert(
+                category="trade",
+                severity="info",
+                title=f"Zrealizowano {signal.side.upper()} {signal.symbol}",
+                body=(
+                    f"Wykonano zlecenie {signal.side} na {signal.symbol} w ilości {plan.quantity:.8f}"
+                    f" po cenie {fill_price:.2f}."
+                ),
+                context={
+                    "symbol": signal.symbol,
+                    "strategy": self._strategy_name,
+                    "profile": self._risk_profile.name,
+                    "notional": f"{plan.notional:.2f}",
+                },
+            )
+
+            results.append(result)
+
+        return results
+
+    def _dispatch_alert(
+        self,
+        *,
+        category: str,
+        severity: str,
+        title: str,
+        body: str,
+        context: Mapping[str, str],
+    ) -> None:
+        message = AlertMessage(
+            category=category,
+            title=title,
+            body=body,
+            severity=severity,
+            context=dict(context),
+        )
+        try:
+            self._alert_router.dispatch(message)
+        except Exception:  # pragma: no cover - powiadomienia nie powinny przerywać pętli
+            _LOGGER.exception("Nie udało się wysłać alertu runtime")
+
+
+__all__ = ["InstrumentConfig", "PlannedOrder", "PositionSizer", "TradingSession"]
+

--- a/bot_core/security/__init__.py
+++ b/bot_core/security/__init__.py
@@ -1,0 +1,21 @@
+"""Warstwa bezpieczeństwa i obsługi sekretów bota handlowego."""
+
+from bot_core.security.base import (
+    SecretManager,
+    SecretPayload,
+    SecretStorage,
+    SecretStorageError,
+)
+from bot_core.security.factory import create_default_secret_storage
+from bot_core.security.file_storage import EncryptedFileSecretStorage
+from bot_core.security.keyring_storage import KeyringSecretStorage
+
+__all__ = [
+    "SecretManager",
+    "SecretPayload",
+    "SecretStorage",
+    "SecretStorageError",
+    "KeyringSecretStorage",
+    "EncryptedFileSecretStorage",
+    "create_default_secret_storage",
+]

--- a/bot_core/security/factory.py
+++ b/bot_core/security/factory.py
@@ -1,0 +1,47 @@
+"""Fabryki magazynów sekretów zależne od systemu operacyjnego."""
+from __future__ import annotations
+
+import os
+import platform
+from pathlib import Path
+
+from bot_core.security.base import SecretStorage, SecretStorageError
+from bot_core.security.file_storage import EncryptedFileSecretStorage
+from bot_core.security.keyring_storage import KeyringSecretStorage
+
+_GUI_ENV_VARS = ("DISPLAY", "WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS")
+
+
+def _has_graphical_session() -> bool:
+    return any(os.environ.get(var) for var in _GUI_ENV_VARS)
+
+
+def create_default_secret_storage(
+    *,
+    namespace: str = "dudzian.trading",
+    headless_passphrase: str | None = None,
+    headless_path: str | os.PathLike[str] | None = None,
+) -> SecretStorage:
+    """Dobiera magazyn sekretów odpowiedni dla danego systemu.
+
+    - Windows/macOS/Linux z aktywnym środowiskiem graficznym → ``KeyringSecretStorage``
+    - Linux headless → ``EncryptedFileSecretStorage`` (wymaga hasła użytkownika)
+    """
+
+    system = platform.system().lower()
+    if system in {"windows", "darwin"}:
+        return KeyringSecretStorage(service_name=namespace)
+
+    if system == "linux" and not _has_graphical_session():
+        if headless_passphrase is None:
+            raise SecretStorageError(
+                "W środowisku headless Linux wymagane jest hasło do szyfrowania magazynu sekretów."
+            )
+        path = Path(headless_path or Path.home() / ".dudzian" / "secrets.age")
+        return EncryptedFileSecretStorage(path, headless_passphrase)
+
+    # Domyślnie traktujemy pozostałe systemy jak środowisko desktopowe
+    return KeyringSecretStorage(service_name=namespace)
+
+
+__all__ = ["create_default_secret_storage"]

--- a/bot_core/security/file_storage.py
+++ b/bot_core/security/file_storage.py
@@ -1,0 +1,161 @@
+"""Magazyn sekretów oparty o zaszyfrowany plik dla środowisk headless."""
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Dict
+
+from bot_core.security.base import SecretStorage, SecretStorageError
+
+try:  # pragma: no cover - zależne od środowiska CI
+    from cryptography.fernet import Fernet, InvalidToken
+except ImportError as exc:  # pragma: no cover - import zależy od opcjonalnej zależności
+    _FERNET_IMPORT_ERROR: Exception | None = exc
+    Fernet = None  # type: ignore[assignment]
+    InvalidToken = Exception  # type: ignore[assignment]
+else:
+    _FERNET_IMPORT_ERROR = None
+
+
+def _derive_key(passphrase: str, salt: bytes, *, iterations: int = 390_000) -> bytes:
+    """Wyprowadza klucz symetryczny z hasła użytkownika."""
+
+    import hashlib
+
+    key = hashlib.pbkdf2_hmac("sha256", passphrase.encode("utf-8"), salt, iterations, dklen=32)
+    return base64.urlsafe_b64encode(key)
+
+
+class EncryptedFileSecretStorage(SecretStorage):
+    """Przechowuje sekrety w pliku zaszyfrowanym kluczem pochodnym od hasła."""
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str],
+        passphrase: str,
+        *,
+        iterations: int = 390_000,
+    ) -> None:
+        if _FERNET_IMPORT_ERROR is not None:
+            raise SecretStorageError(
+                "Biblioteka 'cryptography' jest wymagana do korzystania z szyfrowanego magazynu "
+                "plikowego. Zainstaluj ją poleceniem 'pip install cryptography'."
+            ) from _FERNET_IMPORT_ERROR
+
+        self._path = Path(path).expanduser().resolve()
+        self._passphrase = passphrase
+        self._iterations = iterations
+        self._data: Dict[str, str] = {}
+        self._salt: bytes | None = None
+        self._fernet: Fernet | None = None
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._load_or_initialize()
+
+    # ------------------------------------------------------------------
+    # Implementacja interfejsu ``SecretStorage``
+    # ------------------------------------------------------------------
+    def get_secret(self, key: str) -> str | None:
+        return self._data.get(key)
+
+    def set_secret(self, key: str, value: str) -> None:
+        self._data[key] = value
+        self._persist()
+
+    def delete_secret(self, key: str) -> None:
+        if key in self._data:
+            del self._data[key]
+            self._persist()
+
+    # ------------------------------------------------------------------
+    # Metody pomocnicze
+    # ------------------------------------------------------------------
+    def _ensure_crypto(self) -> Fernet:
+        if self._fernet is None or self._salt is None:
+            raise SecretStorageError("Magazyn plikowy nie został poprawnie zainicjalizowany.")
+        return self._fernet
+
+    def _load_or_initialize(self) -> None:
+        if not self._path.exists():
+            self._salt = os.urandom(16)
+            key = _derive_key(self._passphrase, self._salt, iterations=self._iterations)
+            self._fernet = Fernet(key)
+            self._data = {}
+            self._persist()
+            return
+
+        with self._path.open("r", encoding="utf-8") as handle:
+            try:
+                payload = json.load(handle)
+            except json.JSONDecodeError as exc:
+                raise SecretStorageError(
+                    "Plik magazynu sekretów jest uszkodzony. Usuń go ręcznie i zapisz sekrety ponownie."
+                ) from exc
+
+        try:
+            salt_b64 = payload["salt"]
+            ciphertext_b64 = payload["ciphertext"]
+        except KeyError as exc:
+            raise SecretStorageError(
+                "Plik magazynu sekretów ma niepoprawną strukturę. Usuń go i zainicjalizuj ponownie."
+            ) from exc
+
+        try:
+            self._salt = base64.b64decode(salt_b64)
+            ciphertext = base64.b64decode(ciphertext_b64)
+        except (TypeError, ValueError) as exc:
+            raise SecretStorageError(
+                "Nie udało się odczytać danych z pliku magazynu sekretów."
+            ) from exc
+
+        key = _derive_key(self._passphrase, self._salt, iterations=self._iterations)
+        self._fernet = Fernet(key)
+
+        try:
+            decrypted = self._fernet.decrypt(ciphertext)
+        except InvalidToken as exc:
+            raise SecretStorageError(
+                "Nieprawidłowe hasło lub uszkodzone dane magazynu sekretów."
+            ) from exc
+
+        try:
+            raw_dict = json.loads(decrypted.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise SecretStorageError(
+                "Nie udało się zdeserializować danych z magazynu sekretów."
+            ) from exc
+
+        if not isinstance(raw_dict, dict):
+            raise SecretStorageError("Oczekiwano słownika z parami klucz/wartość w magazynie sekretów.")
+
+        self._data = {str(k): str(v) for k, v in raw_dict.items()}
+
+    def _persist(self) -> None:
+        fernet = self._ensure_crypto()
+        salt = self._salt
+        if salt is None:
+            raise SecretStorageError("Brak soli kryptograficznej w magazynie sekretów.")
+
+        plaintext = json.dumps(self._data, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        ciphertext = fernet.encrypt(plaintext)
+
+        payload = {
+            "salt": base64.b64encode(salt).decode("ascii"),
+            "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
+        }
+
+        with NamedTemporaryFile("w", dir=str(self._path.parent), delete=False, encoding="utf-8") as tmp:
+            json.dump(payload, tmp, separators=(",", ":"))
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp.name, self._path)
+        try:
+            os.chmod(self._path, 0o600)
+        except PermissionError:  # pragma: no cover - na niektórych systemach (np. Windows)
+            pass
+
+
+__all__ = ["EncryptedFileSecretStorage"]

--- a/bot_core/security/keyring_storage.py
+++ b/bot_core/security/keyring_storage.py
@@ -1,0 +1,40 @@
+"""Implementacja magazynu sekretów oparta o bibliotekę ``keyring``."""
+from __future__ import annotations
+
+from typing import Optional
+
+from bot_core.security.base import SecretStorage, SecretStorageError
+
+
+class KeyringSecretStorage(SecretStorage):
+    """Odwzorowuje interfejs ``SecretStorage`` na natywne keychainy systemów operacyjnych."""
+
+    def __init__(self, *, service_name: str = "dudzian.trading") -> None:
+        try:
+            import keyring  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - zależne od środowiska CI
+            raise SecretStorageError(
+                "Biblioteka 'keyring' nie jest dostępna. Zainstaluj ją, aby korzystać z natywnego "
+                "przechowywania sekretów (pip install keyring)."
+            ) from exc
+
+        self._keyring = keyring
+        self._service_name = service_name
+
+    def get_secret(self, key: str) -> Optional[str]:
+        return self._keyring.get_password(self._service_name, key)
+
+    def set_secret(self, key: str, value: str) -> None:
+        result = self._keyring.set_password(self._service_name, key, value)
+        if result is not None:  # pragma: no cover - większość backendów zwraca None
+            raise SecretStorageError(f"Nie udało się zapisać sekretu '{key}'.")
+
+    def delete_secret(self, key: str) -> None:
+        try:
+            self._keyring.delete_password(self._service_name, key)
+        except self._keyring.errors.PasswordDeleteError:
+            # Wyrównujemy zachowanie do idempotentnego kasowania – ignorujemy brak wpisu.
+            return
+
+
+__all__ = ["KeyringSecretStorage"]

--- a/bot_core/strategies/__init__.py
+++ b/bot_core/strategies/__init__.py
@@ -1,0 +1,29 @@
+"""Silniki strategii oraz optymalizacja."""
+
+from bot_core.strategies.base import (
+    MarketSnapshot,
+    StrategyEngine,
+    StrategySignal,
+    WalkForwardOptimizer,
+)
+from bot_core.strategies.daily_trend import (
+    DailyTrendMomentumSettings,
+    DailyTrendMomentumStrategy,
+)
+from bot_core.strategies.walkforward import (
+    RollingWindowWalkForwardOptimizer,
+    WalkForwardError,
+    WalkForwardWindow,
+)
+
+__all__ = [
+    "MarketSnapshot",
+    "StrategyEngine",
+    "StrategySignal",
+    "WalkForwardOptimizer",
+    "DailyTrendMomentumSettings",
+    "DailyTrendMomentumStrategy",
+    "WalkForwardError",
+    "WalkForwardWindow",
+    "RollingWindowWalkForwardOptimizer",
+]

--- a/bot_core/strategies/base.py
+++ b/bot_core/strategies/base.py
@@ -1,0 +1,68 @@
+"""Interfejsy strategii oraz kontrakty walk-forward."""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import Mapping, Protocol, Sequence
+
+
+@dataclass(slots=True)
+class MarketSnapshot:
+    """Minimalny zestaw danych przekazywany do strategii.
+
+    Zawiera standardowe pola OHLCV wraz z opcjonalnymi wskaźnikami
+    wyliczonymi wcześniej w łańcuchu przetwarzania. Wszystkie wartości
+    powinny być w strefie czasu UTC, a ceny wyrażone w walucie kwotowanej
+    instrumentu.
+    """
+
+    symbol: str
+    timestamp: int
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float = 0.0
+    indicators: Mapping[str, float] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class StrategySignal:
+    """Rezultat działania strategii (np. sygnał wejścia/wyjścia)."""
+
+    symbol: str
+    side: str
+    confidence: float
+    metadata: Mapping[str, float]
+
+
+class StrategyEngine(abc.ABC):
+    """Bazowy interfejs silników strategii."""
+
+    @abc.abstractmethod
+    def on_data(self, snapshot: MarketSnapshot) -> Sequence[StrategySignal]:
+        """Przetwarza nowy pakiet danych i zwraca sygnały."""
+
+    @abc.abstractmethod
+    def warm_up(self, history: Sequence[MarketSnapshot]) -> None:
+        """Pozwala przygotować wskaźniki przed startem live/paper."""
+
+
+class WalkForwardOptimizer(Protocol):
+    """Kontrakt dla optymalizatorów walk-forward."""
+
+    def split(
+        self, data: Sequence[MarketSnapshot]
+    ) -> Sequence[tuple[Sequence[MarketSnapshot], Sequence[MarketSnapshot]]]:
+        ...
+
+    def select_parameters(self, in_sample: Sequence[MarketSnapshot]) -> Mapping[str, float]:
+        ...
+
+
+__all__ = [
+    "MarketSnapshot",
+    "StrategySignal",
+    "StrategyEngine",
+    "WalkForwardOptimizer",
+]

--- a/bot_core/strategies/daily_trend.py
+++ b/bot_core/strategies/daily_trend.py
@@ -1,0 +1,217 @@
+"""Strategia trend-following i momentum na interwale dziennym."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, List, Mapping, Sequence
+
+from bot_core.strategies.base import MarketSnapshot, StrategyEngine, StrategySignal
+
+
+@dataclass(slots=True)
+class DailyTrendMomentumSettings:
+    """Parametry strategii trend/momentum."""
+
+    fast_ma: int = 20
+    slow_ma: int = 100
+    breakout_lookback: int = 55
+    momentum_window: int = 20
+    atr_window: int = 14
+    atr_multiplier: float = 2.0
+    min_trend_strength: float = 0.005
+    min_momentum: float = 0.0
+
+    def max_history(self) -> int:
+        """Najdłuższe wymagane okno danych."""
+
+        return (
+            max(self.slow_ma, self.breakout_lookback, self.momentum_window, self.atr_window)
+            + 2
+        )
+
+
+@dataclass(slots=True)
+class _SymbolState:
+    """Stan strategii dla pojedynczego instrumentu."""
+
+    closes: Deque[float]
+    highs: Deque[float]
+    lows: Deque[float]
+    true_ranges: Deque[float]
+    last_close: float | None = None
+    in_position: bool = False
+    peak_close: float | None = None
+
+
+class DailyTrendMomentumStrategy(StrategyEngine):
+    """Łączy trend-following i momentum na danych dziennych."""
+
+    def __init__(self, settings: DailyTrendMomentumSettings | None = None) -> None:
+        self._settings = settings or DailyTrendMomentumSettings()
+        self._states: Dict[str, _SymbolState] = {}
+
+    # ------------------------------------------------------------------
+    # API strategii
+    # ------------------------------------------------------------------
+    def warm_up(self, history: Sequence[MarketSnapshot]) -> None:
+        for snapshot in history:
+            state = self._get_state(snapshot.symbol)
+            self._ingest_snapshot(state, snapshot)
+
+    def on_data(self, snapshot: MarketSnapshot) -> Sequence[StrategySignal]:
+        state = self._get_state(snapshot.symbol)
+        self._ingest_snapshot(state, snapshot)
+
+        if not self._has_sufficient_history(state):
+            return []
+
+        metrics = self._calculate_metrics(state, snapshot)
+        signals: List[StrategySignal] = []
+
+        if not state.in_position and self._should_enter(metrics, snapshot):
+            state.in_position = True
+            state.peak_close = snapshot.close
+            signals.append(
+                StrategySignal(
+                    symbol=snapshot.symbol,
+                    side="buy",
+                    confidence=self._entry_confidence(metrics),
+                    metadata=self._build_metadata(metrics, 1.0),
+                )
+            )
+        elif state.in_position and self._should_exit(metrics, snapshot):
+            state.in_position = False
+            state.peak_close = None
+            signals.append(
+                StrategySignal(
+                    symbol=snapshot.symbol,
+                    side="sell",
+                    confidence=self._exit_confidence(metrics, snapshot),
+                    metadata=self._build_metadata(metrics, 0.0),
+                )
+            )
+        else:
+            if state.in_position:
+                state.peak_close = max(state.peak_close or snapshot.close, snapshot.close)
+        return signals
+
+    # ------------------------------------------------------------------
+    # Metody pomocnicze
+    # ------------------------------------------------------------------
+    def _get_state(self, symbol: str) -> _SymbolState:
+        if symbol not in self._states:
+            maxlen = self._settings.max_history()
+            self._states[symbol] = _SymbolState(
+                closes=deque(maxlen=maxlen),
+                highs=deque(maxlen=maxlen),
+                lows=deque(maxlen=maxlen),
+                true_ranges=deque(maxlen=maxlen),
+            )
+        return self._states[symbol]
+
+    def _ingest_snapshot(self, state: _SymbolState, snapshot: MarketSnapshot) -> None:
+        state.closes.append(snapshot.close)
+        state.highs.append(snapshot.high)
+        state.lows.append(snapshot.low)
+        if state.last_close is None:
+            true_range = snapshot.high - snapshot.low
+        else:
+            true_range = max(
+                snapshot.high - snapshot.low,
+                abs(snapshot.high - state.last_close),
+                abs(snapshot.low - state.last_close),
+            )
+        state.true_ranges.append(true_range)
+        state.last_close = snapshot.close
+        if state.in_position:
+            state.peak_close = max(state.peak_close or snapshot.close, snapshot.close)
+
+    def _has_sufficient_history(self, state: _SymbolState) -> bool:
+        settings = self._settings
+        min_required = max(
+            settings.slow_ma,
+            settings.breakout_lookback + 1,
+            settings.momentum_window + 1,
+            settings.atr_window,
+        )
+        return len(state.closes) >= min_required and len(state.true_ranges) >= settings.atr_window
+
+    def _calculate_metrics(
+        self, state: _SymbolState, snapshot: MarketSnapshot
+    ) -> Mapping[str, float]:
+        settings = self._settings
+
+        closes = list(state.closes)
+        highs = list(state.highs)
+        lows = list(state.lows)
+        trs = list(state.true_ranges)
+
+        sma_fast = sum(closes[-settings.fast_ma :]) / settings.fast_ma
+        sma_slow = sum(closes[-settings.slow_ma :]) / settings.slow_ma
+        trend_strength = (sma_fast / sma_slow) - 1.0 if sma_slow else 0.0
+
+        base_index = -(settings.momentum_window + 1)
+        momentum_base = closes[base_index]
+        momentum = (snapshot.close / momentum_base) - 1.0 if momentum_base else 0.0
+
+        atr = sum(trs[-settings.atr_window :]) / settings.atr_window
+        recent_highs = highs[-(settings.breakout_lookback + 1) : -1]
+        recent_lows = lows[-(settings.breakout_lookback + 1) : -1]
+        breakout_high = max(recent_highs) if recent_highs else snapshot.high
+        breakout_low = min(recent_lows) if recent_lows else snapshot.low
+
+        peak_close = state.peak_close if state.peak_close is not None else snapshot.close
+        stop_price = peak_close - atr * settings.atr_multiplier
+
+        return {
+            "sma_fast": sma_fast,
+            "sma_slow": sma_slow,
+            "trend_strength": trend_strength,
+            "momentum": momentum,
+            "atr": atr,
+            "breakout_high": breakout_high,
+            "breakout_low": breakout_low,
+            "stop_price": stop_price,
+            "close": snapshot.close,
+        }
+
+    def _should_enter(self, metrics: Mapping[str, float], snapshot: MarketSnapshot) -> bool:
+        settings = self._settings
+        price_breakout = snapshot.close >= metrics["breakout_high"]
+        trend_ok = metrics["trend_strength"] >= settings.min_trend_strength
+        momentum_ok = metrics["momentum"] >= settings.min_momentum
+        return price_breakout and trend_ok and momentum_ok
+
+    def _should_exit(self, metrics: Mapping[str, float], snapshot: MarketSnapshot) -> bool:
+        trend_reversal = metrics["trend_strength"] < 0.0
+        stop_hit = snapshot.close <= metrics["stop_price"]
+        breakout_failure = snapshot.close <= metrics["breakout_low"]
+        return trend_reversal or stop_hit or breakout_failure
+
+    def _entry_confidence(self, metrics: Mapping[str, float]) -> float:
+        trend_component = max(0.0, metrics["trend_strength"] - self._settings.min_trend_strength)
+        momentum_component = max(0.0, metrics["momentum"] - self._settings.min_momentum)
+        confidence = 0.35 + 2.0 * trend_component + 1.5 * momentum_component
+        return max(0.1, min(1.0, confidence))
+
+    def _exit_confidence(self, metrics: Mapping[str, float], snapshot: MarketSnapshot) -> float:
+        stop_distance = max(0.0, metrics["stop_price"] - snapshot.close) / max(snapshot.close, 1e-8)
+        trend_component = max(0.0, -metrics["trend_strength"])
+        confidence = 0.35 + 3.0 * stop_distance + 2.0 * trend_component
+        return max(0.1, min(1.0, confidence))
+
+    def _build_metadata(self, metrics: Mapping[str, float], position_flag: float) -> Mapping[str, float]:
+        return {
+            "sma_fast": metrics["sma_fast"],
+            "sma_slow": metrics["sma_slow"],
+            "trend_strength": metrics["trend_strength"],
+            "momentum": metrics["momentum"],
+            "atr": metrics["atr"],
+            "breakout_high": metrics["breakout_high"],
+            "breakout_low": metrics["breakout_low"],
+            "stop_price": metrics["stop_price"],
+            "position": position_flag,
+        }
+
+
+__all__ = ["DailyTrendMomentumSettings", "DailyTrendMomentumStrategy"]

--- a/bot_core/strategies/walkforward.py
+++ b/bot_core/strategies/walkforward.py
@@ -1,0 +1,112 @@
+"""Moduł walk-forward do podziału danych i wyboru parametrów strategii."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+from bot_core.strategies.base import MarketSnapshot, WalkForwardOptimizer
+
+
+class WalkForwardError(RuntimeError):
+    """Wyjątek zgłaszany przy problemach z konfiguracją walk-forward."""
+
+
+@dataclass(slots=True)
+class WalkForwardWindow:
+    """Opisuje długości okien in/out-of-sample dla analizy walk-forward."""
+
+    training_size: int
+    testing_size: int
+    step_size: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.training_size <= 0:
+            raise WalkForwardError("Długość okna treningowego musi być dodatnia.")
+        if self.testing_size <= 0:
+            raise WalkForwardError("Długość okna testowego musi być dodatnia.")
+        if self.step_size is not None and self.step_size <= 0:
+            raise WalkForwardError("Krok przesuwania okna musi być dodatni.")
+
+    @property
+    def step(self) -> int:
+        """Zwraca krok przesunięcia okna (domyślnie długość okresu testowego)."""
+
+        return self.step_size or self.testing_size
+
+
+class RollingWindowWalkForwardOptimizer(WalkForwardOptimizer):
+    """Realizuje prostą analizę walk-forward na ruchomych oknach danych."""
+
+    def __init__(
+        self,
+        window: WalkForwardWindow,
+        parameter_grid: Sequence[Mapping[str, float]],
+        scorer: Callable[[Sequence[MarketSnapshot], Mapping[str, float]], float],
+        *,
+        maximize: bool = True,
+    ) -> None:
+        if not parameter_grid:
+            raise WalkForwardError("Lista kandydatów parametrów nie może być pusta.")
+        self._window = window
+        self._parameter_grid = tuple(parameter_grid)
+        self._scorer = scorer
+        self._maximize = maximize
+
+    def split(
+        self, data: Sequence[MarketSnapshot]
+    ) -> Sequence[tuple[Sequence[MarketSnapshot], Sequence[MarketSnapshot]]]:
+        """Dzieli dane na sekwencję par (in-sample, out-of-sample)."""
+
+        total = len(data)
+        train = self._window.training_size
+        test = self._window.testing_size
+        step = self._window.step
+
+        if total < train + test:
+            raise WalkForwardError(
+                "Za mało danych do przeprowadzenia walk-forward. "
+                f"Wymagane co najmniej {train + test} obserwacji, otrzymano {total}."
+            )
+
+        segments: list[tuple[Sequence[MarketSnapshot], Sequence[MarketSnapshot]]] = []
+        start = 0
+        while start + train + test <= total:
+            in_sample = data[start : start + train]
+            out_sample = data[start + train : start + train + test]
+            segments.append((in_sample, out_sample))
+            start += step
+
+        if not segments:
+            raise WalkForwardError("Nie udało się wygenerować żadnych segmentów walk-forward.")
+        return tuple(segments)
+
+    def select_parameters(self, in_sample: Sequence[MarketSnapshot]) -> Mapping[str, float]:
+        """Wybiera najlepszy zestaw parametrów na podstawie funkcji ``scorer``."""
+
+        best_score: float | None = None
+        best_params: Mapping[str, float] | None = None
+
+        for candidate in self._parameter_grid:
+            score = self._scorer(in_sample, candidate)
+            if best_score is None:
+                best_score = score
+                best_params = candidate
+                continue
+
+            if self._maximize and score > best_score:
+                best_score = score
+                best_params = candidate
+            elif not self._maximize and score < best_score:
+                best_score = score
+                best_params = candidate
+
+        if best_params is None:
+            raise WalkForwardError("Nie udało się wybrać parametrów dla pustej próbki in-sample.")
+        return best_params
+
+
+__all__ = [
+    "WalkForwardError",
+    "WalkForwardWindow",
+    "RollingWindowWalkForwardOptimizer",
+]

--- a/config/core.yaml
+++ b/config/core.yaml
@@ -1,0 +1,387 @@
+# Konfiguracja bazowa etapu 1 – wartości placeholder do dalszego dostosowania.
+
+risk_profiles:
+  conservative:
+    max_daily_loss_pct: 0.01
+    max_position_pct: 0.03
+    target_volatility: 0.07
+    max_leverage: 2.0
+    stop_loss_atr_multiple: 1.0
+    max_open_positions: 3
+    hard_drawdown_pct: 0.05
+  balanced:
+    max_daily_loss_pct: 0.015
+    max_position_pct: 0.05
+    target_volatility: 0.11
+    max_leverage: 3.0
+    stop_loss_atr_multiple: 1.5
+    max_open_positions: 5
+    hard_drawdown_pct: 0.10
+  aggressive:
+    max_daily_loss_pct: 0.03
+    max_position_pct: 0.10
+    target_volatility: 0.19
+    max_leverage: 5.0
+    stop_loss_atr_multiple: 2.0
+    max_open_positions: 10
+    hard_drawdown_pct: 0.20
+  manual:
+    max_daily_loss_pct: 0.0
+    max_position_pct: 0.0
+    target_volatility: 0.0
+    max_leverage: 0.0
+    stop_loss_atr_multiple: 0.0
+    max_open_positions: 0
+    hard_drawdown_pct: 0.0
+
+strategies:
+  core_daily_trend:
+    engine: daily_trend_momentum
+    parameters:
+      fast_ma: 25
+      slow_ma: 100
+      breakout_lookback: 55
+      momentum_window: 20
+      atr_window: 14
+      atr_multiplier: 2.0
+      min_trend_strength: 0.005
+      min_momentum: 0.001
+
+instrument_universes:
+  core_multi_exchange:
+    description: >-
+      Bazowy koszyk instrumentów dostępny na Binance, Krakenie i Zondzie.
+      Zawiera pary BTC i ETH do USDT oraz EUR, sześć głównych altów oraz
+      fiatowe pary na Zondzie wykorzystywane do testów integracyjnych.
+    instruments:
+      BTC_USDT:
+        base_asset: BTC
+        quote_asset: USDT
+        categories: [core, btc, stable]
+        exchanges:
+          binance_spot: BTCUSDT
+          binance_futures: BTCUSDT
+          kraken_spot: XBTUSDT
+          kraken_futures: pi_xbtusd
+          zonda_spot: BTC-USDT
+        backfill:
+          - interval: 1d
+            lookback_days: 3650
+          - interval: 1h
+            lookback_days: 1095
+      ETH_USDT:
+        base_asset: ETH
+        quote_asset: USDT
+        categories: [core, eth, stable]
+        exchanges:
+          binance_spot: ETHUSDT
+          binance_futures: ETHUSDT
+          kraken_spot: ETHUSDT
+          kraken_futures: pi_ethusd
+          zonda_spot: ETH-USDT
+        backfill:
+          - interval: 1d
+            lookback_days: 3650
+          - interval: 1h
+            lookback_days: 1095
+      BTC_EUR:
+        base_asset: BTC
+        quote_asset: EUR
+        categories: [core, btc, fiat]
+        exchanges:
+          binance_spot: BTCEUR
+          kraken_spot: XBTEUR
+          kraken_futures: pi_xbteur
+          zonda_spot: BTC-EUR
+        backfill:
+          - interval: 1d
+            lookback_days: 3650
+          - interval: 1h
+            lookback_days: 730
+      ETH_EUR:
+        base_asset: ETH
+        quote_asset: EUR
+        categories: [core, eth, fiat]
+        exchanges:
+          binance_spot: ETHEUR
+          kraken_spot: ETHEUR
+          kraken_futures: pi_etheur
+          zonda_spot: ETH-EUR
+        backfill:
+          - interval: 1d
+            lookback_days: 3650
+          - interval: 1h
+            lookback_days: 730
+      SOL_USDT:
+        base_asset: SOL
+        quote_asset: USDT
+        categories: [alt, high_liquidity]
+        exchanges:
+          binance_spot: SOLUSDT
+          binance_futures: SOLUSDT
+          kraken_spot: SOLUSDT
+        backfill:
+          - interval: 1d
+            lookback_days: 1825
+          - interval: 1h
+            lookback_days: 730
+      BNB_USDT:
+        base_asset: BNB
+        quote_asset: USDT
+        categories: [alt, high_liquidity]
+        exchanges:
+          binance_spot: BNBUSDT
+          binance_futures: BNBUSDT
+        backfill:
+          - interval: 1d
+            lookback_days: 1825
+          - interval: 1h
+            lookback_days: 730
+      XRP_USDT:
+        base_asset: XRP
+        quote_asset: USDT
+        categories: [alt, high_liquidity]
+        exchanges:
+          binance_spot: XRPUSDT
+          kraken_spot: XRPUSDT
+        backfill:
+          - interval: 1d
+            lookback_days: 1825
+          - interval: 1h
+            lookback_days: 730
+      ADA_USDT:
+        base_asset: ADA
+        quote_asset: USDT
+        categories: [alt, high_liquidity]
+        exchanges:
+          binance_spot: ADAUSDT
+          binance_futures: ADAUSDT
+          kraken_spot: ADAUSDT
+        backfill:
+          - interval: 1d
+            lookback_days: 1825
+          - interval: 1h
+            lookback_days: 730
+      LTC_USDT:
+        base_asset: LTC
+        quote_asset: USDT
+        categories: [alt, high_liquidity]
+        exchanges:
+          binance_spot: LTCUSDT
+          binance_futures: LTCUSDT
+          kraken_spot: LTCUSDT
+        backfill:
+          - interval: 1d
+            lookback_days: 1825
+          - interval: 1h
+            lookback_days: 730
+      MATIC_USDT:
+        base_asset: MATIC
+        quote_asset: USDT
+        categories: [alt, high_liquidity]
+        exchanges:
+          binance_spot: MATICUSDT
+          binance_futures: MATICUSDT
+          kraken_spot: MATICUSDT
+        backfill:
+          - interval: 1d
+            lookback_days: 1825
+          - interval: 1h
+            lookback_days: 730
+      BTC_PLN:
+        base_asset: BTC
+        quote_asset: PLN
+        categories: [fiat, zonda]
+        exchanges:
+          zonda_spot: BTC-PLN
+        backfill:
+          - interval: 1d
+            lookback_days: 3650
+      ETH_PLN:
+        base_asset: ETH
+        quote_asset: PLN
+        categories: [fiat, zonda]
+        exchanges:
+          zonda_spot: ETH-PLN
+        backfill:
+          - interval: 1d
+            lookback_days: 3650
+
+environments:
+  binance_paper:
+    exchange: binance_spot
+    environment: paper
+    keychain_key: binance_paper_trading
+    credential_purpose: trading
+    data_cache_path: ./var/data/binance_paper
+    risk_profile: balanced
+    alert_channels: ["telegram:primary", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  binance_live:
+    exchange: binance_spot
+    environment: live
+    keychain_key: binance_live_trading
+    data_cache_path: ./var/data/binance_live
+    risk_profile: conservative
+    alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  binance_futures_paper:
+    exchange: binance_futures
+    environment: paper
+    keychain_key: binance_futures_paper_trading
+    data_cache_path: ./var/data/binance_futures_paper
+    risk_profile: balanced
+    alert_channels: ["telegram:primary", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  binance_futures_live:
+    exchange: binance_futures
+    environment: live
+    keychain_key: binance_futures_live_trading
+    data_cache_path: ./var/data/binance_futures_live
+    risk_profile: conservative
+    alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  kraken_paper:
+    exchange: kraken_spot
+    environment: paper
+    keychain_key: kraken_paper_trading
+    data_cache_path: ./var/data/kraken_paper
+    risk_profile: balanced
+    alert_channels: ["telegram:primary", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  kraken_live:
+    exchange: kraken_spot
+    environment: live
+    keychain_key: kraken_live_trading
+    data_cache_path: ./var/data/kraken_live
+    risk_profile: conservative
+    alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  kraken_futures_paper:
+    exchange: kraken_futures
+    environment: paper
+    keychain_key: kraken_futures_paper_trading
+    data_cache_path: ./var/data/kraken_futures_paper
+    risk_profile: balanced
+    alert_channels: ["telegram:primary", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  kraken_futures_live:
+    exchange: kraken_futures
+    environment: live
+    keychain_key: kraken_futures_live_trading
+    data_cache_path: ./var/data/kraken_futures_live
+    risk_profile: conservative
+    alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  zonda_paper:
+    exchange: zonda_spot
+    environment: paper
+    keychain_key: zonda_paper_trading
+    data_cache_path: ./var/data/zonda_paper
+    risk_profile: conservative
+    alert_channels: ["telegram:primary"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+  zonda_live:
+    exchange: zonda_spot
+    environment: live
+    keychain_key: zonda_live_trading
+    data_cache_path: ./var/data/zonda_live
+    risk_profile: conservative
+    alert_channels: ["telegram:primary", "sms:nova_is", "email:ops"]
+    ip_allowlist: []
+    instrument_universe: core_multi_exchange
+
+reporting:
+  daily_report_time_utc: "21:00"
+  weekly_report_day: "sunday"
+  retention_months: "24"
+
+
+alerts:
+  telegram_channels:
+    primary:
+      chat_id: "123456789"
+      token_secret: telegram_primary_token
+      parse_mode: MarkdownV2
+  signal_channels:
+    primary_signal:
+      service_url: https://signal-gateway.local
+      sender_number: "+48500100999"
+      recipients:
+        - "+48555111222"
+      credential_secret: signal_cli_token
+      verify_tls: true
+  whatsapp_channels:
+    primary_whatsapp:
+      phone_number_id: "10987654321"
+      recipients:
+        - "48555111222"
+      token_secret: whatsapp_primary_token
+      api_base_url: https://graph.facebook.com
+      api_version: v16.0
+  messenger_channels:
+    ops_messenger:
+      page_id: "1357924680"
+      recipients:
+        - "2468013579"
+      token_secret: messenger_page_token
+      api_base_url: https://graph.facebook.com
+      api_version: v16.0
+  email_channels:
+    ops:
+      host: smtp.example.com
+      port: 587
+      from_address: bot@example.com
+      recipients:
+        - ops@example.com
+      credential_secret: smtp_ops_credentials
+      use_tls: true
+  sms_providers:
+    orange_local:
+      provider: orange_pl
+      api_base_url: https://api.orange.pl/sms/v1
+      from_number: "+48500100100"
+      recipients: ["+48555111222"]
+      allow_alphanumeric_sender: true
+      sender_id: "BOT-ORANGE"
+      credential_key: orange_sms_credentials
+    tmobile_local:
+      provider: tmobile_pl
+      api_base_url: https://api.t-mobile.pl/sms/v1
+      from_number: "+48500100101"
+      recipients: ["+48555111333"]
+      allow_alphanumeric_sender: true
+      sender_id: "BOT-TMOBILE"
+      credential_key: tmobile_sms_credentials
+    plus_local:
+      provider: plus_pl
+      api_base_url: https://api.plus.pl/messaging/v1
+      from_number: "+48500100102"
+      recipients: ["+48555111444"]
+      allow_alphanumeric_sender: false
+      credential_key: plus_sms_credentials
+    play_local:
+      provider: play_pl
+      api_base_url: https://api.play.pl/sms/v1
+      from_number: "+48500100103"
+      recipients: ["+48555111555"]
+      allow_alphanumeric_sender: true
+      sender_id: "BOT-PLAY"
+      credential_key: play_sms_credentials
+    nova_is:
+      provider: nova_is
+      api_base_url: https://api.nova.is/sms/v1
+      from_number: "+3546001001"
+      recipients: ["+3546601234"]
+      allow_alphanumeric_sender: true
+      sender_id: "BOT-NOVA"
+      credential_key: nova_sms_credentials

--- a/docs/architecture/phase1_foundation.md
+++ b/docs/architecture/phase1_foundation.md
@@ -1,0 +1,137 @@
+# Architektura rdzenia – etap 1
+
+Dokument opisuje modularną architekturę przygotowującą bota do integracji z Binance (spot + futures),
+Krakenem i Zondą. W pierwszym etapie budujemy szkielet umożliwiający bezpieczny rozwój bez licencji
+zewnętrznych, z jasnym podziałem na warstwy i środowiska.
+
+## Podział na moduły
+
+| Moduł | Odpowiedzialność | Kluczowe klasy/interfejsy |
+| --- | --- | --- |
+| `bot_core/exchanges` | Adaptery giełdowe z rozdzieleniem środowisk i uprawnień | `ExchangeAdapter`, `ExchangeCredentials`, `BinanceSpotAdapter`, `BinanceFuturesAdapter`, `KrakenSpotAdapter`, `KrakenFuturesAdapter`, `ZondaSpotAdapter` |
+| `bot_core/data` | Pobieranie, normalizacja i cache danych OHLCV | `DataSource`, `CachedOHLCVSource`, `PublicAPIDataSource` |
+| `bot_core/strategies` | Silnik strategii i walk-forward | `StrategyEngine`, `MarketSnapshot`, `StrategySignal`, `WalkForwardOptimizer` |
+| `bot_core/risk` | Profile i enforcement limitów ryzyka | `RiskProfile`, `RiskEngine`, `RiskCheckResult`, profile konserwatywny/zbalansowany/agresywny/ręczny |
+| `bot_core/execution` | Warstwa składania zleceń z retry/backoff | `ExecutionService`, `ExecutionContext`, `RetryPolicy` |
+| `bot_core/alerts` | Wspólne API alertów i kanały powiadomień | `AlertChannel`, `AlertRouter`, kanały `TelegramChannel`, `EmailChannel`, `SMSChannel`, `SignalChannel`, `WhatsAppChannel`, `MessengerChannel` |
+| `bot_core/config` | Ładowanie konfiguracji i mapowanie na dataclasses | `CoreConfig`, `EnvironmentConfig`, `RiskProfileConfig`, `load_core_config` |
+| `bot_core/security` | Bezpieczne przechowywanie kluczy API i integracja z keychainami | `SecretManager`, `KeyringSecretStorage` |
+
+Adaptery `BinanceSpotAdapter` oraz `BinanceFuturesAdapter` obsługują dane publiczne (lista symboli,
+świece OHLCV) oraz podpisane wywołania konta i składania/anulowania zleceń. Wspierają separację
+środowisk (`live`/`paper`/`testnet`), podpis HMAC SHA-256 oraz kontrolę uprawnień (`read`/`trade`).
+Wersja futures korzysta z endpointów USD-M, wymaga jawnego podania symbolu przy anulowaniu i
+odczytuje metryki marginesu z `totalMarginBalance`/`totalAvailableBalance`. Testy jednostkowe
+potwierdzają poprawność podpisów i mapowania odpowiedzi.
+
+Dodany `KrakenSpotAdapter` implementuje podpis HMAC-SHA512 z wymaganym nonce, obsługuje publiczne
+endpointy (`AssetPairs`, `OHLC`) oraz prywatne wywołania (`Balance`, `TradeBalance`, `AddOrder`,
+`CancelOrder`). Adapter egzekwuje podział uprawnień (`read`/`trade`), zapewnia monotonistyczny nonce,
+przetwarza dane konta na `AccountSnapshot` i integruje się z bootstrapem środowiska. Testy
+jednostkowe weryfikują poprawność podpisu oraz serializację zleceń. `KrakenFuturesAdapter`
+korzysta z endpointów `derivatives/api/v3`, generuje podpis HMAC-SHA256 wymagany przez Kraken
+Futures (nagłówki `APIKey`, `Authent`, `Nonce`), mapuje wartości marginesu oraz bilansów na
+`AccountSnapshot`, wspiera składanie zleceń `mkt`/`lmt` i anulowanie przez `DELETE /orders/{id}`.
+Wzbogacone testy jednostkowe potwierdzają budowę podpisu i serializację ciała żądania.
+`ZondaSpotAdapter` wykorzystuje REST API Zondy do pobierania świec (endpoint `trading/candle/history`) oraz danych konta (`trading/balance`). Implementacja korzysta z podpisu HMAC-SHA512 zgodnie z nagłówkiem `API-Hash`, obsługuje mapowanie statusów zleceń i zabezpiecza się przed brakiem uprawnień (`read`/`trade`). Adapter został dodany do domyślnych fabryk bootstrapa, dzięki czemu środowiska paper/live mogą korzystać z Zondy bez modyfikacji logiki strategii czy ryzyka.
+
+
+## Warstwa konfiguracji
+
+Plik `config/core.yaml` przechowuje:
+
+- parametry profili ryzyka (zgodne z wymaganiami: dzienne limity strat, ATR, dźwignia, liczba pozycji,
+  hard-stop drawdown),
+- definicje środowisk (paper/live/testnet) wraz z kluczami do menedżera sekretów, nazwą wpisu w
+  keychainie (`credential_purpose`), ścieżkami cache i listą kanałów alertów,
+- zbiory instrumentów (`instrument_universes`) opisujące koszyk rynków przypisany do środowisk,
+  w tym aliasy symboli na poszczególnych giełdach oraz rekomendowane zakresy backfillu dla interwałów
+  (np. 10 lat D1 dla BTC/ETH, 5 lat dla głównych altów, 1h dla walidacji ryzyka),
+- ustawienia raportowania (czas dziennych/tygodniowych raportów, retencja logów).
+
+Loader `load_core_config` mapuje YAML na dataclasses i zapewnia konwersję pól liczbowych oraz
+walidację środowiska poprzez `Environment` enum. Dzięki temu logika aplikacji otrzymuje w pełni
+ustrukturyzowany obiekt konfiguracyjny wraz z kompletną definicją uniwersum instrumentów, co
+upraszcza backfill danych oraz konfigurację strategii.
+
+### Bootstrap środowiska
+
+Nowy moduł `bot_core/runtime/bootstrap.py` dostarcza funkcję `bootstrap_environment`, która w oparciu
+o `core.yaml` i `SecretManager` buduje kompletny kontekst uruchomieniowy (`BootstrapContext`). W jego
+skład wchodzą: zainicjalizowany adapter giełdowy (z fabryki dopasowanej do `exchange`), zarejestrowany
+profil ryzyka w `ThresholdRiskEngine`, skonfigurowany router alertów z kanałami Telegram/E-mail/SMS/
+Signal/WhatsApp/Messenger
+oraz dziennik audytu. Dzięki temu pojedyncze środowisko (paper/live/testnet) można uruchomić w sposób
+deterministyczny, a desktopowy interfejs w kolejnych etapach będzie mógł komunikować się z core przez
+prostą warstwę IPC, korzystając z gotowego kontekstu.
+
+## Środowiska i separacja uprawnień
+
+Każdy adapter giełdowy otrzymuje `ExchangeCredentials` z informacją o środowisku (live/paper/testnet)
+oraz zakresem uprawnień. Struktura przygotowuje grunt pod rozdzielenie kluczy `read-only` i `trading`
+w Windows Credential Manager/macOS Keychain/Linux keyring (`keychain_key` w konfiguracji). Metoda
+`configure_network` umożliwi egzekwowanie IP allowlist.
+
+## Dane rynkowe
+
+`PublicAPIDataSource` zostanie połączony z adapterami do pobierania danych OHLCV z publicznych API.
+`CachedOHLCVSource` w połączeniu z `OHLCVBackfillService` obsługuje proces „backfill + cache” z
+podziałem na okna czasowe oraz deduplikacją zapisów. Domyślny backend `SQLiteCacheStorage`
+przechowuje dane w pliku `ohlcv.sqlite` (tryb WAL) i udostępnia metadane do audytu. Dla użytkownika
+końcowego przygotowano skrypt `scripts/backfill_ohlcv.py`, który na podstawie `config/core.yaml`
+pobiera świece z Binance lub Zondy (w zależności od środowiska) i aktualizuje lokalny cache w trybie bezkosztowym.
+
+## Strategie i walk-forward
+
+`StrategyEngine` definiuje kontrakt odbierania snapshotów rynkowych oraz generowania sygnałów.
+Pierwszą ukończoną implementacją jest `DailyTrendMomentumStrategy`, która łączy średnie kroczące,
+wybicia Donchiana i trailing stop na bazie ATR, aby realizować trend-following na interwale D1.
+Parametry strategii (okna średnich, próg momentum, wielkość ATR) znajdują się w sekcji `strategies`
+pliku `config/core.yaml` i są mapowane na dataclass `DailyTrendMomentumStrategyConfig`. Interfejsy
+pozostają przygotowane pod kolejne moduły (mean reversion, arbitraż, optymalizacja walk-forward)
+korzystające z tego samego kontraktu `StrategyEngine` i `WalkForwardOptimizer`.
+
+## Zarządzanie ryzykiem
+
+`RiskProfile` i `ThresholdRiskEngine` egzekwują dzienny limit straty, liczbę równoległych pozycji,
+dźwignię, ekspozycję per instrument oraz hard-stop drawdown. Dostępne są cztery gotowe profile
+(konserwatywny, zbalansowany, agresywny, manualny) odwzorowujące wymagane parametry. Silnik
+utrzymuje stan w repozytorium (`RiskRepository`), kontroluje reset doby w UTC, wymusza tryb
+awaryjny po przekroczeniu limitów i wskazuje dopuszczalną maksymalną wielkość zlecenia.
+
+## Bezpieczeństwo i przechowywanie sekretów
+
+Warstwa `bot_core/security` dostarcza `SecretManager`, który serializuje poświadczenia giełdowe i
+umieszcza je w natywnym keychainie systemu operacyjnego poprzez `KeyringSecretStorage`. Dzięki
+temu klucze API są składowane poza repozytorium kodu, z rozdzieleniem środowisk i uprawnień.
+Manager pilnuje zgodności środowiska (paper/live/testnet) oraz pozwala na wielokrotne
+zapisanie/rotację kluczy bez ręcznych zmian w konfiguracji YAML. W środowiskach headless można
+docelowo podmienić implementację `SecretStorage` na wariant oparty o zaszyfrowany plik (np. `age`).
+
+## Egzekucja
+
+`ExecutionService` definiuje pełny cykl życia zlecenia z kontekstem (`ExecutionContext`) zawierającym
+informacje o profilu ryzyka i środowisku. Interfejs `RetryPolicy` pozwoli na polityki zależne od
+błędów API (np. exponential backoff, circuit breaker). Pierwszą implementacją jest
+`PaperTradingExecutionService`, który symuluje egzekucję z natychmiastowym fill'em,
+uwzględnia prowizje maker/taker, poślizg (w punktach bazowych), walidację wielkości zlecenia oraz
+prowadzi dziennik audytowy transakcji.
+
+## Alerty i obserwowalność
+
+`AlertChannel` i `AlertRouter` zapewniają jednolite API dla powiadomień (Telegram, e-mail, SMS, Signal,
+WhatsApp, Messenger). Implementacja `DefaultAlertRouter` obsługuje audyt (`InMemoryAlertAuditLog`),
+kontynuuje wysyłkę pomimo błędów pojedynczych kanałów i zwraca migawkę `health_check` do monitoringu SLO.
+Adaptery kanałów posiadają zabezpieczenia (timeouty, logowanie błędów, walidację odpowiedzi API) oraz
+formatowanie wiadomości z kontekstem ryzyka i znacznikami czasu UTC.
+
+## Kolejne kroki implementacyjne
+
+1. Rozszerzyć testy integracyjne kanałów komunikatorów o scenariusze awarii i fallback do alternatywnych
+   dostawców oraz dodać mechanizm throttle/acknowledgement dla krytycznych incydentów.
+2. Podłączyć metryki Prometheus (latencja wysyłek, error rate) i dashboard zgodny z wymaganiami SLO.
+3. Ustandaryzować eksport audytu do formatu Parquet/CSV z podpisem kryptograficznym oraz przygotować
+   rotację logów zgodną z polityką 24–60 miesięcy.
+4. Zintegrować alerty z planowanym modułem raportowania dziennego/tygodniowego.
+
+Dokument będzie aktualizowany wraz z postępem implementacji kolejnych modułów.

--- a/docs/audit/2024-05_code_review.md
+++ b/docs/audit/2024-05_code_review.md
@@ -1,0 +1,97 @@
+# Przegląd kodu bota handlowego – maj 2024
+
+> Cel dokumentu: zebrać aktualny stan repozytorium, zidentyfikować najważniejsze luki względem wymagań
+> produktowych i bezpieczeństwa oraz zaproponować etapowy plan rozwoju prowadzący do funkcjonalności
+> porównywalnej z komercyjnymi botami (np. CryptoHopper). Poniższe wnioski powstały na bazie pełnej
+> analizy struktury `bot_core` oraz historycznego monolitu `KryptoLowca`.
+
+## 1. Ocena struktury i jakości modułów
+
+### 1.1. Warstwa `bot_core`
+
+| Obszar | Pliki | Ocena i rekomendacje |
+| --- | --- | --- |
+| Adaptery giełdowe | `bot_core/exchanges/*` | Interfejs `ExchangeAdapter` dobrze oddziela środowiska (`live`/`paper`/`testnet`). Implementacje Binance/Kraken/Zonda są kompletne, ale wymagają dalszego hardeningu (np. circuit breaker, cache uprawnień). Należy utrzymywać rozdział kluczy *read-only* i *trading* oraz rozszerzyć testy integracyjne o symulację rate limitów. |
+| Warstwa danych | `bot_core/data/base.py`, `bot_core/data/ohlcv/*` | Proces backfillu i cache SQLite spełnia założenia bezkosztowego pozyskania OHLCV. Brakuje jeszcze eksportu do Parquet oraz schedulerów aktualizacji intraday. Zalecane dodanie walidacji integralności danych i metryk (liczba nowych świec). |
+| Strategie | `bot_core/strategies/*` | Strategia `DailyTrendMomentumStrategy` odwzorowuje trend-following + momentum na D1 i ma testy jednostkowe. Przygotowany interfejs pod przyszłe klasy (mean reversion, arbitraż). Kolejny krok to implementacja modułu walk-forward i parametryzacji per instrument. |
+| Ryzyko | `bot_core/risk/*` | `ThresholdRiskEngine` egzekwuje limity dziennych strat, maksymalną liczbę pozycji oraz poziom dźwigni dla profili konserwatywny/zbalansowany/agresywny. Wymagane dopracowanie modułu raportowania naruszeń i archiwizacji stanu (logi append-only + backupy). |
+| Egzekucja | `bot_core/execution/*` | `PaperTradingExecutionService` zapewnia realistyczną symulację z poślizgiem i prowizjami. Brakuje jeszcze modułu `LiveExecutionService` z mechanizmami retry/backoff oraz monitorowania SLO. |
+| Alerty | `bot_core/alerts/*` | Router i kanały (Telegram, e-mail, SMS, Signal, WhatsApp, Messenger) są gotowe, posiadają audyt i health-check. Do wdrożenia pozostaje integracja z realnymi API (np. webhook Telegrama) oraz obsługa ról odbiorców w przyszłości. |
+| Bezpieczeństwo | `bot_core/security/*` | `SecretManager` obsługuje keyring (Windows/macOS/Linux) i zaszyfrowany magazyn plikowy. Wymagane są testy manualne na docelowych OS oraz procedury rotacji co 90 dni z przypomnieniami alertowymi. |
+| Runtime | `bot_core/runtime/*` | `bootstrap_environment` i `TradingSession` spinają strategię, ryzyko, egzekucję i alerty. Konieczne jest dodanie integracji z raportami oraz scheduler do codziennego uruchamiania strategii D1. |
+| Observability | `bot_core/observability/*` | Prometheus-kompatybilne metryki dostępne, ale trzeba zbudować eksportera/endpoint oraz dashboard (docelowo w desktop UI). |
+
+### 1.2. Historyczny monolit `KryptoLowca`
+
+| Plik | Problemy | Zalecenia |
+| --- | --- | --- |
+| `trading_gui.py` | Silne sprzężenie GUI z logiką, brak IPC. | Pozostawić jako referencję, dalszy rozwój przenieść do nowej architektury. |
+| `exchange_manager.py`, `core/trading_engine.py` | Monolityczne klasy, brak separacji środowisk, zależność od CCXT. | Migracja do `bot_core`, stopniowa deprecjacja modułów. |
+| `risk_management.py` | Heurystyki różnią się od nowych profili i limitów. | Zachować do analizy, ale wdrożyć nowy silnik ryzyka w produkcyjnym kodzie. |
+| `managers/security_manager.py` | Brak integracji z natywnymi keychainami. | Zastąpić implementacją `bot_core/security`. |
+| `data_preprocessor.py` | Przetwarza dane in-memory, brak cache/backfill. | Utrzymywać jedynie do kompatybilności; nowe procesy w `bot_core/data`. |
+
+## 2. Luki względem wymagań biznesowych
+
+1. **Scheduler i orkiestracja** – brak automatycznego harmonogramu uruchamiania strategii D1, raportów dziennych/tygodniowych i rotacji kluczy.
+2. **Raportowanie i compliance** – konieczne generowanie CSV/PDF oraz archiwów JSON/Parquet z logami decyzji i audytem (retencja 24 miesiące).
+3. **Observability produkcyjne** – trzeba dostarczyć endpoint metryk, agregację logów i definicję SLO (latencja zleceń, fill rate, error rate).
+4. **Paper trading poza Binance** – brak symulatorów nakładanych na real-time feed Kraken/Zonda (na wypadek braku pełnego sandboxa).
+5. **Testy integracyjne** – potrzebne scenariusze end-to-end (backfill → strategia → risk → paper execution) oraz testy regresyjne przy rotacji konfiguracji.
+
+## 3. Etapowy plan rozwoju
+
+### Etap 0 – Stabilizacja i dokumentacja (1 tydzień)
+- Zatwierdzenie architektury (`ADR-001`), uporządkowanie konfiguracji i checklist bezpieczeństwa.
+- Przygotowanie skryptów bootstrap/test (`scripts/run_paper_session.py`).
+- Testy: `python -m compileall bot_core`, `pytest tests/test_config_loader.py`, manualna weryfikacja keyringów.
+
+### Etap 1 – Integracja Binance (4–5 tygodni)
+1. **Adaptery**: finalizacja obsługi błędów sieciowych, rate limitów i retry (spot + futures, testnet/live).
+2. **Dane**: rozszerzenie backfillu o eksport Parquet, walidację integralności i harmonogram aktualizacji.
+3. **Strategie**: wdrożenie walk-forward + parametryzacja per instrument w YAML.
+4. **Ryzyko**: raporty naruszeń, reset dziennych limitów, integracja z alertami.
+5. **Egzekucja**: `LiveExecutionService` z politykami retry/backoff oraz monitorowaniem SLO.
+6. **Alerty**: połączenie z realnymi API (Telegram webhook, SMTP, SMS provider) i rejestr audytowy.
+7. **Paper trading**: smoke test na Binance Testnet + dzienny raport P&L.
+
+### Etap 2 – Kraken (3 tygodnie)
+- Adaptery spot/futures z obsługą specyficznych podpisów, mapowania par i IP allowlist.
+- Symulator paper tradingu na feedzie REST/websocket, odwzorowanie prowizji i limitów.
+- Rozszerzenie konfiguracji o status KYC/AML kont i przypomnienia rotacji kluczy.
+
+### Etap 3 – Zonda (3 tygodnie)
+- Adapter spot z podpisem HMAC-SHA512, wsparcie par PLN/EUR oraz mapowania symboli.
+- Paper trading na real-time danych, raport porównujący z Binance/Kraken.
+- Integracja alertów i risk engine ze specyficznymi limitami fiat.
+
+### Etap 4 – Rozszerzenia strategiczne i raportowanie (6+ tygodni)
+- Biblioteka strategii (mean reversion, volatility breakout na 1h/15m), marketplace presetów.
+- Moduł raportowania (CSV + PDF + archiwa JSON/Parquet) z retencją 24–60 miesięcy.
+- Dashboard w przyszłym desktop UI (metryki, alerty, dzienniki decyzji).
+
+## 4. Pierwszy krok rozwoju (do wykonania po zatwierdzeniu)
+1. Utworzyć skrypt `scripts/run_paper_session.py`, który:
+   - ładuje `config/core.yaml`,
+   - inicjalizuje `bootstrap_environment` dla środowiska paper Binance,
+   - uruchamia jedną iterację strategii `DailyTrendMomentumStrategy` na danych z cache,
+   - loguje wynik do audytu i konsoli.
+2. Przygotować zestaw testów jednostkowych dla nowego skryptu (mock adaptera + risk engine).
+3. Uruchomić dry-run na Binance Testnet (papierowy) przed wprowadzeniem jakichkolwiek kont live.
+
+## 5. Rekomendacje bezpieczeństwa i compliance
+- Rotacja kluczy API co 90 dni, osobne klucze `read-only` i `trading`, brak uprawnień do wypłat.
+- IP allowlist na dwa–trzy adresy (stacja robocza, VPN, host CI) – oddzielnie dla live i paper.
+- Maskowanie sekretów w logach, audyt append-only z timestampami UTC, podpisy archiwów.
+- Backup konfiguracji i cache na zaszyfrowanych nośnikach, testy odtwarzania środowiska.
+- Zgodność z RODO: minimalizacja danych, możliwość usunięcia wpisów dotyczących operatora.
+
+## 6. Wskazówki testowe po każdej iteracji
+- ✅ `python -m compileall bot_core`
+- ✅ `pytest tests/<zależne moduły>`
+- ⚠️ Manualny backtest/paper trading (wyłącznie środowiska demo/testnet)
+- ⚠️ Dry-run alertów (mock webhooków/API)
+
+> Uwaga: aż do uzyskania spójności P&L pomiędzy backtestem a paper tradingiem **wszystkie testy
+> wykonujemy na środowiskach demo/testnet**. Dopiero po pozytywnym raporcie z etapu 1 rozważamy
+> ograniczone wdrożenie live na niewielkiej alokacji kapitału.

--- a/docs/audit/initial_review.md
+++ b/docs/audit/initial_review.md
@@ -1,0 +1,84 @@
+# Wstępna ocena kodu (wrzesień 2025)
+
+Ten dokument podsumowuje stan obecnego repozytorium bota handlowego w momencie rozpoczęcia
+prac modernizacyjnych. Analiza obejmuje strukturę kodu, jakość implementacji, luki
+funkcjonalne oraz ryzyka operacyjne. Wnioski służą jako punkt odniesienia przy migracji do
+nowej architektury `bot_core` oraz przy planowaniu kolejnych iteracji rozwoju.
+
+## 1. Struktura i modularność
+
+- **Pakiet `KryptoLowca`** pozostaje monolityczny: klasy GUI (`trading_gui.py`), logika
+  strategii (`trading_strategies/engine.py`), zarządzanie giełdą (`exchange_manager.py`) i
+  polityka ryzyka (`risk_management.py`) są ze sobą silnie sprzężone.
+- **Aliasowe moduły w katalogu głównym** (`auto_trader.py`, `trading_gui.py`,
+  `trading_strategies.py`) duplikują importy i utrudniają zrozumienie punktu wejścia.
+- Brak formalnych interfejsów dla adapterów giełdowych, strategii i warstwy egzekucji,
+  co blokuje rozszerzanie systemu o nowe rynki lub algorytmy bez zmian w kodzie głównym.
+
+## 2. Funkcjonalność względem wymagań produktowych
+
+- **Warstwa giełdowa** opiera się na pojedynczej konfiguracji CCXT bez separacji środowisk
+  (testnet/paper/live) oraz bez rozdziału kluczy read-only/trade.
+- **Dane rynkowe**: brak procesu „backfill + cache” opartego na publicznych API i lokalnym
+  magazynie Parquet/SQLite; `data_preprocessor.py` zakłada gotowe dane w pamięci.
+- **Strategie**: istnieją pojedyncze implementacje, ale brak systemu walk-forward i
+  parametryzacji przez pliki konfiguracyjne.
+- **Zarządzanie ryzykiem** nie obejmuje wymaganych profili (konserwatywny, zbalansowany,
+  agresywny, ręczny) ani egzekucji limitów dziennych, ATR i hard-stop drawdown.
+- **Powiadomienia** ograniczają się do logów – brak kanałów Telegram, e-mail, SMS czy
+  komunikatorów, a także audytu i health-checków.
+- **Bezpieczeństwo sekretów** bazuje na lokalnym szyfrowaniu; nie ma integracji z natywnymi
+  keychainami (Windows Credential Manager, macOS Keychain, GNOME Keyring/age) ani polityki
+  rotacji i allowlist IP.
+
+## 3. Jakość kodu i testy
+
+- Testy jednostkowe pokrywają wybrane moduły, ale są ściśle powiązane z monolitem –
+  ich utrzymanie przy migracji będzie trudne.
+- Wiele metod ma szeroki zakres odpowiedzialności (np. `TradingEngine.execute()`), co
+  utrudnia dodawanie logiki compliance lub rozbudowanej telemetrii.
+- Brak spójnego logowania strukturalnego oraz standardu obsługi wyjątków; krytyczne błędy
+  mogą pozostać niezauważone podczas handlu live.
+
+## 4. Ryzyka operacyjne i compliance
+
+- **Brak audytu** działań (append-only) z retencją 24–60 miesięcy i podpisem kryptograficznym.
+- **Polityka KYC/AML** nie jest odnotowywana w logach ani konfiguracji środowisk.
+- **Brak obserwowalności**: brak metryk latencji zleceń, fill rate, error rate i brak SLO.
+- **Paper trading** dzieli stan z kontem produkcyjnym; nie ma izolacji pozwalającej na
+  realistyczne testy bez ryzyka dla kapitału.
+
+## 5. Rekomendowane kierunki działania
+
+1. **Migracja do modułowej architektury `bot_core`** – oddzielenie adapterów giełdowych,
+   warstwy danych, strategii, ryzyka, egzekucji, alertów i bezpieczeństwa.
+2. **Nowy system konfiguracji** (`config/core.yaml`) z definicją środowisk, profili ryzyka,
+   koszyków instrumentów oraz kanałów alertów.
+3. **Proces „backfill + cache”** korzystający z publicznych endpointów REST (Binance, Kraken,
+   Zonda) z zapisem do SQLite/Parquet i inkrementalnymi aktualizacjami.
+4. **Silnik strategii D1** (trend-following + momentum breakout) z parametryzacją,
+   walk-forward i spójnym modelem kosztów/poślizgu.
+5. **Risk engine** egzekwujący profile konserwatywny/zbalansowany/agresywny/ręczny z twardymi
+   limitami oraz natychmiastowym zamykaniem pozycji po przekroczeniu dziennej straty.
+6. **Alerty wielokanałowe** (Telegram, e-mail, SMS, komunikatory) z audytem i health-checkami.
+7. **Secret manager** oparty o natywne keychainy i rotację kluczy co 90 dni, z wymuszaniem
+   modelu najmniejszych uprawnień i allowlist IP.
+8. **Observability**: metryki, logi strukturalne, eksport raportów CSV/PDF, retention 24 mies.
+
+## 6. Pierwsze kroki wdrożeniowe
+
+- Utrzymać monolit w stanie „frozen” – bez dalszych modyfikacji poza poprawkami krytycznych błędów.
+- Rozpocząć prace w pakiecie `bot_core`, począwszy od interfejsów i konfiguracji (już obecne w repo),
+  a następnie iteracyjnie przenosić funkcjonalność z monolitu.
+- Wprowadzić standard dokumentowania decyzji architektonicznych (ADRs) oraz checklistę testów dla
+  każdego PR (backtest → paper → live, logi audytu, alerty).
+
+## 7. Testy zalecane po modernizacji
+
+- **Backtesty** na danych D1 i 1h (BTC/USDT, ETH/USDT, SOL/USDT) z podziałem in/out-of-sample.
+- **Paper trading** na Binance Testnet oraz symulatorze dla giełd bez sandboxa.
+- **Testy integracyjne alertów** z kanałami Telegram/E-mail/SMS (mock API + sandbox).
+- **Testy bezpieczeństwa**: rotacja kluczy, odtwarzanie środowiska z backupu, walidacja allowlist IP.
+
+> **Bezpieczeństwo**: wszystkie nowe moduły należy testować w środowisku demo/testnet, zanim
+> cokolwiek trafi na konto live. Każde odstępstwo musi być zatwierdzone i odnotowane w audycie.

--- a/docs/roadmap/phase1_plan.md
+++ b/docs/roadmap/phase1_plan.md
@@ -1,0 +1,67 @@
+# Roadmapa etapu 1 – Integracja Binance i fundamenty core
+
+Dokument opisuje harmonogram i zakres zadań, które doprowadzą bota do stabilnego trybu paper
+trading zintegrowanego z Binance (spot + futures). Plan bazuje na wymaganiach biznesowych,
+bezpieczeństwa i compliance przedstawionych w specyfikacji. Każdy etap kończy się zestawem
+konkretnych testów (backtest → paper), zanim przejdziemy do kolejnych prac.
+
+## Założenia główne
+
+- Architektura modułowa w pakiecie `bot_core` – interfejsy adapterów, warstwa danych,
+  strategie, risk engine, execution i alerty.
+- Brak zmian w monolicie `KryptoLowca` poza krytycznymi poprawkami; nowy rozwój to `bot_core`.
+- Sekrety przechowywane w natywnych keychainach (Windows Credential Manager, macOS Keychain,
+  GNOME Keyring/age dla środowisk headless).
+- Testy przeprowadzamy w kolejności: **backtest** → **paper trading** na Binance Testnet →
+  **ograniczony live** (po zakończeniu etapu 1).
+
+## Harmonogram sześciotygodniowy
+
+| Tydzień | Zakres | Artefakty | Testy końcowe |
+| --- | --- | --- | --- |
+| 1 | Finalizacja interfejsów (`exchanges`, `data`, `risk`, `execution`, `alerts`), struktura `config/core.yaml`, rejestry instrumentów i profili. | ADR #001 (architektura modułowa), zaktualizowany `config/core.yaml`. | ✅ `python -m compileall bot_core`<br>✅ `pytest tests/test_config_loader.py` |
+| 2 | Implementacja `BinanceSpotAdapter` i `BinanceFuturesAdapter` (public + signed REST, testnet/live, rozdział uprawnień). | Adaptery + testy podpisów (`tests/test_binance_spot_adapter.py`, `tests/test_binance_futures_adapter.py`). | ✅ `pytest tests/test_binance_spot_adapter.py tests/test_binance_futures_adapter.py` |
+| 3 | Warstwa danych: `OHLCVBackfillService`, `CachedOHLCVSource`, magazyn SQLite/Parquet, konfiguracja uniwersów instrumentów. | Skrypt `scripts/backfill_ohlcv.py`, aktualizacja dokumentacji danych. | ✅ `pytest tests/test_ohlcv_backfill.py`<br>✅ manualny backfill BTC/USDT D1 (dry-run) |
+| 4 | Risk engine (`ThresholdRiskEngine`) z profilami konserwatywny/zbalansowany/agresywny/ręczny, integracja z konfiguracją. | Testy `tests/test_risk_engine.py`, raport mapowania limitów. | ✅ `pytest tests/test_risk_engine.py` |
+| 5 | `PaperTradingExecutionService`, router alertów z kanałami Telegram/E-mail/SMS, audyt alertów i health-check. | Testy `tests/test_paper_execution.py`, `tests/test_alerts.py`, dokument procedury alertów. | ✅ `pytest tests/test_paper_execution.py tests/test_alerts.py`<br>⚠️ Manualny dry-run alertów (mock API) |
+| 6 | Integracja: `bootstrap_environment`, scenariusz end-to-end (backtest → paper), dokumentacja użytkownika i checklisty bezpieczeństwa. | `docs/runbooks/paper_trading.md`, log audytu papierowego dnia. | ✅ `pytest tests/test_runtime_bootstrap.py`<br>✅ symulacja paper tradingu BTC/USDT (24h na testnecie) |
+
+> ⚠️ Wszystkie testy manualne (backfill, alerty, paper trading) wykonujemy wyłącznie na kontach
+demo/testnet i z kluczami bez uprawnień do wypłat. W logach nie zapisujemy pełnych sekretów –
+maskujemy klucze i stosujemy audyt append-only.
+
+## Kryteria „Definition of Done” etapu 1
+
+1. **Strategia D1** (trend-following + momentum breakout) działa w trybie paper trading,
+   korzystając z danych backfillowanych lokalnie i profilu ryzyka zbalansowanego.
+2. **Risk engine** egzekwuje dzienne limity strat, ekspozycję na instrument, ATR stop oraz
+   hard-stop drawdown dla wszystkich profili.
+3. **Alerty**: sygnały wejścia/wyjścia, przekroczenia progów ryzyka, błędy adapterów/API i
+   health-check są wysyłane kanałami Telegram/E-mail/SMS z wpisem w audycie.
+4. **Observability**: metryki podstawowe (latencja zleceń, fill rate, error rate) dostępne w
+   warstwie telemetrycznej (np. Prometheus endpoint / plik JSON).
+5. **Bezpieczeństwo**: klucze API zapisane w keychainie, rotacja i allowlist IP udokumentowane,
+   a wszystkie środowiska korzystają z modelu najmniejszych uprawnień.
+
+## Następne etapy (wysoki poziom)
+
+- **Etap 2 – Kraken**: adaptery spot/futures, specyficzne opłaty i wymogi regulacyjne,
+  symulator paper trading przy braku pełnego sandboxa.
+- **Etap 3 – Zonda**: adapter spot, mapowanie fiatów (PLN/EUR), integracja z risk engine i
+  raportowaniem.
+- **Etap 4 – Rozszerzenia strategii**: biblioteka strategii (mean reversion, volatility targeting,
+  arbitraż), scheduler, marketplace presetów.
+- **Etap 5 – Observability i compliance+**: pełne raporty PDF/CSV, podpisane archiwa, monitoring SLO,
+  moduł rotacji kluczy z przypomnieniami.
+
+## Checklisty testowe dla kolejnych PR-ów
+
+Każda iteracja powinna zawierać w opisie PR sekcję testów z następującego szablonu:
+
+- ✅ `python -m compileall bot_core`
+- ✅/⚠️ `pytest <wybrane moduły>`
+- ⚠️ Manualny backtest/paper trading (opis zakresu, środowisko demo/testnet)
+- ⚠️ Dry-run alertów (jeśli zmiany dotyczą powiadomień)
+
+Utrzymanie tej checklisty zapewni spójność jakościową i ułatwi przejście do audytowalnego
+procesu CI/CD w późniejszym czasie.

--- a/scripts/backfill_ohlcv.py
+++ b/scripts/backfill_ohlcv.py
@@ -1,0 +1,226 @@
+"""Uruchamia proces backfillu OHLCV zgodny z architekturą etapu 1."""
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Sequence
+
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import InstrumentUniverseConfig
+from bot_core.data.ohlcv import (
+    OHLCVBackfillService,
+    CachedOHLCVSource,
+    PublicAPIDataSource,
+    SQLiteCacheStorage,
+)
+from bot_core.exchanges.base import Environment, ExchangeCredentials
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _parse_timestamp(value: str) -> int:
+    """Zamienia wejście użytkownika na timestamp w milisekundach (UTC)."""
+
+    value = value.strip()
+    if value.isdigit():
+        return int(value)
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - walidacja wejścia
+        raise argparse.ArgumentTypeError(
+            "Użyj formatu ISO (YYYY-MM-DD) lub liczby milisekund od epochy."
+        ) from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _build_adapter(exchange: str, environment: Environment) -> PublicAPIDataSource:
+    """Zwraca adapter publicznego API dla wskazanej giełdy."""
+
+    builders: dict[str, Callable[[Environment], PublicAPIDataSource]] = {
+        "binance_spot": lambda env: PublicAPIDataSource(
+            exchange_adapter=BinanceSpotAdapter(
+                ExchangeCredentials(key_id="public", environment=env)
+            )
+        ),
+        "zonda_spot": lambda env: PublicAPIDataSource(
+            exchange_adapter=ZondaSpotAdapter(
+                ExchangeCredentials(key_id="public", environment=env)
+            )
+        ),
+    }
+
+    try:
+        builder = builders[exchange]
+    except KeyError as exc:  # pragma: no cover - zabezpieczenie przyszłych rozszerzeń
+        raise ValueError(f"Brak obsługi exchange={exchange} w procesie backfillu") from exc
+
+    return builder(environment)
+
+
+def _resolve_symbols(
+    universe: InstrumentUniverseConfig | None,
+    exchange_name: str,
+    explicit_symbols: Sequence[str] | None,
+) -> tuple[str, ...]:
+    if explicit_symbols:
+        return tuple(explicit_symbols)
+
+    if universe is None:
+        raise SystemExit(
+            "Środowisko nie posiada przypisanego uniwersum instrumentów – podaj symbole ręcznie."
+        )
+
+    resolved: list[str] = []
+    for instrument in universe.instruments:
+        symbol = instrument.exchange_symbols.get(exchange_name)
+        if symbol:
+            resolved.append(symbol)
+
+    if not resolved:
+        raise SystemExit(
+            "Żaden instrument z uniwersum nie jest dostępny dla wskazanej giełdy. Zdefiniuj aliasy lub"
+            " przekaż symbole przez --symbols."
+        )
+    return tuple(resolved)
+
+
+def _determine_start_timestamp(
+    interval: str,
+    requested_start: int | None,
+    universe: InstrumentUniverseConfig | None,
+) -> int:
+    if requested_start is not None:
+        return requested_start
+
+    if universe is None:
+        raise SystemExit(
+            "Nie określono daty początkowej (--start), a środowisko nie wskazuje uniwersum z parametrami"
+            " backfillu."
+        )
+
+    max_lookback_days = 0
+    for instrument in universe.instruments:
+        for window in instrument.backfill_windows:
+            if window.interval == interval:
+                if window.lookback_days > max_lookback_days:
+                    max_lookback_days = window.lookback_days
+
+    if max_lookback_days == 0:
+        raise SystemExit(
+            "Uniwersum nie zawiera zakresu backfill dla wskazanego interwału – podaj --start ręcznie."
+        )
+
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(days=max_lookback_days)
+    return int(cutoff.timestamp() * 1000)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Backfill danych OHLCV z publicznych API")
+    parser.add_argument(
+        "--config",
+        default="config/core.yaml",
+        help="Ścieżka do pliku konfiguracji",
+    )
+    parser.add_argument(
+        "--environment",
+        default="binance_paper",
+        help="Nazwa środowiska z konfiguracji",
+    )
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        help="Lista symboli do backfillu (domyślnie pobierane z uniwersum środowiska)",
+    )
+    parser.add_argument("--interval", default="1d", help="Interwał (np. 1d, 1h)")
+    parser.add_argument(
+        "--start",
+        type=_parse_timestamp,
+        help="Początek zakresu w ms od epochy lub dacie ISO (domyślnie wg uniwersum)",
+    )
+    parser.add_argument(
+        "--end",
+        type=_parse_timestamp,
+        help="Koniec zakresu (domyślnie teraz)",
+    )
+    parser.add_argument(
+        "--chunk-limit",
+        type=int,
+        default=1000,
+        help="Liczba świec pobieranych jednorazowo (maks. limit API)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Poziom logowania",
+    )
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+
+    config = load_core_config(args.config)
+    try:
+        env_cfg = config.environments[args.environment]
+    except KeyError as exc:
+        raise SystemExit(f"Nie znaleziono środowiska {args.environment} w konfiguracji") from exc
+
+    universe: InstrumentUniverseConfig | None = None
+    if env_cfg.instrument_universe:
+        universe = config.instrument_universes.get(env_cfg.instrument_universe)
+        if universe is None:
+            raise SystemExit(
+                f"Środowisko {args.environment} wskazuje nieistniejące uniwersum "
+                f"{env_cfg.instrument_universe}."
+            )
+
+    symbols = _resolve_symbols(universe, env_cfg.exchange, args.symbols)
+
+    storage_path = Path(env_cfg.data_cache_path) / "ohlcv.sqlite"
+    storage = SQLiteCacheStorage(storage_path)
+
+    upstream_source = _build_adapter(env_cfg.exchange, env_cfg.environment)
+    upstream_source.exchange_adapter.configure_network(ip_allowlist=env_cfg.ip_allowlist)
+
+    cached_source = CachedOHLCVSource(storage=storage, upstream=upstream_source)
+    backfill_service = OHLCVBackfillService(cached_source, chunk_limit=args.chunk_limit)
+
+    start_ts = _determine_start_timestamp(args.interval, args.start, universe)
+    end_ts = args.end or int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+    _LOGGER.info(
+        "Rozpoczynam backfill: env=%s, interval=%s, start=%s, end=%s, symbole=%s",
+        args.environment,
+        args.interval,
+        start_ts,
+        end_ts,
+        ",".join(symbols),
+    )
+
+    summaries = backfill_service.synchronize(
+        symbols=symbols,
+        interval=args.interval,
+        start=start_ts,
+        end=end_ts,
+    )
+
+    for summary in summaries:
+        _LOGGER.info(
+            "Symbol %s (%s): pobrano %s nowych świec (pominięto %s).",
+            summary.symbol,
+            summary.interval,
+            summary.fetched_candles,
+            summary.skipped_candles,
+        )
+
+    _LOGGER.info("Backfill zakończony – łączna liczba symboli: %s", len(summaries))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - punkt wejścia CLI
+    raise SystemExit(main())

--- a/scripts/manage_secrets.py
+++ b/scripts/manage_secrets.py
@@ -1,0 +1,299 @@
+"""Narzędzie CLI do zarządzania sekretami w natywnych keychainach."""
+from __future__ import annotations
+
+import argparse
+import getpass
+import logging
+from pathlib import Path
+from typing import Sequence
+
+from bot_core.exchanges.base import Environment, ExchangeCredentials
+from bot_core.security import SecretManager, SecretStorageError, create_default_secret_storage
+
+_LOGGER = logging.getLogger("scripts.manage_secrets")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Zarządza kluczami API i innymi sekretami w magazynie systemowym.",
+    )
+    parser.add_argument(
+        "--namespace",
+        default="dudzian.trading",
+        help="Prefiks identyfikatorów w magazynie sekretów (domyślnie: dudzian.trading)",
+    )
+    parser.add_argument(
+        "--headless-passphrase",
+        help="Hasło do magazynu plikowego w trybie Linux headless",
+    )
+    parser.add_argument(
+        "--headless-secret-path",
+        help="Ścieżka do zaszyfrowanego magazynu w trybie headless",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Poziom logowania komunikatów narzędzia",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    store_exchange = subparsers.add_parser(
+        "store-exchange",
+        help="Zapisuje poświadczenia giełdy w magazynie sekretów",
+    )
+    _add_common_exchange_arguments(store_exchange)
+    store_exchange.add_argument(
+        "--secret",
+        help="Sekret API (jeśli pominięty, narzędzie poprosi o bezpieczne wprowadzenie)",
+    )
+    store_exchange.add_argument(
+        "--passphrase",
+        help="Opcjonalne hasło/phrase wymagane przez niektóre giełdy (np. Coinbase, Kraken)",
+    )
+    store_exchange.add_argument(
+        "--permission",
+        action="append",
+        default=[],
+        help="Lista uprawnień (można podać wiele razy, np. --permission read --permission trade)",
+    )
+
+    show_exchange = subparsers.add_parser(
+        "show-exchange",
+        help="Wyświetla parametry zapisanych poświadczeń (bez pełnego sekretu)",
+    )
+    _add_common_exchange_arguments(show_exchange, include_key_id=False)
+    show_exchange.add_argument(
+        "--mask-length",
+        type=int,
+        default=4,
+        help="Liczba widocznych znaków sekretu po zamaskowaniu (domyślnie: 4)",
+    )
+
+    delete_exchange = subparsers.add_parser(
+        "delete-exchange",
+        help="Usuwa zapisane poświadczenia giełdy",
+    )
+    _add_common_exchange_arguments(delete_exchange, include_key_id=False)
+
+    store_secret = subparsers.add_parser(
+        "store-secret",
+        help="Zapisuje dowolny sekret tekstowy (np. token bota Telegram)",
+    )
+    _add_common_secret_arguments(store_secret)
+    store_secret.add_argument(
+        "--value",
+        help="Wartość sekretu (jeśli pominięta, zostanie poproszony bezpieczny input)",
+    )
+
+    show_secret = subparsers.add_parser(
+        "show-secret",
+        help="Wyświetla informacje o sekrecie (domyślnie bez ujawniania pełnej wartości)",
+    )
+    _add_common_secret_arguments(show_secret)
+    show_secret.add_argument(
+        "--reveal",
+        action="store_true",
+        help="Wymusza wypisanie pełnej wartości sekretu (ostrożnie!)",
+    )
+    show_secret.add_argument(
+        "--mask-length",
+        type=int,
+        default=3,
+        help="Liczba widocznych znaków maskowanej wartości (domyślnie: 3)",
+    )
+
+    delete_secret = subparsers.add_parser(
+        "delete-secret",
+        help="Usuwa sekret zapisany w magazynie",
+    )
+    _add_common_secret_arguments(delete_secret)
+
+    return parser
+
+
+def _add_common_exchange_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    include_key_id: bool = True,
+) -> None:
+    parser.add_argument("--key", required=True, help="Nazwa klucza w magazynie (np. binance_paper)")
+    if include_key_id:
+        parser.add_argument("--key-id", required=True, help="Identyfikator API key (publiczny klucz)")
+    parser.add_argument(
+        "--environment",
+        default=Environment.LIVE.value,
+        choices=[env.value for env in Environment],
+        help="Środowisko poświadczeń (live/paper/testnet)",
+    )
+    parser.add_argument(
+        "--purpose",
+        default="trading",
+        help="Cel sekretu (np. trading, data, readonly)",
+    )
+
+
+def _add_common_secret_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--key",
+        required=True,
+        help="Identyfikator sekretu (np. telegram_bot, email_smtp)",
+    )
+    parser.add_argument(
+        "--purpose",
+        default="generic",
+        help="Cel przechowywania (np. alerts, reporting)",
+    )
+
+
+def _prompt_secret(prompt: str) -> str:
+    value = getpass.getpass(prompt)
+    if not value:
+        raise ValueError("Podana wartość nie może być pusta.")
+    return value
+
+
+def _mask_value(value: str | None, *, visible: int) -> str:
+    if not value:
+        return "(brak)"
+    if visible <= 0:
+        return "*" * min(len(value), 8)
+    if len(value) <= visible:
+        return value[0] + "*" * (len(value) - 1)
+    prefix = value[:visible]
+    suffix = value[-1]
+    hidden_length = max(len(value) - visible - 1, 0)
+    masked_middle = "*" * max(hidden_length, 3)
+    return f"{prefix}{masked_middle}{suffix}"
+
+
+def _store_exchange_credentials(manager: SecretManager, args: argparse.Namespace) -> None:
+    secret = args.secret
+    if secret is None:
+        secret = _prompt_secret("Wprowadź sekret API: ")
+    passphrase = args.passphrase or None
+    permissions: Sequence[str] = tuple(args.permission) if args.permission else ()
+    credentials = ExchangeCredentials(
+        key_id=args.key_id,
+        secret=secret or None,
+        passphrase=passphrase,
+        environment=Environment(args.environment),
+        permissions=permissions,
+    )
+    manager.store_exchange_credentials(args.key, credentials, purpose=args.purpose)
+    _LOGGER.info(
+        "Zapisano poświadczenia '%s' (środowisko: %s, cel: %s, uprawnienia: %s)",
+        args.key,
+        args.environment,
+        args.purpose,
+        permissions or "(brak)",
+    )
+
+
+def _show_exchange_credentials(manager: SecretManager, args: argparse.Namespace) -> None:
+    credentials = manager.load_exchange_credentials(
+        args.key,
+        expected_environment=Environment(args.environment),
+        purpose=args.purpose,
+    )
+    masked_secret = _mask_value(credentials.secret, visible=args.mask_length)
+    masked_passphrase = _mask_value(credentials.passphrase, visible=min(args.mask_length, 2))
+    permissions = ", ".join(credentials.permissions) if credentials.permissions else "(brak)"
+    print("--- Poświadczenia giełdowe ---")
+    print(f"Klucz magazynu: {args.key}")
+    print(f"Środowisko: {credentials.environment.value}")
+    print(f"Cel: {args.purpose}")
+    print(f"ID API: {credentials.key_id}")
+    print(f"Sekret: {masked_secret}")
+    print(f"Passphrase: {masked_passphrase}")
+    print(f"Uprawnienia: {permissions}")
+
+
+def _delete_exchange_credentials(manager: SecretManager, args: argparse.Namespace) -> None:
+    manager.delete_exchange_credentials(args.key, purpose=args.purpose)
+    _LOGGER.info(
+        "Usunięto poświadczenia '%s' (cel: %s)",
+        args.key,
+        args.purpose,
+    )
+
+
+def _store_generic_secret(manager: SecretManager, args: argparse.Namespace) -> None:
+    value = args.value
+    if value is None:
+        value = _prompt_secret("Wprowadź wartość sekretu: ")
+    manager.store_secret_value(args.key, value, purpose=args.purpose)
+    _LOGGER.info("Zapisano sekret '%s' (cel: %s)", args.key, args.purpose)
+
+
+def _show_generic_secret(manager: SecretManager, args: argparse.Namespace) -> None:
+    value = manager.load_secret_value(args.key, purpose=args.purpose)
+    if args.reveal:
+        print("--- Sekret ---")
+        print(f"Klucz: {args.key}")
+        print(f"Cel: {args.purpose}")
+        print(f"Wartość: {value}")
+    else:
+        masked = _mask_value(value, visible=args.mask_length)
+        print("--- Sekret ---")
+        print(f"Klucz: {args.key}")
+        print(f"Cel: {args.purpose}")
+        print(f"Długość: {len(value)} znaków")
+        print(f"Podgląd: {masked}")
+        print("Użyj --reveal, aby wyświetlić pełną wartość (tylko w zaufanym środowisku).")
+
+
+def _delete_generic_secret(manager: SecretManager, args: argparse.Namespace) -> None:
+    manager.delete_secret_value(args.key, purpose=args.purpose)
+    _LOGGER.info("Usunięto sekret '%s' (cel: %s)", args.key, args.purpose)
+
+
+def _create_manager(args: argparse.Namespace) -> SecretManager:
+    storage = create_default_secret_storage(
+        namespace=args.namespace,
+        headless_passphrase=args.headless_passphrase,
+        headless_path=Path(args.headless_secret_path) if args.headless_secret_path else None,
+    )
+    return SecretManager(storage, namespace=args.namespace)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level))
+
+    try:
+        manager = _create_manager(args)
+    except SecretStorageError as exc:
+        _LOGGER.error("Nie udało się zainicjalizować magazynu sekretów: %s", exc)
+        return 1
+
+    try:
+        if args.command == "store-exchange":
+            _store_exchange_credentials(manager, args)
+        elif args.command == "show-exchange":
+            _show_exchange_credentials(manager, args)
+        elif args.command == "delete-exchange":
+            _delete_exchange_credentials(manager, args)
+        elif args.command == "store-secret":
+            _store_generic_secret(manager, args)
+        elif args.command == "show-secret":
+            _show_generic_secret(manager, args)
+        elif args.command == "delete-secret":
+            _delete_generic_secret(manager, args)
+        else:  # pragma: no cover - zabezpieczenie przed nowymi komendami
+            parser.error(f"Nieobsługiwane polecenie: {args.command}")
+            return 2
+    except SecretStorageError as exc:
+        _LOGGER.error("Operacja na magazynie nie powiodła się: %s", exc)
+        return 1
+    except ValueError as exc:
+        _LOGGER.error("Nieprawidłowe dane wejściowe: %s", exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/run_paper_session.py
+++ b/scripts/run_paper_session.py
@@ -1,0 +1,410 @@
+"""Uruchamia pojedynczą iterację sesji paper trading na podstawie konfiguracji."""
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+from bot_core.config.models import (
+    CoreConfig,
+    DailyTrendMomentumStrategyConfig,
+    InstrumentUniverseConfig,
+    RiskProfileConfig,
+)
+from bot_core.data.base import OHLCVRequest, OHLCVResponse
+from bot_core.data.ohlcv import CachedOHLCVSource, PublicAPIDataSource, SQLiteCacheStorage
+from bot_core.execution.paper import MarketMetadata, PaperTradingExecutionService
+from bot_core.exchanges.base import AccountSnapshot, ExchangeAdapter, ExchangeCredentials
+from bot_core.risk.profiles.manual import ManualProfile
+from bot_core.runtime.bootstrap import bootstrap_environment
+from bot_core.runtime.session import InstrumentConfig, TradingSession
+from bot_core.security import SecretManager, SecretStorageError, create_default_secret_storage
+from bot_core.strategies.base import MarketSnapshot
+from bot_core.strategies.daily_trend import DailyTrendMomentumSettings, DailyTrendMomentumStrategy
+
+_LOGGER = logging.getLogger("scripts.run_paper_session")
+
+
+class _PaperAccountAdapter(ExchangeAdapter):
+    """Udostępnia wirtualny rachunek paper trading dla modułu runtime."""
+
+    def __init__(
+        self,
+        credentials: ExchangeCredentials,
+        execution: PaperTradingExecutionService,
+        *,
+        default_quote_asset: str,
+    ) -> None:
+        super().__init__(credentials)
+        self._execution = execution
+        self._default_quote = default_quote_asset
+
+    def configure_network(self, *, ip_allowlist: Sequence[str] | None = None) -> None:  # noqa: D401, ARG002
+        """Adapter paper trading nie wymaga dodatkowej konfiguracji sieciowej."""
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        balances = self._execution.balances()
+        total_equity = sum(balances.values())
+        available_margin = balances.get(self._default_quote, total_equity)
+        return AccountSnapshot(
+            balances=balances,
+            total_equity=total_equity,
+            available_margin=available_margin,
+            maintenance_margin=0.0,
+        )
+
+    def fetch_symbols(self) -> Iterable[str]:  # pragma: no cover - nieużywane w tym skrypcie
+        return ()
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: int | None = None,
+        end: int | None = None,
+        limit: int | None = None,
+    ) -> Sequence[Sequence[float]]:  # pragma: no cover - ochrona przed przypadkowym użyciem
+        raise NotImplementedError("Adapter paper trading nie obsługuje pobierania danych OHLCV.")
+
+    def place_order(self, request: "OrderRequest") -> "OrderResult":  # pragma: no cover - bezpieczeństwo
+        raise RuntimeError(
+            "Zlecenia należy kierować przez PaperTradingExecutionService – adapter nie wykonuje tradingu."
+        )
+
+    def cancel_order(self, order_id: str, *, symbol: str | None = None) -> None:  # pragma: no cover - bezpieczeństwo
+        raise RuntimeError("Anulacje nie są obsługiwane przez adapter paper trading.")
+
+    def stream_public_data(self, *, channels: Sequence[str]):  # pragma: no cover - bezpieczeństwo
+        raise NotImplementedError("Streaming danych nie jest wspierany w trybie paper.")
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # pragma: no cover - bezpieczeństwo
+        raise NotImplementedError("Streaming danych nie jest wspierany w trybie paper.")
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Uruchamia pojedynczą iterację paper tradingu.")
+    parser.add_argument("--config", default="config/core.yaml", help="Ścieżka do pliku konfiguracji")
+    parser.add_argument("--environment", default="binance_paper", help="Nazwa środowiska z konfiguracji")
+    parser.add_argument("--strategy", default="core_daily_trend", help="Strategia do uruchomienia")
+    parser.add_argument("--symbol", help="Symbol giełdowy – domyślnie pierwszy z uniwersum środowiska")
+    parser.add_argument("--interval", default="1d", help="Interwał OHLCV (np. 1d, 1h)")
+    parser.add_argument(
+        "--history-limit",
+        type=int,
+        help="Liczba świec do pobrania (domyślnie minimalna liczba wymagana przez strategię)",
+    )
+    parser.add_argument("--quote-balance", type=float, default=100_000.0, help="Saldo waluty kwotowanej w symulatorze")
+    parser.add_argument("--base-balance", type=float, default=0.0, help="Saldo aktywa bazowego w symulatorze")
+    parser.add_argument("--maker-fee", type=float, default=0.0004, help="Prowizja maker w symulatorze")
+    parser.add_argument("--taker-fee", type=float, default=0.0006, help="Prowizja taker w symulatorze")
+    parser.add_argument("--slippage-bps", type=float, default=5.0, help="Poślizg cenowy w punktach bazowych")
+    parser.add_argument("--min-quantity", type=float, default=0.0, help="Minimalna ilość kontraktowa")
+    parser.add_argument("--min-notional", type=float, default=0.0, help="Minimalny notional zlecenia")
+    parser.add_argument("--step-size", type=float, help="Krok ilościowy (lot size)")
+    parser.add_argument("--tick-size", type=float, help="Krok cenowy (tick size)")
+    parser.add_argument("--portfolio-id", default="paper-demo", help="Identyfikator portfela w logach")
+    parser.add_argument(
+        "--headless-passphrase",
+        help="Hasło do magazynu sekretów w trybie Linux headless (EncryptedFileSecretStorage)",
+    )
+    parser.add_argument(
+        "--headless-secret-path",
+        help="Ścieżka do zaszyfrowanego magazynu sekretów dla trybu headless",
+    )
+    parser.add_argument(
+        "--secret-namespace",
+        default="dudzian.trading",
+        help="Prefiks nazw kluczy w magazynie sekretów",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Poziom logowania",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_universe(core_config: CoreConfig, universe_key: str | None) -> InstrumentUniverseConfig | None:
+    if universe_key is None:
+        return None
+    universe = core_config.instrument_universes.get(universe_key)
+    if universe is None:
+        raise SystemExit(
+            f"Środowisko wskazuje uniwersum '{universe_key}', które nie istnieje w konfiguracji."
+        )
+    return universe
+
+
+def _select_symbol(
+    universe: InstrumentUniverseConfig | None, exchange_name: str, explicit_symbol: str | None
+) -> tuple[str, InstrumentConfig]:
+    instruments: MutableMapping[str, InstrumentConfig] = {}
+    if universe:
+        for instrument in universe.instruments:
+            symbol = instrument.exchange_symbols.get(exchange_name)
+            if not symbol:
+                continue
+            instruments[symbol] = InstrumentConfig(
+                symbol=symbol,
+                base_asset=instrument.base_asset,
+                quote_asset=instrument.quote_asset,
+                min_quantity=0.0,
+                min_notional=0.0,
+                step_size=None,
+            )
+
+    if explicit_symbol:
+        try:
+            return explicit_symbol, instruments[explicit_symbol]
+        except KeyError as exc:
+            available = ", ".join(sorted(instruments)) or "brak"
+            raise SystemExit(
+                f"Symbol '{explicit_symbol}' nie jest dostępny w uniwersum dla giełdy {exchange_name}."
+                f" Dostępne symbole: {available}."
+            ) from exc
+
+    if not instruments:
+        raise SystemExit(
+            "Środowisko nie definiuje żadnych instrumentów dla wybranej giełdy. Uzupełnij sekcję "
+            "instrument_universes lub przekaż symbol ręcznie poprzez --symbol."
+        )
+
+    selected_symbol, metadata = next(iter(instruments.items()))
+    return selected_symbol, metadata
+
+
+def _build_strategy(
+    config: DailyTrendMomentumStrategyConfig,
+) -> tuple[DailyTrendMomentumStrategy, DailyTrendMomentumSettings]:
+    settings = DailyTrendMomentumSettings(
+        fast_ma=config.fast_ma,
+        slow_ma=config.slow_ma,
+        breakout_lookback=config.breakout_lookback,
+        momentum_window=config.momentum_window,
+        atr_window=config.atr_window,
+        atr_multiplier=config.atr_multiplier,
+        min_trend_strength=config.min_trend_strength,
+        min_momentum=config.min_momentum,
+    )
+    return DailyTrendMomentumStrategy(settings), settings
+
+
+def _build_risk_profile(config: RiskProfileConfig) -> ManualProfile:
+    return ManualProfile(
+        name=config.name,
+        max_positions=config.max_open_positions,
+        max_leverage=config.max_leverage,
+        drawdown_limit=config.hard_drawdown_pct,
+        daily_loss_limit=config.max_daily_loss_pct,
+        max_position_pct=config.max_position_pct,
+        target_volatility=config.target_volatility,
+        stop_loss_atr_multiple=config.stop_loss_atr_multiple,
+    )
+
+
+def _build_data_source(
+    base_adapter: ExchangeAdapter,
+    cache_path: Path,
+) -> CachedOHLCVSource:
+    storage = SQLiteCacheStorage(cache_path / "ohlcv.sqlite")
+    upstream = PublicAPIDataSource(exchange_adapter=base_adapter)
+    return CachedOHLCVSource(storage=storage, upstream=upstream)
+
+
+def _rows_to_snapshots(symbol: str, response: OHLCVResponse) -> list[MarketSnapshot]:
+    snapshots: list[MarketSnapshot] = []
+    for row in response.rows:
+        if len(row) < 6:
+            continue
+        try:
+            timestamp = int(float(row[0]))
+            open_price = float(row[1])
+            high = float(row[2])
+            low = float(row[3])
+            close = float(row[4])
+            volume = float(row[5])
+        except (TypeError, ValueError):
+            continue
+        snapshots.append(
+            MarketSnapshot(
+                symbol=symbol,
+                timestamp=timestamp,
+                open=open_price,
+                high=high,
+                low=low,
+                close=close,
+                volume=volume,
+            )
+        )
+    return snapshots
+
+
+def _log_audit_entries(audit_log: Iterable[Mapping[str, str]]) -> None:
+    for entry in audit_log:
+        channel = entry.get("channel", "unknown")
+        title = entry.get("title", "brak tytułu")
+        severity = entry.get("severity", "info")
+        body = entry.get("body", "")
+        _LOGGER.info("AUDYT [%s][%s] %s — %s", channel, severity.upper(), title, body)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+
+    try:
+        storage = create_default_secret_storage(
+            namespace=args.secret_namespace,
+            headless_passphrase=args.headless_passphrase,
+            headless_path=args.headless_secret_path,
+        )
+    except SecretStorageError as exc:
+        _LOGGER.error("Nie udało się zainicjalizować magazynu sekretów: %s", exc)
+        return 1
+
+    secret_manager = SecretManager(storage, namespace=args.secret_namespace)
+
+    try:
+        context = bootstrap_environment(
+            args.environment,
+            config_path=args.config,
+            secret_manager=secret_manager,
+        )
+    except SecretStorageError as exc:
+        _LOGGER.error("Brak wymaganych sekretów: %s", exc)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.exception("Błąd podczas bootstrappingu środowiska: %s", exc)
+        return 1
+
+    environment_cfg = context.environment
+    core_config = context.core_config
+
+    risk_config = core_config.risk_profiles.get(environment_cfg.risk_profile)
+    if risk_config is None:
+        _LOGGER.error(
+            "Profil ryzyka '%s' nie istnieje w konfiguracji – zaktualizuj config/core.yaml.",
+            environment_cfg.risk_profile,
+        )
+        return 1
+
+    try:
+        universe = _resolve_universe(core_config, environment_cfg.instrument_universe)
+    except SystemExit as exc:
+        _LOGGER.error(str(exc))
+        return 1
+    symbol, instrument_metadata = _select_symbol(universe, environment_cfg.exchange, args.symbol)
+
+    strategy_config = core_config.strategies.get(args.strategy)
+    if strategy_config is None:
+        _LOGGER.error("Strategia '%s' nie została zdefiniowana w konfiguracji.", args.strategy)
+        return 1
+
+    strategy, strategy_settings = _build_strategy(strategy_config)
+    risk_profile = _build_risk_profile(risk_config)
+    context.risk_engine.register_profile(risk_profile)
+
+    cache_root = Path(environment_cfg.data_cache_path)
+    if not cache_root.is_absolute():
+        cache_root = (Path(args.config).resolve().parent / cache_root).resolve()
+
+    data_source = _build_data_source(context.adapter, cache_root)
+
+    required_history = strategy_config.slow_ma + 5
+    history_limit = args.history_limit or max(required_history, strategy_settings.max_history())
+    now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+    request = OHLCVRequest(symbol=symbol, interval=args.interval, start=0, end=now_ms, limit=history_limit + 1)
+    response = data_source.fetch_ohlcv(request)
+    snapshots = _rows_to_snapshots(symbol, response)
+
+    if len(snapshots) <= 1:
+        _LOGGER.error(
+            "Brak danych OHLCV dla %s (%s). Uruchom najpierw scripts/backfill_ohlcv.py, aby zasilić cache.",
+            symbol,
+            args.interval,
+        )
+        return 1
+
+    history, latest = snapshots[:-1], snapshots[-1]
+    strategy.warm_up(history)
+
+    markets = {
+        symbol: MarketMetadata(
+            base_asset=instrument_metadata.base_asset,
+            quote_asset=instrument_metadata.quote_asset,
+            min_quantity=args.min_quantity or instrument_metadata.min_quantity,
+            min_notional=args.min_notional or instrument_metadata.min_notional,
+            step_size=args.step_size or instrument_metadata.step_size,
+            tick_size=args.tick_size,
+        )
+    }
+
+    execution = PaperTradingExecutionService(
+        markets,
+        initial_balances={
+            instrument_metadata.quote_asset: args.quote_balance,
+            instrument_metadata.base_asset: args.base_balance,
+        },
+        maker_fee=args.maker_fee,
+        taker_fee=args.taker_fee,
+        slippage_bps=args.slippage_bps,
+    )
+
+    adapter = _PaperAccountAdapter(
+        context.credentials,
+        execution,
+        default_quote_asset=instrument_metadata.quote_asset,
+    )
+
+    session = TradingSession(
+        strategy=strategy,
+        strategy_name=args.strategy,
+        adapter=adapter,
+        risk_engine=context.risk_engine,
+        risk_profile=risk_profile,
+        execution=execution,
+        alert_router=context.alert_router,
+        instruments={symbol: instrument_metadata},
+        environment=environment_cfg.environment,
+        portfolio_id=args.portfolio_id,
+        context_metadata={"config_path": str(Path(args.config).resolve())},
+    )
+
+    _LOGGER.info(
+        "Start sesji paper trading: env=%s, symbol=%s, interval=%s, historia=%s świec",
+        args.environment,
+        symbol,
+        args.interval,
+        len(snapshots),
+    )
+
+    results = session.process_snapshot(latest)
+
+    if results:
+        for result in results:
+            avg_price = result.avg_price if result.avg_price is not None else latest.close
+            _LOGGER.info(
+                "Zrealizowano zlecenie paper trading: id=%s status=%s qty=%.8f price=%.2f",
+                result.order_id,
+                result.status,
+                result.filled_quantity,
+                avg_price,
+            )
+    else:
+        _LOGGER.info("Strategia nie wygenerowała zleceń dla bieżącej świecy – brak zmian w portfelu.")
+
+    _log_audit_entries(context.audit_log.export())
+
+    balances = execution.balances()
+    for asset, value in sorted(balances.items()):
+        _LOGGER.info("Saldo paper trading %s: %.8f", asset, value)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - punkt wejścia CLI
+    raise SystemExit(main())
+

--- a/scripts/run_paper_session.py
+++ b/scripts/run_paper_session.py
@@ -139,10 +139,14 @@ def _resolve_universe(core_config: CoreConfig, universe_key: str | None) -> Inst
 
 
 def _select_symbol(
-    universe: InstrumentUniverseConfig | None, exchange_name: str, explicit_symbol: str | None
+    universe: InstrumentUniverseConfig | None,
+    exchange_name: str,
+    explicit_symbol: str | None,
+    *,
+    prebuilt: Mapping[str, InstrumentConfig] | None = None,
 ) -> tuple[str, InstrumentConfig]:
-    instruments: MutableMapping[str, InstrumentConfig] = {}
-    if universe:
+    instruments: MutableMapping[str, InstrumentConfig] = dict(prebuilt or {})
+    if universe and not instruments:
         for instrument in universe.instruments:
             symbol = instrument.exchange_symbols.get(exchange_name)
             if not symbol:
@@ -296,7 +300,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     except SystemExit as exc:
         _LOGGER.error(str(exc))
         return 1
-    symbol, instrument_metadata = _select_symbol(universe, environment_cfg.exchange, args.symbol)
+    symbol, instrument_metadata = _select_symbol(
+        universe,
+        environment_cfg.exchange,
+        args.symbol,
+        prebuilt=context.instruments,
+    )
 
     strategy_config = core_config.strategies.get(args.strategy)
     if strategy_config is None:

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,320 @@
+"""Testy modułu alertów."""
+from __future__ import annotations
+
+import base64
+import json
+from email.message import EmailMessage
+from pathlib import Path
+from typing import List
+from urllib import request
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from bot_core.alerts import (
+    AlertDeliveryError,
+    AlertMessage,
+    DefaultAlertRouter,
+    EmailChannel,
+    InMemoryAlertAuditLog,
+    MessengerChannel,
+    SMSChannel,
+    SignalChannel,
+    TelegramChannel,
+    WhatsAppChannel,
+    DEFAULT_SMS_PROVIDERS,
+    get_sms_provider,
+)
+from bot_core.alerts.base import AlertChannel
+
+
+class DummyChannel(AlertChannel):
+    name = "dummy"
+
+    def __init__(self) -> None:
+        self.messages: List[AlertMessage] = []
+
+    def send(self, message: AlertMessage) -> None:
+        self.messages.append(message)
+
+    def health_check(self) -> dict[str, str]:
+        return {"status": "ok", "delivered": str(len(self.messages))}
+
+
+class FailingChannel(AlertChannel):
+    name = "failing"
+
+    def send(self, message: AlertMessage) -> None:  # noqa: ARG002 - interfejs wymaga parametru
+        raise AlertDeliveryError("celowy błąd")
+
+    def health_check(self) -> dict[str, str]:
+        return {"status": "error"}
+
+
+@pytest.fixture()
+def sample_message() -> AlertMessage:
+    return AlertMessage(
+        category="risk",
+        title="Limit ryzyka osiągnięty",
+        body="Dzienne straty przekroczyły próg.",
+        severity="critical",
+        context={"profile": "conservative", "instrument": "BTC/USDT"},
+    )
+
+
+def test_router_dispatch_records_audit(sample_message: AlertMessage) -> None:
+    audit = InMemoryAlertAuditLog()
+    router = DefaultAlertRouter(audit_log=audit)
+    channel = DummyChannel()
+    router.register(channel)
+
+    router.dispatch(sample_message)
+
+    assert channel.messages == [sample_message]
+    exported = tuple(audit.export())
+    assert len(exported) == 1
+    assert exported[0]["channel"] == "dummy"
+
+
+def test_router_continues_on_error(sample_message: AlertMessage, caplog: pytest.LogCaptureFixture) -> None:
+    audit = InMemoryAlertAuditLog()
+    router = DefaultAlertRouter(audit_log=audit)
+    router.register(FailingChannel())
+    router.register(DummyChannel())
+
+    router.dispatch(sample_message)
+
+    exported = tuple(audit.export())
+    assert len(exported) == 1
+    assert exported[0]["channel"] == "dummy"
+    assert any("Część kanałów zgłosiła błędy" in record.message for record in caplog.records)
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status: int, payload: bytes) -> None:
+        self.status = status
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def getcode(self) -> int:
+        return self.status
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401, ANN001
+        return None
+
+
+def test_telegram_channel_sends_payload(sample_message: AlertMessage) -> None:
+    captured: dict[str, request.Request] = {}
+
+    def opener(req: request.Request, *, timeout: float):  # noqa: ANN001
+        captured["request"] = req
+        return _FakeHTTPResponse(200, b"{\"ok\": true}")
+
+    channel = TelegramChannel(bot_token="token", chat_id="chat", _opener=opener)
+    channel.send(sample_message)
+
+    sent_request = captured["request"]
+    assert sent_request.full_url.endswith("/sendMessage")
+    body = sent_request.data.decode("utf-8")
+    assert "chat" in body
+    assert "Limit ryzyka" in body
+    assert channel.health_check()["status"] == "ok"
+
+
+class _FakeSMTP:
+    def __init__(self, host: str, port: int, timeout: float) -> None:  # noqa: D401
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.sent: list[EmailMessage] = []
+
+    def __enter__(self) -> "_FakeSMTP":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401, ANN001
+        return None
+
+    def ehlo(self) -> None:
+        return None
+
+    def starttls(self) -> None:
+        return None
+
+    def login(self, username: str, password: str) -> None:  # noqa: D401
+        self.username = username
+        self.password = password
+
+    def send_message(self, message: EmailMessage) -> None:
+        self.sent.append(message)
+
+
+def test_email_channel_builds_message(sample_message: AlertMessage) -> None:
+    fake_smtp = _FakeSMTP("localhost", 25, timeout=5)
+
+    def factory(host: str, port: int, timeout: float) -> _FakeSMTP:  # noqa: ANN001
+        assert host == "localhost"
+        assert port == 25
+        assert timeout == 5
+        return fake_smtp
+
+    channel = EmailChannel(
+        host="localhost",
+        port=25,
+        from_address="bot@example.com",
+        recipients=["user@example.com"],
+        username="user",
+        password="secret",
+        use_tls=True,
+        timeout=5,
+        _smtp_factory=factory,  # type: ignore[arg-type]
+    )
+
+    channel.send(sample_message)
+
+    assert len(fake_smtp.sent) == 1
+    email = fake_smtp.sent[0]
+    assert email["Subject"] == "[CRITICAL] Limit ryzyka osiągnięty"
+    assert "Dzienne straty" in email.get_content()
+    assert channel.health_check()["status"] == "ok"
+
+
+def test_sms_channel_sends_to_all_recipients(sample_message: AlertMessage) -> None:
+    captured_requests: list[request.Request] = []
+
+    def opener(req: request.Request, *, timeout: float):  # noqa: ANN001
+        captured_requests.append(req)
+        return _FakeHTTPResponse(201, b"{}")
+
+    channel = SMSChannel(
+        account_sid="AC123",
+        auth_token="token",
+        from_number="123",
+        recipients=("+48111222333", "+3546600000"),
+        _opener=opener,
+    )
+
+    channel.send(sample_message)
+
+    assert len(captured_requests) == 2
+    first_request = captured_requests[0]
+    assert first_request.data is not None
+    decoded_body = first_request.data.decode("utf-8")
+    assert "To=%2B48111222333" in decoded_body
+    auth_header = first_request.get_header("Authorization")
+    assert auth_header is not None
+    decoded_auth = base64.b64decode(auth_header.split()[1]).decode("utf-8")
+    assert decoded_auth == "AC123:token"
+    assert channel.health_check()["status"] == "ok"
+
+
+def test_default_sms_providers_cover_regions() -> None:
+    required = {"orange_pl", "tmobile_pl", "plus_pl", "play_pl", "nova_is"}
+    assert required.issubset(DEFAULT_SMS_PROVIDERS.keys())
+
+
+def test_sms_channel_uses_provider_metadata(sample_message: AlertMessage) -> None:
+    captured = []
+
+    def opener(req: request.Request, *, timeout: float):  # noqa: ANN001
+        captured.append(req)
+        return _FakeHTTPResponse(200, b"{}")
+
+    provider = get_sms_provider("orange_pl")
+    channel = SMSChannel(
+        account_sid="AC456",
+        auth_token="token",
+        from_number="123",
+        recipients=("+48555111222",),
+        provider=provider,
+        _opener=opener,
+    )
+
+    channel.send(sample_message)
+
+    assert captured
+    assert captured[0].full_url.startswith(provider.api_base_url)
+    health = channel.health_check()
+    assert health["provider"] == "orange_pl"
+    assert health["country"] == "PL"
+
+
+def test_signal_channel_builds_payload(sample_message: AlertMessage) -> None:
+    captured: dict[str, request.Request] = {}
+
+    def opener(req: request.Request, *, timeout: float, context):  # noqa: ANN001
+        captured["request"] = req
+        assert context is not None
+        return _FakeHTTPResponse(200, b"{}")
+
+    channel = SignalChannel(
+        service_url="https://signal-gateway.local",
+        sender_number="+48500100999",
+        recipients=("+48555111222",),
+        auth_token="secret",
+        _opener=opener,
+    )
+
+    channel.send(sample_message)
+
+    req = captured["request"]
+    assert req.full_url.endswith("/v2/send")
+    body = json.loads(req.data.decode("utf-8"))
+    assert body["number"] == "+48500100999"
+    assert body["recipients"] == ["+48555111222"]
+    assert "Authorization" in req.headers
+    assert channel.health_check()["status"] == "ok"
+
+
+def test_whatsapp_channel_formats_messages(sample_message: AlertMessage) -> None:
+    captured: list[request.Request] = []
+
+    def opener(req: request.Request, *, timeout: float):  # noqa: ANN001
+        captured.append(req)
+        return _FakeHTTPResponse(200, b"{}")
+
+    channel = WhatsAppChannel(
+        phone_number_id="10987654321",
+        access_token="token",
+        recipients=("48555111222", "48555111333"),
+        _opener=opener,
+    )
+
+    channel.send(sample_message)
+
+    assert len(captured) == 2
+    payload = json.loads(captured[0].data.decode("utf-8"))
+    assert payload["messaging_product"] == "whatsapp"
+    assert payload["to"] == "48555111222"
+    assert "Authorization" in captured[0].headers
+    assert channel.health_check()["status"] == "ok"
+
+
+def test_messenger_channel_sends_text(sample_message: AlertMessage) -> None:
+    captured: list[request.Request] = []
+
+    def opener(req: request.Request, *, timeout: float):  # noqa: ANN001
+        captured.append(req)
+        return _FakeHTTPResponse(200, b"{}")
+
+    channel = MessengerChannel(
+        page_id="1357924680",
+        access_token="token",
+        recipients=("2468013579",),
+        _opener=opener,
+    )
+
+    channel.send(sample_message)
+
+    assert captured
+    payload = json.loads(captured[0].data.decode("utf-8"))
+    assert payload["recipient"]["id"] == "2468013579"
+    assert payload["message"]["text"]
+    assert channel.health_check()["status"] == "ok"

--- a/tests/test_binance_futures_adapter.py
+++ b/tests/test_binance_futures_adapter.py
@@ -1,0 +1,199 @@
+"""Testy jednostkowe adaptera Binance Futures."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.request import Request
+
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeCredentials, OrderRequest
+from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_fetch_account_snapshot_parses_assets(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "assets": [
+                {"asset": "USDT", "walletBalance": "120.5"},
+                {"asset": "BUSD", "walletBalance": "50"},
+            ],
+            "totalMarginBalance": "180.5",
+            "totalAvailableBalance": "150.5",
+            "totalMaintMargin": "12.0",
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="futures-key",
+        secret="secret",
+        permissions=("read", "trade"),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    snapshot = adapter.fetch_account_snapshot()
+
+    assert isinstance(snapshot, AccountSnapshot)
+    assert snapshot.balances["USDT"] == pytest.approx(120.5)
+    assert snapshot.balances["BUSD"] == pytest.approx(50.0)
+    assert snapshot.total_equity == pytest.approx(180.5)
+    assert snapshot.available_margin == pytest.approx(150.5)
+    assert snapshot.maintenance_margin == pytest.approx(12.0)
+    assert captured_request is not None
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "futures-key"
+    assert "signature=" in captured_request.full_url
+    assert captured_request.full_url.startswith("https://fapi.binance.com/fapi/v2/account")
+
+
+def test_place_order_builds_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "orderId": 999,
+            "status": "NEW",
+            "executedQty": "0",
+            "avgPrice": "0",
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.time.time", lambda: 1_700_000_100.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    order_request = OrderRequest(
+        symbol="BTCUSDT",
+        side="sell",
+        quantity=0.05,
+        order_type="limit",
+        price=25_000,
+        time_in_force="GTC",
+        client_order_id="abc-123",
+    )
+
+    result = adapter.place_order(order_request)
+
+    assert result.order_id == "999"
+    assert result.status == "NEW"
+    assert result.filled_quantity == pytest.approx(0)
+    assert result.avg_price is None
+    assert captured_request is not None
+    assert captured_request.get_method() == "POST"
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "key"
+    body = captured_request.data.decode("utf-8") if captured_request.data else ""
+    expected_prefix = (
+        "symbol=BTCUSDT&side=SELL&type=LIMIT&quantity=0.05&price=25000&timeInForce=GTC&newClientOrderId=abc-123"
+    )
+    assert body.startswith(expected_prefix)
+    assert "signature=" in body
+    assert captured_request.full_url.startswith("https://fapi.binance.com/fapi/v1/order")
+
+
+def test_cancel_order_requires_symbol() -> None:
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    with pytest.raises(ValueError):
+        adapter.cancel_order("1")
+
+
+def test_cancel_order_uses_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {"status": "CANCELED"}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.futures.time.time", lambda: 1_700_000_200.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    adapter.cancel_order("42", symbol="BTCUSDT")
+
+    assert captured_request is not None
+    assert captured_request.get_method() == "DELETE"
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "key"
+    url = captured_request.full_url
+    assert url.startswith("https://fapi.binance.com/fapi/v1/order")
+    assert "symbol=BTCUSDT" in url
+    assert "orderId=42" in url
+    assert "signature=" in url
+
+
+def test_fetch_symbols_filters_non_trading(monkeypatch: pytest.MonkeyPatch) -> None:
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("read",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceFuturesAdapter(credentials)
+
+    payload = {
+        "symbols": [
+            {"symbol": "BTCUSDT", "status": "TRADING", "contractType": "PERPETUAL"},
+            {"symbol": "ETHUSDT", "status": "TRADING", "contractType": "CURRENT_QUARTER"},
+            {"symbol": "BAD", "status": "HALT"},
+            {"symbol": None, "status": "TRADING"},
+        ]
+    }
+
+    monkeypatch.setattr(adapter, "_public_request", lambda path, params=None, method="GET": payload)
+
+    symbols = list(adapter.fetch_symbols())
+
+    assert symbols == ["BTCUSDT", "ETHUSDT"]
+

--- a/tests/test_binance_spot_adapter.py
+++ b/tests/test_binance_spot_adapter.py
@@ -1,0 +1,150 @@
+"""Testy jednostkowe adaptera Binance Spot."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.request import Request
+
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeCredentials, OrderRequest
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_fetch_account_snapshot_parses_balances(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "balances": [
+                {"asset": "BTC", "free": "0.5", "locked": "0.1"},
+                {"asset": "USDT", "free": "100", "locked": "0"},
+            ],
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="test-key",
+        secret="secret",
+        permissions=("read", "trade"),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceSpotAdapter(credentials)
+
+    snapshot = adapter.fetch_account_snapshot()
+
+    assert isinstance(snapshot, AccountSnapshot)
+    assert snapshot.balances["BTC"] == pytest.approx(0.6)
+    assert snapshot.balances["USDT"] == pytest.approx(100.0)
+    assert snapshot.total_equity == pytest.approx(100.6)
+    assert snapshot.available_margin == pytest.approx(100.5)
+    assert captured_request is not None
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "test-key"
+    assert "signature=" in captured_request.full_url
+
+
+def test_place_order_builds_signed_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "orderId": 12345,
+            "status": "NEW",
+            "executedQty": "0",
+            "price": "0",
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceSpotAdapter(credentials)
+
+    order_request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.01,
+        order_type="limit",
+        price=20_000,
+        time_in_force="GTC",
+        client_order_id="cli-1",
+    )
+
+    result = adapter.place_order(order_request)
+
+    assert result.order_id == "12345"
+    assert result.status == "NEW"
+    assert result.filled_quantity == pytest.approx(0)
+    assert result.avg_price is None
+    assert captured_request is not None
+    assert captured_request.get_method() == "POST"
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "key"
+    body = captured_request.data.decode("utf-8") if captured_request.data else ""
+    expected_prefix = "symbol=BTCUSDT&side=BUY&type=LIMIT&quantity=0.01&price=20000&timeInForce=GTC&newClientOrderId=cli-1&timestamp=1700000000000"
+    assert body.startswith(expected_prefix)
+    assert "signature=" in body
+
+
+def test_cancel_order_uses_delete_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {"status": "CANCELED"}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.binance.spot.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = BinanceSpotAdapter(credentials)
+
+    adapter.cancel_order("123", symbol="BTCUSDT")
+
+    assert captured_request is not None
+    assert captured_request.get_method() == "DELETE"
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["x-mbx-apikey"] == "key"
+    assert "symbol=BTCUSDT" in captured_request.full_url
+    assert "orderId=123" in captured_request.full_url
+    assert "signature=" in captured_request.full_url

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,174 @@
+"""Testy ładowania konfiguracji."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.config import (
+    EmailChannelSettings,
+    InstrumentConfig,
+    MessengerChannelSettings,
+    SMSProviderSettings,
+    SignalChannelSettings,
+    TelegramChannelSettings,
+    WhatsAppChannelSettings,
+    load_core_config,
+)
+
+
+def test_load_core_config_reads_sms_providers(tmp_path: Path) -> None:
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(
+        """
+        risk_profiles: {}
+        instrument_universes:
+          core_multi_exchange:
+            description: "Testowe uniwersum"
+            instruments:
+              BTC_USDT:
+                base_asset: BTC
+                quote_asset: USDT
+                categories: [core]
+                exchanges:
+                  binance_spot: BTCUSDT
+                  kraken_spot: XBTUSDT
+                backfill:
+                  - interval: 1d
+                    lookback_days: 3650
+        environments: {}
+        reporting: {}
+        alerts:
+          sms_providers:
+            orange_local:
+              provider: orange_pl
+              api_base_url: https://api.orange.pl/sms/v1
+              from_number: "+48500100100"
+              recipients: ["+48555111222"]
+              allow_alphanumeric_sender: true
+              sender_id: BOT-ORANGE
+              credential_key: orange_sms_credentials
+          telegram_channels:
+            primary:
+              chat_id: "123456789"
+              token_secret: telegram_primary_token
+              parse_mode: MarkdownV2
+          signal_channels:
+            workstation:
+              service_url: https://signal-gateway.local
+              sender_number: "+48500100999"
+              recipients: ["+48555111222"]
+              credential_secret: signal_cli_token
+              verify_tls: true
+          whatsapp_channels:
+            business:
+              phone_number_id: "10987654321"
+              recipients: ["48555111222"]
+              token_secret: whatsapp_primary_token
+              api_base_url: https://graph.facebook.com
+              api_version: v16.0
+          messenger_channels:
+            ops:
+              page_id: "1357924680"
+              recipients: ["2468013579"]
+              token_secret: messenger_page_token
+              api_base_url: https://graph.facebook.com
+              api_version: v16.0
+          email_channels:
+            ops:
+              host: smtp.example.com
+              port: 587
+              from_address: bot@example.com
+              recipients: ["ops@example.com"]
+              credential_secret: smtp_ops_credentials
+              use_tls: true
+        """,
+        encoding="utf-8",
+    )
+
+    config = load_core_config(config_path)
+
+    assert "orange_local" in config.sms_providers
+    provider = config.sms_providers["orange_local"]
+    assert isinstance(provider, SMSProviderSettings)
+    assert provider.provider_key == "orange_pl"
+    assert provider.api_base_url == "https://api.orange.pl/sms/v1"
+    assert provider.allow_alphanumeric_sender is True
+    assert provider.sender_id == "BOT-ORANGE"
+    assert provider.credential_key == "orange_sms_credentials"
+    assert isinstance(config.telegram_channels["primary"], TelegramChannelSettings)
+    telegram = config.telegram_channels["primary"]
+    assert telegram.chat_id == "123456789"
+    assert telegram.token_secret == "telegram_primary_token"
+    assert telegram.parse_mode == "MarkdownV2"
+    signal = config.signal_channels["workstation"]
+    assert isinstance(signal, SignalChannelSettings)
+    assert signal.service_url == "https://signal-gateway.local"
+    assert signal.sender_number == "+48500100999"
+    assert signal.credential_secret == "signal_cli_token"
+    whatsapp = config.whatsapp_channels["business"]
+    assert isinstance(whatsapp, WhatsAppChannelSettings)
+    assert whatsapp.phone_number_id == "10987654321"
+    assert whatsapp.token_secret == "whatsapp_primary_token"
+    assert whatsapp.api_version == "v16.0"
+    messenger = config.messenger_channels["ops"]
+    assert isinstance(messenger, MessengerChannelSettings)
+    assert messenger.page_id == "1357924680"
+    assert messenger.token_secret == "messenger_page_token"
+    email = config.email_channels["ops"]
+    assert isinstance(email, EmailChannelSettings)
+    assert email.host == "smtp.example.com"
+    assert email.port == 587
+    assert email.from_address == "bot@example.com"
+    assert email.recipients == ("ops@example.com",)
+    assert email.credential_secret == "smtp_ops_credentials"
+    assert email.use_tls is True
+    universe = config.instrument_universes["core_multi_exchange"]
+    assert universe.description == "Testowe uniwersum"
+    assert len(universe.instruments) == 1
+    instrument = universe.instruments[0]
+    assert isinstance(instrument, InstrumentConfig)
+    assert instrument.exchange_symbols["binance_spot"] == "BTCUSDT"
+    assert instrument.backfill_windows[0].interval == "1d"
+    assert instrument.backfill_windows[0].lookback_days == 3650
+
+
+
+def test_load_core_config_loads_strategies(tmp_path: Path) -> None:
+    config_path = tmp_path / 'core.yaml'
+    config_path.write_text(
+        """
+        risk_profiles: {}
+        strategies:
+          core_daily_trend:
+            engine: daily_trend_momentum
+            parameters:
+              fast_ma: 30
+              slow_ma: 120
+              breakout_lookback: 60
+              momentum_window: 25
+              atr_window: 15
+              atr_multiplier: 1.8
+              min_trend_strength: 0.01
+              min_momentum: 0.002
+        instrument_universes: {}
+        environments: {}
+        reporting: {}
+        alerts: {}
+        """,
+        encoding='utf-8',
+    )
+
+    config = load_core_config(config_path)
+
+    assert 'core_daily_trend' in config.strategies
+    strategy = config.strategies['core_daily_trend']
+    assert strategy.fast_ma == 30
+    assert strategy.slow_ma == 120
+    assert strategy.breakout_lookback == 60
+    assert strategy.momentum_window == 25
+    assert strategy.atr_window == 15
+    assert abs(strategy.atr_multiplier - 1.8) < 1e-9
+    assert abs(strategy.min_trend_strength - 0.01) < 1e-9
+    assert abs(strategy.min_momentum - 0.002) < 1e-9

--- a/tests/test_daily_trend_strategy.py
+++ b/tests/test_daily_trend_strategy.py
@@ -1,0 +1,105 @@
+"""Testy strategii trend/momentum na danych dziennych."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.strategies import MarketSnapshot
+from bot_core.strategies.daily_trend import (
+    DailyTrendMomentumSettings,
+    DailyTrendMomentumStrategy,
+)
+
+
+def _snapshot(ts: int, price: float, high: float | None = None, low: float | None = None) -> MarketSnapshot:
+    high = high if high is not None else price
+    low = low if low is not None else price
+    return MarketSnapshot(
+        symbol="BTCUSDT",
+        timestamp=ts,
+        open=price,
+        high=high,
+        low=low,
+        close=price,
+        volume=1.0,
+    )
+
+
+def test_daily_trend_strategy_generates_entry_signal() -> None:
+    settings = DailyTrendMomentumSettings(
+        fast_ma=3,
+        slow_ma=5,
+        breakout_lookback=4,
+        momentum_window=3,
+        atr_window=3,
+        atr_multiplier=1.5,
+        min_trend_strength=0.0,
+        min_momentum=0.0,
+    )
+    strategy = DailyTrendMomentumStrategy(settings)
+
+    history = [
+        _snapshot(1, 100, high=101, low=99),
+        _snapshot(2, 101, high=102, low=100),
+        _snapshot(3, 102, high=103, low=101),
+        _snapshot(4, 103, high=104, low=102),
+        _snapshot(5, 104, high=105, low=103),
+    ]
+    strategy.warm_up(history)
+
+    signal_snapshot = _snapshot(6, 107, high=108, low=106)
+    signals = strategy.on_data(signal_snapshot)
+
+    assert len(signals) == 1
+    signal = signals[0]
+    assert signal.side == "buy"
+    assert 0.0 <= signal.confidence <= 1.0
+    assert signal.metadata["position"] == 1.0
+    assert signal.metadata["breakout_high"] <= signal_snapshot.close
+
+
+def test_daily_trend_strategy_generates_exit_on_stop() -> None:
+    settings = DailyTrendMomentumSettings(
+        fast_ma=3,
+        slow_ma=5,
+        breakout_lookback=4,
+        momentum_window=3,
+        atr_window=3,
+        atr_multiplier=1.5,
+        min_trend_strength=0.0,
+        min_momentum=0.0,
+    )
+    strategy = DailyTrendMomentumStrategy(settings)
+
+    history = [
+        _snapshot(1, 100, high=101, low=99),
+        _snapshot(2, 101, high=102, low=100),
+        _snapshot(3, 102, high=103, low=101),
+        _snapshot(4, 103, high=104, low=102),
+        _snapshot(5, 104, high=105, low=103),
+    ]
+    strategy.warm_up(history)
+
+    entry_snapshot = _snapshot(6, 108, high=109, low=107)
+    entry_signals = strategy.on_data(entry_snapshot)
+    assert entry_signals and entry_signals[0].side == "buy"
+
+    exit_snapshot = _snapshot(7, 100, high=101, low=97)
+    exit_signals = strategy.on_data(exit_snapshot)
+
+    assert exit_signals, "Strategia powinna wygenerować sygnał wyjścia"
+    exit_signal = exit_signals[0]
+    assert exit_signal.side == "sell"
+    assert 0.0 <= exit_signal.confidence <= 1.0
+    assert exit_signal.metadata["position"] == 0.0
+
+
+def test_daily_trend_strategy_requires_history() -> None:
+    strategy = DailyTrendMomentumStrategy(
+        DailyTrendMomentumSettings(fast_ma=3, slow_ma=5, breakout_lookback=4, momentum_window=3, atr_window=3)
+    )
+    snapshot = _snapshot(1, 100, high=101, low=99)
+
+    assert strategy.on_data(snapshot) == []

--- a/tests/test_kraken_futures_adapter.py
+++ b/tests/test_kraken_futures_adapter.py
@@ -1,0 +1,162 @@
+import base64
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+from urllib.request import Request
+
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeCredentials, OrderRequest
+from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _credentials() -> ExchangeCredentials:
+    secret = base64.b64encode(b"kraken-futures-secret").decode("utf-8")
+    return ExchangeCredentials(
+        key_id="kraken-futures-key",
+        secret=secret,
+        permissions=("read", "trade"),
+        environment=Environment.LIVE,
+    )
+
+
+def test_fetch_account_snapshot_signed_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 20):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {
+            "result": "success",
+            "accounts": {
+                "futures": {
+                    "balances": {
+                        "USD": {"balance": "1000.0"},
+                        "BTC": {"available": "0.05"},
+                    },
+                    "accountValue": "1200.0",
+                    "availableMargin": "800.0",
+                    "initialMargin": "200.0",
+                }
+            },
+        }
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.kraken.futures.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.kraken.futures.time.time", lambda: 1_700_000_000.0)
+
+    adapter = KrakenFuturesAdapter(_credentials(), environment=Environment.LIVE)
+    snapshot = adapter.fetch_account_snapshot()
+
+    assert isinstance(snapshot, AccountSnapshot)
+    assert snapshot.balances["USD"] == pytest.approx(1000.0)
+    assert snapshot.balances["BTC"] == pytest.approx(0.05)
+    assert snapshot.total_equity == pytest.approx(1200.0)
+    assert snapshot.available_margin == pytest.approx(800.0)
+    assert snapshot.maintenance_margin == pytest.approx(200.0)
+
+    assert captured_request is not None
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["apikey"] == "kraken-futures-key"
+    expected_signature = _expected_signature(
+        path="/accounts",
+        body=b"",
+        secret=_credentials().secret or "",
+        nonce=headers["nonce"],
+    )
+    assert headers["authent"] == expected_signature
+
+
+def test_place_order_builds_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 20):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        if request.get_method() == "POST":
+            payload = {
+                "result": "success",
+                "sendStatus": {
+                    "order_id": "OF12345",
+                    "status": "accepted",
+                    "orderEvents": [
+                        {"type": "fill", "fill_size": "0.01", "price": "30000.0"}
+                    ],
+                },
+            }
+        else:
+            payload = {"result": "success", "cancelStatus": {"status": "cancelled"}}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.kraken.futures.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.kraken.futures.time.time", lambda: 1_700_000_000.0)
+
+    adapter = KrakenFuturesAdapter(_credentials(), environment=Environment.LIVE)
+    order = OrderRequest(
+        symbol="pi_xbtusd",
+        side="buy",
+        quantity=0.01,
+        order_type="limit",
+        price=30_000.0,
+        time_in_force="GTC",
+        client_order_id="cli-kraken",
+    )
+
+    result = adapter.place_order(order)
+    assert result.order_id == "OF12345"
+    assert result.status == "ACCEPTED"
+    assert result.filled_quantity == pytest.approx(0.01)
+    assert result.avg_price == pytest.approx(30_000.0)
+
+    assert captured_request is not None
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["apikey"] == "kraken-futures-key"
+    body_bytes = captured_request.data or b""
+    assert b"\"cliOrdId\":\"cli-kraken\"" in body_bytes
+    assert b"\"limitPrice\":\"30000.00\"" in body_bytes
+    expected_signature = _expected_signature(
+        path="/orders",
+        body=body_bytes,
+        secret=_credentials().secret or "",
+        nonce=headers["nonce"],
+    )
+    assert headers["authent"] == expected_signature
+
+
+def test_cancel_order_validates_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(request: Request, timeout: int = 20):  # type: ignore[override]
+        payload = {"result": "success", "cancelStatus": {"status": "cancelled"}}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.kraken.futures.urlopen", fake_urlopen)
+    adapter = KrakenFuturesAdapter(_credentials(), environment=Environment.LIVE)
+
+    adapter.cancel_order("OID-1")
+
+
+def _expected_signature(*, path: str, body: bytes, secret: str, nonce: str) -> str:
+    decoded_secret = base64.b64decode(secret)
+    message = nonce.encode("utf-8") + path.encode("utf-8") + b"" + body
+    sha_digest = hashlib.sha256(message).digest()
+    mac = hmac.new(decoded_secret, sha_digest, hashlib.sha256)
+    return base64.b64encode(mac.digest()).decode("utf-8")

--- a/tests/test_kraken_spot_adapter.py
+++ b/tests/test_kraken_spot_adapter.py
@@ -1,0 +1,151 @@
+"""Testy jednostkowe adaptera Kraken Spot."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl
+from urllib.request import Request
+
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeCredentials, OrderRequest
+from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _build_credentials() -> ExchangeCredentials:
+    secret = base64.b64encode(b"super-secret").decode("utf-8")
+    return ExchangeCredentials(
+        key_id="kraken-key",
+        secret=secret,
+        permissions=("read", "trade"),
+        environment=Environment.LIVE,
+    )
+
+
+def test_fetch_account_snapshot_uses_private_signed_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_requests: list[Request] = []
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        captured_requests.append(request)
+        if request.full_url.endswith("TradeBalance"):
+            payload = {"error": [], "result": {"eb": "1200.0", "mf": "800.0", "m": "200.0"}}
+        else:
+            payload = {"error": [], "result": {"ZUSD": "1000.0", "XXBT": "0.5"}}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.kraken.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.kraken.spot.time.time", lambda: 1_700_000_000.0)
+
+    adapter = KrakenSpotAdapter(_build_credentials(), environment=Environment.LIVE)
+
+    snapshot = adapter.fetch_account_snapshot()
+
+    assert isinstance(snapshot, AccountSnapshot)
+    assert snapshot.balances["ZUSD"] == pytest.approx(1000.0)
+    assert snapshot.total_equity == pytest.approx(1200.0)
+    assert snapshot.available_margin == pytest.approx(800.0)
+    assert snapshot.maintenance_margin == pytest.approx(200.0)
+
+    assert len(captured_requests) == 2
+    first_headers = {name.lower(): value for name, value in captured_requests[0].header_items()}
+    assert first_headers["api-key"] == "kraken-key"
+    # Sprawdzamy deterministycznie podpis API-Sign.
+    signature = first_headers["api-sign"]
+    body_params = dict(parse_qsl(captured_requests[0].data.decode("utf-8")))
+    expected_signature = _expected_signature(
+        path="/0/private/Balance",
+        params=body_params,
+        secret=_build_credentials().secret or "",
+    )
+    assert signature == expected_signature
+
+
+def test_place_order_builds_payload_with_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_request: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured_request
+        captured_request = request
+        payload = {"error": [], "result": {"txid": ["OID123"], "descr": {"order": "buy 0.1 XBTUSD"}}}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.kraken.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.kraken.spot.time.time", lambda: 1_700_000_000.0)
+
+    adapter = KrakenSpotAdapter(_build_credentials(), environment=Environment.LIVE)
+
+    order = OrderRequest(
+        symbol="XBTUSD",
+        side="buy",
+        quantity=0.1,
+        order_type="limit",
+        price=25_000.0,
+        time_in_force="GTC",
+        client_order_id="cli-1",
+    )
+
+    result = adapter.place_order(order)
+
+    assert result.order_id == "OID123"
+    assert captured_request is not None
+    headers = {name.lower(): value for name, value in captured_request.header_items()}
+    assert headers["api-key"] == "kraken-key"
+    signature = headers["api-sign"]
+    body_params = dict(parse_qsl(captured_request.data.decode("utf-8"))) if captured_request else {}
+    expected_signature = _expected_signature(
+        path="/0/private/AddOrder",
+        params=body_params,
+        secret=_build_credentials().secret or "",
+    )
+    assert signature == expected_signature
+    body = captured_request.data.decode("utf-8") if captured_request and captured_request.data else ""
+    assert "pair=XBTUSD" in body
+    assert "ordertype=limit" in body
+    assert "userref=cli-1" in body
+
+
+def test_cancel_order_validates_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        payload = {"error": [], "result": {"count": 1}}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.kraken.spot.urlopen", fake_urlopen)
+    adapter = KrakenSpotAdapter(_build_credentials(), environment=Environment.LIVE)
+
+    adapter.cancel_order("OID123")
+
+
+def _expected_signature(*, path: str, params: dict[str, Any], secret: str) -> str:
+    params = dict(params)
+    nonce = params.pop("nonce", None)
+    if nonce is None:
+        raise AssertionError("Brak pola nonce w parametrów podpisu")
+    sorted_items = sorted(params.items())
+    encoded_params = "&".join(f"{k}={v}" for k, v in sorted_items)
+    message = (nonce + encoded_params).encode("utf-8")
+    sha_digest = hashlib.sha256(message).digest()
+    decoded_secret = base64.b64decode(secret)
+    mac = hmac.new(decoded_secret, (path.encode("utf-8") + sha_digest), hashlib.sha512)
+    return base64.b64encode(mac.digest()).decode("utf-8")

--- a/tests/test_manage_secrets_cli.py
+++ b/tests/test_manage_secrets_cli.py
@@ -1,0 +1,195 @@
+"""Testy narzędzia CLI do zarządzania sekretami."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import manage_secrets
+
+
+class _InMemoryKeyring:
+    """Prosty backend keyring używany do testowania CLI."""
+
+    class errors:
+        class PasswordDeleteError(Exception):
+            """Wyjątek zgodny z interfejsem biblioteki keyring."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        try:
+            del self._store[(service, username)]
+        except KeyError as exc:  # pragma: no cover - zachowanie zgodne z biblioteką keyring
+            raise self.errors.PasswordDeleteError(str(exc)) from exc
+
+
+@pytest.fixture(autouse=True)
+def fake_keyring() -> types.ModuleType:
+    """Podmienia moduł ``keyring`` na implementację pamięciową."""
+
+    module = types.ModuleType("keyring")
+    backend = _InMemoryKeyring()
+    module.get_password = backend.get_password
+    module.set_password = backend.set_password
+    module.delete_password = backend.delete_password
+    module.errors = backend.errors
+    sys.modules["keyring"] = module
+    yield module
+    sys.modules.pop("keyring", None)
+
+
+@pytest.fixture(autouse=True)
+def fake_desktop_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wymusza wariant desktopowy create_default_secret_storage."""
+
+    monkeypatch.setenv("DISPLAY", ":1")
+    monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "session")
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+
+def test_store_and_show_exchange_credentials(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = manage_secrets.main(
+        [
+            "--namespace",
+            "tests.cli",
+            "store-exchange",
+            "--key",
+            "binance_paper",
+            "--key-id",
+            "pub123",
+            "--secret",
+            "sec456",
+            "--environment",
+            "paper",
+            "--permission",
+            "read",
+            "--permission",
+            "trade",
+        ]
+    )
+    assert exit_code == 0
+
+    exit_code = manage_secrets.main(
+        [
+            "--namespace",
+            "tests.cli",
+            "show-exchange",
+            "--key",
+            "binance_paper",
+            "--environment",
+            "paper",
+        ]
+    )
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "pub123" in output
+    assert "paper" in output
+    assert "sec456" not in output
+    secret_line = next(line for line in output.splitlines() if line.startswith("Sekret:"))
+    assert "*" in secret_line
+
+
+def test_store_show_and_delete_generic_secret(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = manage_secrets.main(
+        [
+            "--namespace",
+            "tests.cli",
+            "store-secret",
+            "--key",
+            "telegram_bot",
+            "--purpose",
+            "alerts",
+            "--value",
+            "token123",
+        ]
+    )
+    assert exit_code == 0
+
+    exit_code = manage_secrets.main(
+        [
+            "--namespace",
+            "tests.cli",
+            "show-secret",
+            "--key",
+            "telegram_bot",
+            "--purpose",
+            "alerts",
+        ]
+    )
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "telegram_bot" in output
+    assert "alerts" in output
+    assert "token123" not in output
+    assert "Podgląd" in output
+
+    exit_code = manage_secrets.main(
+        [
+            "--namespace",
+            "tests.cli",
+            "show-secret",
+            "--key",
+            "telegram_bot",
+            "--purpose",
+            "alerts",
+            "--reveal",
+        ]
+    )
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "token123" in output
+
+    exit_code = manage_secrets.main(
+        [
+            "--namespace",
+            "tests.cli",
+            "delete-secret",
+            "--key",
+            "telegram_bot",
+            "--purpose",
+            "alerts",
+        ]
+    )
+    assert exit_code == 0
+
+    exit_code = manage_secrets.main(
+        [
+            "--namespace",
+            "tests.cli",
+            "show-secret",
+            "--key",
+            "telegram_bot",
+            "--purpose",
+            "alerts",
+        ]
+    )
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert output == ""
+
+
+def test_show_missing_exchange_returns_error() -> None:
+    exit_code = manage_secrets.main(
+        [
+            "--namespace",
+            "tests.cli",
+            "show-exchange",
+            "--key",
+            "missing",
+            "--environment",
+            "paper",
+        ]
+    )
+    assert exit_code == 1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import sys
+
+import math
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.observability.metrics import (  # type: ignore[import-not-found]
+    CounterMetric,
+    GaugeMetric,
+    HistogramMetric,
+    MetricsRegistry,
+)
+
+
+def test_counter_tracks_values_per_labels() -> None:
+    registry = MetricsRegistry()
+    counter = registry.counter("orders_total", "Liczba zleceń")
+    counter.inc(labels={"symbol": "BTCUSDT"})
+    counter.inc(2.0, labels={"symbol": "BTCUSDT"})
+    counter.inc(labels={"symbol": "ETHUSDT"})
+
+    assert counter.value(labels={"symbol": "BTCUSDT"}) == pytest.approx(3.0)
+    assert counter.value(labels={"symbol": "ETHUSDT"}) == pytest.approx(1.0)
+
+
+def test_gauge_can_set_and_increment() -> None:
+    registry = MetricsRegistry()
+    gauge = registry.gauge("open_positions", "Liczba otwartych pozycji")
+    gauge.set(2.0, labels={"profile": "balanced"})
+    gauge.inc(labels={"profile": "balanced"})
+    gauge.dec(0.5, labels={"profile": "balanced"})
+
+    assert gauge.value(labels={"profile": "balanced"}) == pytest.approx(2.5)
+
+
+def test_histogram_records_buckets_and_snapshot() -> None:
+    registry = MetricsRegistry()
+    histogram = registry.histogram(
+        "latency_seconds",
+        "Latency prób",
+        buckets=(0.1, 0.5, 1.0),
+    )
+
+    histogram.observe(0.05, labels={"status": "ok"})
+    histogram.observe(0.3, labels={"status": "ok"})
+    histogram.observe(0.9, labels={"status": "ok"})
+
+    snapshot = histogram.snapshot(labels={"status": "ok"})
+    assert snapshot.count == 3
+    assert snapshot.counts[0.1] == 1
+    assert snapshot.counts[0.5] == 2
+    assert snapshot.counts[1.0] == 3
+    assert snapshot.counts[math.inf] == 3
+    assert snapshot.sum == pytest.approx(1.25)
+
+
+def test_render_prometheus_format_contains_headers() -> None:
+    registry = MetricsRegistry()
+    registry.counter("test_metric", "Opis").inc()
+    output = registry.render_prometheus()
+    assert "# HELP test_metric Opis" in output
+    assert "# TYPE test_metric counter" in output
+
+
+def test_registry_get_returns_metric_instance() -> None:
+    registry = MetricsRegistry()
+    counter = registry.counter("executions_total", "Licznik")
+    retrieved = registry.get("executions_total")
+    assert isinstance(retrieved, CounterMetric)
+    assert retrieved is counter
+
+

--- a/tests/test_ohlcv_backfill.py
+++ b/tests/test_ohlcv_backfill.py
@@ -1,0 +1,108 @@
+"""Testy procesu backfillu OHLCV."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.data.base import CacheStorage, DataSource, OHLCVRequest, OHLCVResponse
+from bot_core.data.ohlcv.backfill import OHLCVBackfillService
+from bot_core.data.ohlcv.cache import CachedOHLCVSource
+
+
+class InMemoryStorage(CacheStorage):
+    """Prosta pamięciowa implementacja magazynu do testów."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, Mapping[str, Sequence[Sequence[float]]]] = {}
+        self._metadata: dict[str, str] = {}
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        if key not in self._store:
+            raise KeyError(key)
+        return self._store[key]
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        self._store[key] = payload
+
+    def metadata(self) -> MutableMapping[str, str]:
+        return self._metadata
+
+    def latest_timestamp(self, key: str) -> float | None:
+        try:
+            rows = self._store[key]["rows"]
+        except KeyError:
+            return None
+        if not rows:
+            return None
+        return float(rows[-1][0])
+
+
+@dataclass(slots=True)
+class StubSource(DataSource):
+    """Źródło danych generujące deterministyczne świece dla testów."""
+
+    interval_ms: int
+
+    def fetch_ohlcv(self, request: OHLCVRequest) -> OHLCVResponse:
+        rows: list[Sequence[float]] = []
+        current = request.start
+        limit = request.limit or 1000
+        while current <= request.end and len(rows) < limit:
+            rows.append([float(current), 1.0, 2.0, 0.5, 1.5, 10.0])
+            current += self.interval_ms
+        return OHLCVResponse(columns=("open_time", "open", "high", "low", "close", "volume"), rows=rows)
+
+    def warm_cache(self, symbols: Iterable[str], intervals: Iterable[str]) -> None:  # pragma: no cover
+        del symbols, intervals
+
+
+def test_backfill_downloads_missing_candles() -> None:
+    storage = InMemoryStorage()
+    cached = CachedOHLCVSource(storage=storage, upstream=StubSource(interval_ms=86_400_000))
+    service = OHLCVBackfillService(cached, chunk_limit=2)
+
+    summaries = service.synchronize(
+        symbols=("BTCUSDT",),
+        interval="1d",
+        start=0,
+        end=86_400_000 * 4,
+    )
+
+    summary = summaries[0]
+    assert summary.fetched_candles == 5
+    assert summary.skipped_candles == 0
+
+
+def test_backfill_skips_up_to_date_symbol() -> None:
+    storage = InMemoryStorage()
+    # Wstępnie zapisujemy trzy świece
+    storage.write(
+        "BTCUSDT::1d",
+        {
+            "columns": ("open_time", "open", "high", "low", "close", "volume"),
+            "rows": [
+                [0.0, 1.0, 2.0, 0.5, 1.5, 10.0],
+                [86_400_000.0, 1.0, 2.0, 0.5, 1.5, 10.0],
+                [172_800_000.0, 1.0, 2.0, 0.5, 1.5, 10.0],
+            ],
+        },
+    )
+
+    cached = CachedOHLCVSource(storage=storage, upstream=StubSource(interval_ms=86_400_000))
+    service = OHLCVBackfillService(cached, chunk_limit=2)
+
+    summaries = service.synchronize(
+        symbols=("BTCUSDT",),
+        interval="1d",
+        start=0,
+        end=172_800_000,
+    )
+
+    summary = summaries[0]
+    assert summary.fetched_candles == 0
+    assert summary.skipped_candles == 3

--- a/tests/test_paper_execution.py
+++ b/tests/test_paper_execution.py
@@ -1,0 +1,168 @@
+"""Testy symulatora paper trading."""
+from __future__ import annotations
+
+import pytest
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.execution import (  # type: ignore[import-not-found]
+    ExecutionContext,
+    InsufficientBalanceError,
+    MarketMetadata,
+    PaperTradingExecutionService,
+)
+from bot_core.exchanges.base import OrderRequest
+from bot_core.observability.metrics import CounterMetric, HistogramMetric, MetricsRegistry
+
+
+def _default_service(**kwargs: object) -> PaperTradingExecutionService:
+    markets = {
+        "BTCUSDT": MarketMetadata(
+            base_asset="BTC",
+            quote_asset="USDT",
+            min_quantity=0.001,
+            min_notional=10.0,
+            step_size=0.001,
+        )
+    }
+    balances = {"USDT": 100_000.0, "BTC": 1.0}
+    return PaperTradingExecutionService(markets, initial_balances=balances, **kwargs)
+
+
+def _default_context() -> ExecutionContext:
+    return ExecutionContext(
+        portfolio_id="paper-1",
+        risk_profile="balanced",
+        environment="paper",
+        metadata={},
+    )
+
+
+def test_buy_order_consumes_quote_balance() -> None:
+    service = _default_service()
+    context = _default_context()
+    request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.5,
+        order_type="market",
+        price=20_000.0,
+    )
+
+    result = service.execute(request, context)
+
+    assert result.status == "filled"
+    balances = service.balances()
+    assert balances["BTC"] > 1.0
+    assert balances["USDT"] < 100_000.0
+
+
+def test_sell_requires_position() -> None:
+    service = _default_service()
+    context = _default_context()
+    request = OrderRequest(
+        symbol="BTCUSDT",
+        side="sell",
+        quantity=5.0,
+        order_type="market",
+        price=20_000.0,
+    )
+
+    with pytest.raises(InsufficientBalanceError):
+        service.execute(request, context)
+
+
+def test_slippage_affects_price_directionally() -> None:
+    service = _default_service(slippage_bps=10.0)
+    context = _default_context()
+
+    buy_request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.1,
+        order_type="market",
+        price=20_000.0,
+    )
+    sell_request = OrderRequest(
+        symbol="BTCUSDT",
+        side="sell",
+        quantity=0.1,
+        order_type="market",
+        price=20_000.0,
+    )
+
+    buy_result = service.execute(buy_request, context)
+    sell_result = service.execute(sell_request, context)
+
+    assert buy_result.avg_price and sell_result.avg_price
+    assert buy_result.avg_price > 20_000.0
+    assert sell_result.avg_price < 20_000.0
+
+
+def test_ledger_contains_audit_entries() -> None:
+    service = _default_service()
+    context = _default_context()
+
+    service.execute(
+        OrderRequest(
+            symbol="BTCUSDT",
+            side="buy",
+            quantity=0.2,
+            order_type="limit",
+            price=19_500.0,
+        ),
+        context,
+    )
+
+    entries = list(service.ledger())
+    assert entries
+    first = entries[0]
+    assert first["symbol"] == "BTCUSDT"
+    assert first["status"] == "filled"
+    assert first["fee"] > 0
+
+
+def test_metrics_are_recorded_for_success_and_failures() -> None:
+    registry = MetricsRegistry()
+    service = _default_service(metrics=registry)
+    context = _default_context()
+
+    successful = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.1,
+        order_type="market",
+        price=20_000.0,
+    )
+    failed = OrderRequest(
+        symbol="BTCUSDT",
+        side="sell",
+        quantity=5.0,
+        order_type="market",
+        price=20_000.0,
+    )
+
+    service.execute(successful, context)
+
+    with pytest.raises(InsufficientBalanceError):
+        service.execute(failed, context)
+
+    orders_total = registry.get("paper_orders_total")
+    assert isinstance(orders_total, CounterMetric)
+    assert orders_total.value(labels={"symbol": "BTCUSDT", "side": "buy"}) == pytest.approx(1.0)
+
+    rejected_total = registry.get("paper_orders_rejected_total")
+    assert rejected_total.value(labels={"symbol": "BTCUSDT", "reason": "insufficient_balance"}) == pytest.approx(1.0)
+
+    latency_hist = registry.get("paper_execution_latency_seconds")
+    assert isinstance(latency_hist, HistogramMetric)
+    snapshot = latency_hist.snapshot(labels={"symbol": "BTCUSDT", "status": "filled"})
+    assert snapshot.count == 1
+    rejected_snapshot = latency_hist.snapshot(labels={"symbol": "BTCUSDT", "status": "rejected"})
+    assert rejected_snapshot.count == 1
+
+    traded_notional = registry.get("paper_traded_notional_total")
+    assert traded_notional.value(labels={"symbol": "BTCUSDT", "side": "buy"}) > 0

--- a/tests/test_run_paper_session.py
+++ b/tests/test_run_paper_session.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import sys
+from typing import Iterable, Mapping, Sequence
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import scripts.run_paper_session as runner
+from bot_core.alerts import DefaultAlertRouter, InMemoryAlertAuditLog
+from bot_core.alerts.base import AlertChannel, AlertMessage
+from bot_core.config.models import (
+    CoreConfig,
+    DailyTrendMomentumStrategyConfig,
+    EnvironmentConfig,
+    InstrumentBackfillWindow,
+    InstrumentConfig,
+    InstrumentUniverseConfig,
+    RiskProfileConfig,
+)
+from bot_core.data.base import OHLCVResponse
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderResult,
+)
+from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.runtime.bootstrap import BootstrapContext
+
+
+class _DummySecretStorage:
+    def get_secret(self, key: str) -> str | None:  # noqa: D401 - implementacja testowa
+        return "{}"
+
+    def set_secret(self, key: str, value: str) -> None:  # noqa: D401 - implementacja testowa
+        return None
+
+    def delete_secret(self, key: str) -> None:  # noqa: D401 - implementacja testowa
+        return None
+
+
+class _DummyAdapter(ExchangeAdapter):
+    def __init__(self) -> None:
+        super().__init__(ExchangeCredentials(key_id="dummy", environment=Environment.PAPER))
+
+    def configure_network(self, *, ip_allowlist: Sequence[str] | None = None) -> None:  # noqa: D401, ARG002
+        return None
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        return AccountSnapshot(
+            balances={"USDT": 100_000.0},
+            total_equity=100_000.0,
+            available_margin=100_000.0,
+            maintenance_margin=0.0,
+        )
+
+    def fetch_symbols(self) -> Iterable[str]:  # pragma: no cover - nieużywane w testach
+        return ()
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: int | None = None,
+        end: int | None = None,
+        limit: int | None = None,
+    ) -> Sequence[Sequence[float]]:  # pragma: no cover - nieużywane
+        return ()
+
+    def place_order(self, request):  # pragma: no cover - bezpieczeństwo testów
+        raise NotImplementedError
+
+    def cancel_order(self, order_id: str, *, symbol: str | None = None) -> None:  # pragma: no cover - bezpieczeństwo
+        raise NotImplementedError
+
+    def stream_public_data(self, *, channels: Sequence[str]):  # pragma: no cover - bezpieczeństwo
+        raise NotImplementedError
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # pragma: no cover - bezpieczeństwo
+        raise NotImplementedError
+
+
+class _DummyChannel(AlertChannel):
+    def __init__(self) -> None:
+        self.name = "dummy"
+        self.messages: list[AlertMessage] = []
+
+    def send(self, message: AlertMessage) -> None:
+        self.messages.append(message)
+
+    def health_check(self) -> Mapping[str, str]:
+        return {"status": "ok"}
+
+
+class _DummyExecution:
+    def __init__(self, markets, *, initial_balances=None, **_: object) -> None:
+        self.markets = markets
+        self.initial_balances = dict(initial_balances or {})
+        self.requests: list = []
+
+    def execute(self, request, context):  # noqa: ARG002 - testowy stub
+        self.requests.append(request)
+        return OrderResult(
+            order_id="paper-1",
+            status="filled",
+            filled_quantity=request.quantity,
+            avg_price=request.price or 100.0,
+            raw_response={"source": "test"},
+        )
+
+    def cancel(self, order_id: str, context) -> None:  # noqa: ARG002 - metoda wymagana przez interfejs
+        return None
+
+    def flush(self) -> None:
+        return None
+
+    def balances(self) -> Mapping[str, float]:
+        return {
+            "USDT": self.initial_balances.get("USDT", 0.0),
+            "BTC": self.initial_balances.get("BTC", 0.0)
+            + sum(req.quantity for req in self.requests if req.side.lower() == "buy"),
+        }
+
+
+class _DummyDataSource:
+    def __init__(self, rows: Sequence[Sequence[float]]) -> None:
+        self._response = OHLCVResponse(
+            columns=("open_time", "open", "high", "low", "close", "volume"),
+            rows=rows,
+        )
+
+    def fetch_ohlcv(self, request):  # noqa: ARG002 - testowy stub
+        return self._response
+
+
+@pytest.fixture
+def trending_rows() -> list[list[float]]:
+    rows: list[list[float]] = []
+    base = 100.0
+    for idx in range(10):
+        base += 1.0
+        rows.append(
+            [
+                float(idx * 86_400_000),
+                base - 1.0,
+                base + 0.5,
+                base - 1.5,
+                base,
+                1_000.0,
+            ]
+        )
+    return rows
+
+
+def _build_core_config(tmp_path: Path) -> tuple[CoreConfig, EnvironmentConfig]:
+    env_cfg = EnvironmentConfig(
+        name="binance_paper",
+        exchange="binance_spot",
+        environment=Environment.PAPER,
+        keychain_key="paper_key",
+        data_cache_path=str(tmp_path / "cache"),
+        risk_profile="balanced",
+        alert_channels=[],
+        ip_allowlist=[],
+        credential_purpose="trading",
+        instrument_universe="core_universe",
+    )
+    risk_cfg = RiskProfileConfig(
+        name="balanced",
+        max_daily_loss_pct=0.015,
+        max_position_pct=0.05,
+        target_volatility=0.11,
+        max_leverage=3.0,
+        stop_loss_atr_multiple=1.5,
+        max_open_positions=5,
+        hard_drawdown_pct=0.10,
+    )
+    instrument = InstrumentConfig(
+        name="BTC_USDT",
+        base_asset="BTC",
+        quote_asset="USDT",
+        categories=("core",),
+        exchange_symbols={"binance_spot": "BTCUSDT"},
+        backfill_windows=(
+            InstrumentBackfillWindow(interval="1d", lookback_days=365),
+        ),
+    )
+    universe = InstrumentUniverseConfig(
+        name="core_universe",
+        description="Testowe uniwersum",
+        instruments=(instrument,),
+    )
+    strategy_cfg = DailyTrendMomentumStrategyConfig(
+        name="core_daily_trend",
+        fast_ma=3,
+        slow_ma=5,
+        breakout_lookback=5,
+        momentum_window=3,
+        atr_window=3,
+        atr_multiplier=2.0,
+        min_trend_strength=0.0,
+        min_momentum=0.0,
+    )
+    core_config = CoreConfig(
+        environments={"binance_paper": env_cfg},
+        risk_profiles={"balanced": risk_cfg},
+        instrument_universes={"core_universe": universe},
+        strategies={"core_daily_trend": strategy_cfg},
+        reporting={},
+        sms_providers={},
+        telegram_channels={},
+        email_channels={},
+        signal_channels={},
+        whatsapp_channels={},
+        messenger_channels={},
+    )
+    return core_config, env_cfg
+
+
+def _prepare_context(tmp_path: Path) -> tuple[BootstrapContext, _DummyChannel, ThresholdRiskEngine]:
+    core_config, env_cfg = _build_core_config(tmp_path)
+    risk_engine = ThresholdRiskEngine()
+    audit_log = InMemoryAlertAuditLog()
+    channel = _DummyChannel()
+    router = DefaultAlertRouter(audit_log=audit_log)
+    router.register(channel)
+    context = BootstrapContext(
+        core_config=core_config,
+        environment=env_cfg,
+        credentials=ExchangeCredentials(key_id="paper", environment=Environment.PAPER),
+        adapter=_DummyAdapter(),
+        risk_engine=risk_engine,
+        alert_router=router,
+        alert_channels={channel.name: channel},
+        audit_log=audit_log,
+    )
+    return context, channel, risk_engine
+
+
+def test_run_paper_session_executes_single_iteration(monkeypatch, tmp_path, caplog, trending_rows):
+    context, channel, _ = _prepare_context(tmp_path)
+
+    monkeypatch.setattr(runner, "create_default_secret_storage", lambda **_: _DummySecretStorage())
+
+    def _fake_bootstrap(environment_name: str, *, config_path: str, secret_manager, adapter_factories=None):  # noqa: ARG001
+        assert environment_name == "binance_paper"
+        return context
+
+    monkeypatch.setattr(runner, "bootstrap_environment", _fake_bootstrap)
+
+    executed: list[_DummyExecution] = []
+
+    def _execution_factory(*args, **kwargs):
+        instance = _DummyExecution(*args, **kwargs)
+        executed.append(instance)
+        return instance
+
+    monkeypatch.setattr(runner, "PaperTradingExecutionService", _execution_factory)
+
+    data_source = _DummyDataSource(trending_rows)
+    monkeypatch.setattr(runner, "_build_data_source", lambda adapter, cache_path: data_source)
+
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text("{}\n", encoding="utf-8")
+
+    caplog.set_level(logging.INFO, logger="scripts.run_paper_session")
+
+    exit_code = runner.main(
+        [
+            "--config",
+            str(config_path),
+            "--environment",
+            "binance_paper",
+            "--strategy",
+            "core_daily_trend",
+            "--interval",
+            "1d",
+        ]
+    )
+
+    assert exit_code == 0
+    assert executed and executed[0].requests, "Powinno zostać złożone co najmniej jedno zlecenie paper trading"
+    assert channel.messages, "Alerty powinny zostać zapisane w audycie"
+    assert any("Zrealizowano zlecenie" in message for message in caplog.messages)
+
+
+def test_run_paper_session_errors_when_universe_empty(monkeypatch, tmp_path, caplog):
+    context, _, _ = _prepare_context(tmp_path)
+    context.core_config.instrument_universes.clear()
+
+    monkeypatch.setattr(runner, "create_default_secret_storage", lambda **_: _DummySecretStorage())
+    monkeypatch.setattr(runner, "bootstrap_environment", lambda *_, **__: context)
+    monkeypatch.setattr(runner, "_build_data_source", lambda *_, **__: _DummyDataSource([]))
+
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text("{}\n", encoding="utf-8")
+
+    caplog.set_level(logging.INFO, logger="scripts.run_paper_session")
+    exit_code = runner.main([
+        "--config",
+        str(config_path),
+        "--environment",
+        "binance_paper",
+    ])
+
+    assert exit_code == 1
+    assert any("uniwersum" in message for message in caplog.messages)

--- a/tests/test_run_paper_session.py
+++ b/tests/test_run_paper_session.py
@@ -238,6 +238,8 @@ def _prepare_context(tmp_path: Path) -> tuple[BootstrapContext, _DummyChannel, T
         alert_router=router,
         alert_channels={channel.name: channel},
         audit_log=audit_log,
+        instrument_universe=None,
+        instruments={},
     )
     return context, channel, risk_engine
 

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.alerts import EmailChannel, SMSChannel, TelegramChannel
+from bot_core.exchanges.base import AccountSnapshot, Environment, OrderRequest
+from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.runtime import BootstrapContext, bootstrap_environment
+from bot_core.security import SecretManager, SecretStorage
+
+
+class _MemorySecretStorage(SecretStorage):
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    def get_secret(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    def set_secret(self, key: str, value: str) -> None:
+        self._store[key] = value
+
+    def delete_secret(self, key: str) -> None:
+        self._store.pop(key, None)
+
+
+def _write_config(tmp_path: Path) -> Path:
+    content = """
+    risk_profiles:
+      balanced:
+        max_daily_loss_pct: 0.015
+        max_position_pct: 0.05
+        target_volatility: 0.11
+        max_leverage: 3.0
+        stop_loss_atr_multiple: 1.5
+        max_open_positions: 5
+        hard_drawdown_pct: 0.10
+    environments:
+      binance_paper:
+        exchange: binance_spot
+        environment: paper
+        keychain_key: binance_paper_key
+        credential_purpose: trading
+        data_cache_path: ./var/data/binance_paper
+        risk_profile: balanced
+        alert_channels: ["telegram:primary", "email:ops", "sms:orange_local"]
+        ip_allowlist: ["127.0.0.1"]
+    reporting: {}
+    alerts:
+      telegram_channels:
+        primary:
+          chat_id: "123456789"
+          token_secret: telegram_token
+      email_channels:
+        ops:
+          host: smtp.example.com
+          port: 587
+          from_address: bot@example.com
+          recipients: ["ops@example.com"]
+          credential_secret: smtp_credentials
+      sms_providers:
+        orange_local:
+          provider: orange_pl
+          api_base_url: https://api.orange.pl/sms/v1
+          from_number: BOT-ORANGE
+          recipients: ["+48555111222"]
+          allow_alphanumeric_sender: true
+          sender_id: BOT-ORANGE
+          credential_key: sms_orange
+    """
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(content, encoding="utf-8")
+    return config_path
+
+
+def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
+    storage = _MemorySecretStorage()
+    manager = SecretManager(storage, namespace="tests")
+
+    config_path = _write_config(tmp_path)
+    credentials_payload = {
+        "key_id": "paper-key",
+        "secret": "paper-secret",
+        "passphrase": None,
+        "permissions": ["read", "trade"],
+        "environment": Environment.PAPER.value,
+    }
+    storage.set_secret("tests:binance_paper_key:trading", json.dumps(credentials_payload))
+    manager.store_secret_value("telegram_token", "telegram-secret", purpose="alerts:telegram")
+    manager.store_secret_value(
+        "smtp_credentials",
+        json.dumps({"username": "bot", "password": "secret"}),
+        purpose="alerts:email",
+    )
+    manager.store_secret_value(
+        "sms_orange",
+        json.dumps({"account_sid": "AC123", "auth_token": "token"}),
+        purpose="alerts:sms",
+    )
+
+    context = bootstrap_environment(
+        "binance_paper", config_path=config_path, secret_manager=manager
+    )
+
+    assert isinstance(context, BootstrapContext)
+    assert context.environment.name == "binance_paper"
+    assert context.credentials.key_id == "paper-key"
+    assert context.adapter.credentials.key_id == "paper-key"
+
+    assert isinstance(context.risk_engine, ThresholdRiskEngine)
+    result = context.risk_engine.apply_pre_trade_checks(
+        OrderRequest(symbol="BTCUSDT", side="buy", quantity=0.2, order_type="limit", price=100.0),
+        account=AccountSnapshot(
+            balances={"USDT": 1000.0},
+            total_equity=1000.0,
+            available_margin=1000.0,
+            maintenance_margin=0.0,
+        ),
+        profile_name="balanced",
+    )
+    assert result.allowed is True
+
+    assert set(context.alert_channels.keys()) == {
+        "telegram:primary",
+        "email:ops",
+        "sms:orange_local",
+    }
+    assert isinstance(context.alert_channels["telegram:primary"], TelegramChannel)
+    assert isinstance(context.alert_channels["email:ops"], EmailChannel)
+    assert isinstance(context.alert_channels["sms:orange_local"], SMSChannel)
+    assert len(context.alert_router.channels) == 3
+    assert context.alert_router.audit_log is context.audit_log
+
+    # Health check nie powinien zgłaszać wyjątków dla świeżo zainicjalizowanych kanałów.
+    snapshot = context.alert_router.health_snapshot()
+    assert snapshot["telegram:primary"]["status"] == "ok"
+
+    assert context.risk_engine.should_liquidate(profile_name="balanced") is False
+
+
+
+def test_bootstrap_environment_supports_zonda(tmp_path: Path) -> None:
+    storage = _MemorySecretStorage()
+    manager = SecretManager(storage, namespace="tests")
+
+    config_content = """
+    risk_profiles:
+      conservative:
+        max_daily_loss_pct: 0.01
+        max_position_pct: 0.03
+        target_volatility: 0.07
+        max_leverage: 2.0
+        stop_loss_atr_multiple: 1.0
+        max_open_positions: 3
+        hard_drawdown_pct: 0.05
+    environments:
+      zonda_live:
+        exchange: zonda_spot
+        environment: live
+        keychain_key: zonda_live_key
+        credential_purpose: trading
+        data_cache_path: ./var/data/zonda_live
+        risk_profile: conservative
+        alert_channels: ["telegram:primary"]
+        ip_allowlist: []
+    reporting: {}
+    alerts:
+      telegram_channels:
+        primary:
+          chat_id: "123"
+          token_secret: telegram_token
+      email_channels: {}
+      sms_providers: {}
+      signal_channels: {}
+      whatsapp_channels: {}
+      messenger_channels: {}
+    """
+
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(config_content, encoding="utf-8")
+
+    credentials_payload = {
+        "key_id": "zonda-key",
+        "secret": "zonda-secret",
+        "permissions": ["read", "trade"],
+        "environment": Environment.LIVE.value,
+    }
+    storage.set_secret("tests:zonda_live_key:trading", json.dumps(credentials_payload))
+    manager.store_secret_value("telegram_token", "tg-token", purpose="alerts:telegram")
+
+    context = bootstrap_environment("zonda_live", config_path=config_path, secret_manager=manager)
+
+    assert context.adapter.name == "zonda_spot"
+    assert context.credentials.key_id == "zonda-key"
+    assert context.environment.exchange == "zonda_spot"

--- a/tests/test_security_manager.py
+++ b/tests/test_security_manager.py
@@ -1,0 +1,197 @@
+"""Testy warstwy zarządzania sekretami wykorzystującej natywne keychainy."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import Environment, ExchangeCredentials
+from bot_core.security import (
+    EncryptedFileSecretStorage,
+    KeyringSecretStorage,
+    SecretManager,
+    SecretStorageError,
+    create_default_secret_storage,
+)
+
+
+class _InMemoryKeyring:
+    """Minimalna implementacja back-endu keyring na potrzeby testów."""
+
+    class errors:
+        class PasswordDeleteError(Exception):
+            """Wyjątek naśladujący oryginalny interfejs biblioteki keyring."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        try:
+            del self._store[(service, username)]
+        except KeyError as exc:
+            raise self.errors.PasswordDeleteError(str(exc)) from exc
+
+
+@pytest.fixture(autouse=True)
+def fake_keyring() -> types.ModuleType:
+    """Podmienia moduł ``keyring`` na wariant in-memory, aby testy były deterministyczne."""
+
+    module = types.ModuleType("keyring")
+    backend = _InMemoryKeyring()
+    module.get_password = backend.get_password
+    module.set_password = backend.set_password
+    module.delete_password = backend.delete_password
+    module.errors = backend.errors
+    sys.modules["keyring"] = module
+    yield module
+    sys.modules.pop("keyring", None)
+
+
+def test_roundtrip_store_and_load_credentials() -> None:
+    storage = KeyringSecretStorage(service_name="unit.test")
+    manager = SecretManager(storage, namespace="tests")
+
+    credentials = ExchangeCredentials(
+        key_id="abc",
+        secret="topsecret",
+        passphrase="phrase",
+        environment=Environment.PAPER,
+        permissions=("read", "trade"),
+    )
+
+    manager.store_exchange_credentials("binance_paper_trading", credentials)
+    loaded = manager.load_exchange_credentials(
+        "binance_paper_trading", expected_environment=Environment.PAPER
+    )
+
+    assert loaded.key_id == credentials.key_id
+    assert loaded.secret == credentials.secret
+    assert loaded.passphrase == credentials.passphrase
+    assert loaded.permissions == credentials.permissions
+    assert loaded.environment == Environment.PAPER
+
+
+def test_load_missing_secret_raises_error() -> None:
+    storage = KeyringSecretStorage(service_name="unit.test")
+    manager = SecretManager(storage)
+
+    with pytest.raises(SecretStorageError):
+        manager.load_exchange_credentials("missing", expected_environment=Environment.LIVE)
+
+
+def test_environment_mismatch_detected() -> None:
+    storage = KeyringSecretStorage(service_name="unit.test")
+    manager = SecretManager(storage)
+
+    credentials = ExchangeCredentials(
+        key_id="abc",
+        secret="topsecret",
+        passphrase=None,
+        environment=Environment.PAPER,
+        permissions=("read",),
+    )
+
+    manager.store_exchange_credentials("binance_paper", credentials)
+
+    with pytest.raises(SecretStorageError) as excinfo:
+        manager.load_exchange_credentials("binance_paper", expected_environment=Environment.LIVE)
+
+    assert "nie pasuje" in str(excinfo.value)
+
+
+def test_store_and_load_generic_secret() -> None:
+    storage = KeyringSecretStorage(service_name="unit.test")
+    manager = SecretManager(storage, namespace="tests")
+
+    manager.store_secret_value("telegram_bot", "token123", purpose="alerts")
+    loaded = manager.load_secret_value("telegram_bot", purpose="alerts")
+
+    assert loaded == "token123"
+
+    manager.delete_secret_value("telegram_bot", purpose="alerts")
+
+    with pytest.raises(SecretStorageError):
+        manager.load_secret_value("telegram_bot", purpose="alerts")
+
+
+def test_encrypted_file_secret_storage_roundtrip(tmp_path: Path) -> None:
+    pytest.importorskip("cryptography.fernet")
+
+    storage_path = tmp_path / "secrets.age"
+    storage = EncryptedFileSecretStorage(storage_path, passphrase="haslo")
+
+    assert storage.get_secret("api") is None
+    storage.set_secret("api", "sekret")
+    assert storage.get_secret("api") == "sekret"
+
+    storage.delete_secret("api")
+    assert storage.get_secret("api") is None
+
+    storage_again = EncryptedFileSecretStorage(storage_path, passphrase="haslo")
+    assert storage_again.get_secret("api") is None
+
+
+def test_encrypted_file_secret_storage_persists_between_instances(tmp_path: Path) -> None:
+    pytest.importorskip("cryptography.fernet")
+
+    storage_path = tmp_path / "secrets.age"
+    first = EncryptedFileSecretStorage(storage_path, passphrase="tajne")
+    first.set_secret("binance", "key123")
+
+    second = EncryptedFileSecretStorage(storage_path, passphrase="tajne")
+    assert second.get_secret("binance") == "key123"
+
+
+def test_create_default_secret_storage_linux_gui(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DISPLAY", ":1")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "")
+    monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "address")
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    storage = create_default_secret_storage(namespace="unit.gui")
+    assert isinstance(storage, KeyringSecretStorage)
+
+
+def test_create_default_secret_storage_linux_headless(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    pytest.importorskip("cryptography.fernet")
+
+    storage = create_default_secret_storage(
+        namespace="unit.headless",
+        headless_passphrase="bardzotajne",
+        headless_path=tmp_path / "vault.age",
+    )
+
+    assert isinstance(storage, EncryptedFileSecretStorage)
+    storage.set_secret("kraken", "sekret")
+
+    reloaded = EncryptedFileSecretStorage(tmp_path / "vault.age", passphrase="bardzotajne")
+    assert reloaded.get_secret("kraken") == "sekret"
+
+
+def test_create_default_secret_storage_headless_requires_passphrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    with pytest.raises(SecretStorageError):
+        create_default_secret_storage(headless_path=tmp_path / "vault.age")

--- a/tests/test_trading_session.py
+++ b/tests/test_trading_session.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from bot_core.alerts import DefaultAlertRouter, InMemoryAlertAuditLog
+from bot_core.alerts.base import AlertChannel, AlertMessage
+from bot_core.execution.base import ExecutionContext, ExecutionService
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeCredentials,
+    OrderRequest,
+    OrderResult,
+)
+from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.profiles.manual import ManualProfile
+from bot_core.runtime.session import InstrumentConfig, TradingSession
+from bot_core.strategies.base import MarketSnapshot, StrategyEngine, StrategySignal
+
+
+class _StaticStrategy(StrategyEngine):
+    def __init__(self, signals: Sequence[StrategySignal]) -> None:
+        self._signals = list(signals)
+
+    def on_data(self, snapshot: MarketSnapshot) -> Sequence[StrategySignal]:  # noqa: ARG002
+        return list(self._signals)
+
+    def warm_up(self, history: Sequence[MarketSnapshot]) -> None:  # noqa: D401, ARG002 - brak dodatkowych działań
+        """Strategia statyczna nie wymaga rozgrzewania."""
+        return None
+
+
+class _MemoryExecutionService(ExecutionService):
+    def __init__(self) -> None:
+        self.requests: list[OrderRequest] = []
+        self.contexts: list[ExecutionContext] = []
+
+    def execute(self, request: OrderRequest, context: ExecutionContext) -> OrderResult:
+        self.requests.append(request)
+        self.contexts.append(context)
+        return OrderResult(
+            order_id="exec-1",
+            status="filled",
+            filled_quantity=request.quantity,
+            avg_price=request.price,
+            raw_response={"source": "test"},
+        )
+
+    def cancel(self, order_id: str, context: ExecutionContext) -> None:  # noqa: ARG002 - tylko interfejs
+        return None
+
+    def flush(self) -> None:
+        return None
+
+
+class _StubAdapter(ExchangeAdapter):
+    def __init__(self, snapshot: AccountSnapshot) -> None:
+        super().__init__(ExchangeCredentials(key_id="stub"))
+        self._snapshot = snapshot
+
+    def configure_network(self, *, ip_allowlist: Sequence[str] | None = None) -> None:  # noqa: D401, ARG002
+        """Konfiguracja sieciowa nie jest potrzebna w testach."""
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        return self._snapshot
+
+    def fetch_symbols(self) -> Iterable[str]:
+        return []
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: int | None = None,
+        end: int | None = None,
+        limit: int | None = None,
+    ) -> Sequence[Sequence[float]]:  # noqa: D401, ARG002
+        """Nie korzystamy z danych OHLCV w testach runtime."""
+        return []
+
+    def place_order(self, request: OrderRequest) -> OrderResult:  # pragma: no cover - nieużywane w tym teście
+        raise NotImplementedError
+
+    def cancel_order(self, order_id: str, *, symbol: str | None = None) -> None:  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+    def stream_public_data(self, *, channels: Sequence[str]):  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+    def stream_private_data(self, *, channels: Sequence[str]):  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+
+class _DummyChannel(AlertChannel):
+    def __init__(self) -> None:
+        self.name = "dummy"
+        self.messages: list[AlertMessage] = []
+
+    def send(self, message: AlertMessage) -> None:
+        self.messages.append(message)
+
+    def health_check(self) -> Mapping[str, str]:
+        return {"status": "ok"}
+
+
+def _build_profile(name: str) -> ManualProfile:
+    return ManualProfile(
+        name=name,
+        max_positions=5,
+        max_leverage=3.0,
+        drawdown_limit=0.10,
+        daily_loss_limit=0.015,
+        max_position_pct=0.05,
+        target_volatility=0.11,
+        stop_loss_atr_multiple=1.5,
+    )
+
+
+def test_trading_session_executes_signal_and_sends_alert() -> None:
+    profile = _build_profile("balanced")
+    risk_engine = ThresholdRiskEngine()
+    risk_engine.register_profile(profile)
+
+    execution = _MemoryExecutionService()
+    adapter = _StubAdapter(
+        AccountSnapshot(
+            balances={"USDT": 60000.0, "BTC": 0.0},
+            total_equity=100000.0,
+            available_margin=60000.0,
+            maintenance_margin=0.0,
+        )
+    )
+
+    channel = _DummyChannel()
+    router = DefaultAlertRouter(audit_log=InMemoryAlertAuditLog())
+    router.register(channel)
+
+    strategy = _StaticStrategy(
+        [
+            StrategySignal(
+                symbol="BTCUSDT",
+                side="buy",
+                confidence=0.8,
+                metadata={
+                    "stop_price": 19000.0,
+                    "atr": 1000.0,
+                },
+            )
+        ]
+    )
+
+    session = TradingSession(
+        strategy=strategy,
+        strategy_name="daily_trend",
+        adapter=adapter,
+        risk_engine=risk_engine,
+        risk_profile=profile,
+        execution=execution,
+        alert_router=router,
+        instruments={
+            "BTCUSDT": InstrumentConfig(
+                symbol="BTCUSDT",
+                base_asset="BTC",
+                quote_asset="USDT",
+                min_quantity=0.001,
+                min_notional=10.0,
+                step_size=0.001,
+            )
+        },
+        environment=Environment.PAPER,
+        portfolio_id="core",
+    )
+
+    snapshot = MarketSnapshot(
+        symbol="BTCUSDT",
+        timestamp=1_700_000_000,
+        open=20000.0,
+        high=20500.0,
+        low=19800.0,
+        close=20000.0,
+        volume=123.0,
+    )
+
+    results = session.process_snapshot(snapshot)
+
+    assert len(results) == 1
+    request = execution.requests[0]
+    assert pytest.approx(request.quantity, rel=1e-3) == 0.2
+    assert channel.messages, "Kanał powinien otrzymać alert po realizacji zlecenia."
+    message = channel.messages[-1]
+    assert message.category == "trade"
+    assert message.severity == "info"
+
+
+def test_trading_session_reports_risk_rejection() -> None:
+    profile = ManualProfile(
+        name="tight",
+        max_positions=0,
+        max_leverage=1.0,
+        drawdown_limit=0.05,
+        daily_loss_limit=0.01,
+        max_position_pct=0.05,
+        target_volatility=0.05,
+        stop_loss_atr_multiple=1.0,
+    )
+    risk_engine = ThresholdRiskEngine()
+    risk_engine.register_profile(profile)
+
+    execution = _MemoryExecutionService()
+    adapter = _StubAdapter(
+        AccountSnapshot(
+            balances={"USDT": 60000.0},
+            total_equity=100000.0,
+            available_margin=60000.0,
+            maintenance_margin=0.0,
+        )
+    )
+
+    channel = _DummyChannel()
+    router = DefaultAlertRouter(audit_log=InMemoryAlertAuditLog())
+    router.register(channel)
+
+    strategy = _StaticStrategy(
+        [
+            StrategySignal(
+                symbol="BTCUSDT",
+                side="buy",
+                confidence=0.9,
+                metadata={"stop_price": 19000.0},
+            )
+        ]
+    )
+
+    session = TradingSession(
+        strategy=strategy,
+        strategy_name="daily_trend",
+        adapter=adapter,
+        risk_engine=risk_engine,
+        risk_profile=profile,
+        execution=execution,
+        alert_router=router,
+        instruments={
+            "BTCUSDT": InstrumentConfig(
+                symbol="BTCUSDT",
+                base_asset="BTC",
+                quote_asset="USDT",
+                min_quantity=0.001,
+                min_notional=10.0,
+                step_size=0.001,
+            )
+        },
+        environment=Environment.PAPER,
+        portfolio_id="core",
+    )
+
+    snapshot = MarketSnapshot(
+        symbol="BTCUSDT",
+        timestamp=1_700_000_100,
+        open=20000.0,
+        high=20200.0,
+        low=19900.0,
+        close=20000.0,
+        volume=50.0,
+    )
+
+    results = session.process_snapshot(snapshot)
+
+    assert results == []
+    assert execution.requests == []
+    assert channel.messages, "Oczekiwano alertu ostrzegającego o odrzuceniu przez ryzyko."
+    assert channel.messages[-1].severity == "warning"

--- a/tests/test_walkforward_optimizer.py
+++ b/tests/test_walkforward_optimizer.py
@@ -1,0 +1,105 @@
+"""Testy modułu walk-forward."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Sequence
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.strategies import MarketSnapshot
+from bot_core.strategies.walkforward import (
+    RollingWindowWalkForwardOptimizer,
+    WalkForwardError,
+    WalkForwardWindow,
+)
+
+
+def _build_snapshot(index: int, symbol: str = "BTC/USDT") -> MarketSnapshot:
+    price = float(index + 1)
+    return MarketSnapshot(
+        symbol=symbol,
+        timestamp=index,
+        open=price,
+        high=price + 0.5,
+        low=price - 0.5,
+        close=price,
+        volume=1.0,
+    )
+
+
+def _build_series(length: int, symbol: str = "BTC/USDT") -> Sequence[MarketSnapshot]:
+    return tuple(_build_snapshot(i, symbol) for i in range(length))
+
+
+def test_split_generates_overlapping_segments() -> None:
+    series = _build_series(12)
+    window = WalkForwardWindow(training_size=5, testing_size=2)
+    optimizer = RollingWindowWalkForwardOptimizer(
+        window,
+        parameter_grid=[{"alpha": 0.1}],
+        scorer=lambda data, params: 0.0,
+    )
+
+    segments = optimizer.split(series)
+
+    assert len(segments) == 3
+    assert all(len(in_sample) == 5 for in_sample, _ in segments)
+    assert all(len(out_sample) == 2 for _, out_sample in segments)
+    # upewniamy się, że segmenty przesuwają się o długość testową
+    assert segments[0][0][0].timestamp == 0
+    assert segments[1][0][0].timestamp == 2
+    assert segments[2][0][0].timestamp == 4
+
+
+def test_split_requires_enough_data() -> None:
+    series = _build_series(6)
+    window = WalkForwardWindow(training_size=5, testing_size=2)
+    optimizer = RollingWindowWalkForwardOptimizer(
+        window,
+        parameter_grid=[{"alpha": 0.1}],
+        scorer=lambda data, params: 0.0,
+    )
+
+    with pytest.raises(WalkForwardError):
+        optimizer.split(series)
+
+
+def test_select_parameters_respects_objective_direction() -> None:
+    series = _build_series(10)
+    window = WalkForwardWindow(training_size=6, testing_size=2, step_size=2)
+
+    def scorer(data: Sequence[MarketSnapshot], params: dict[str, float]) -> float:
+        total = sum(snapshot.close for snapshot in data)
+        return total * params["alpha"]
+
+    optimizer = RollingWindowWalkForwardOptimizer(
+        window,
+        parameter_grid=[{"alpha": 0.5}, {"alpha": 1.0}],
+        scorer=scorer,
+        maximize=True,
+    )
+
+    best = optimizer.select_parameters(series[:6])
+    assert best == {"alpha": 1.0}
+
+    optimizer_min = RollingWindowWalkForwardOptimizer(
+        window,
+        parameter_grid=[{"alpha": 0.5}, {"alpha": 1.0}],
+        scorer=scorer,
+        maximize=False,
+    )
+
+    best_min = optimizer_min.select_parameters(series[:6])
+    assert best_min == {"alpha": 0.5}
+
+
+def test_walkforward_window_validates_arguments() -> None:
+    with pytest.raises(WalkForwardError):
+        WalkForwardWindow(training_size=0, testing_size=2)
+    with pytest.raises(WalkForwardError):
+        WalkForwardWindow(training_size=5, testing_size=0)
+    with pytest.raises(WalkForwardError):
+        WalkForwardWindow(training_size=5, testing_size=2, step_size=0)

--- a/tests/test_zonda_spot_adapter.py
+++ b/tests/test_zonda_spot_adapter.py
@@ -1,0 +1,156 @@
+import json
+import sys
+from pathlib import Path
+from hashlib import sha512
+import hmac
+from urllib.request import Request
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeCredentials, OrderRequest
+from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_fetch_account_snapshot_builds_signature(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: Request | None = None
+
+    def fake_urlopen(request: Request, timeout: int = 15):  # type: ignore[override]
+        nonlocal captured
+        captured = request
+        payload = {"status": "Ok", "balances": []}
+        return _FakeResponse(payload)
+
+    monkeypatch.setattr("bot_core.exchanges.zonda.spot.urlopen", fake_urlopen)
+    monkeypatch.setattr("bot_core.exchanges.zonda.spot.time.time", lambda: 1_700_000_000.0)
+
+    credentials = ExchangeCredentials(
+        key_id="key",
+        secret="secret",
+        permissions=("read",),
+        environment=Environment.LIVE,
+    )
+    adapter = ZondaSpotAdapter(credentials)
+
+    snapshot = adapter.fetch_account_snapshot()
+
+    assert isinstance(snapshot, AccountSnapshot)
+    assert captured is not None
+    headers = {name.lower(): value for name, value in captured.header_items()}
+    assert headers["api-key"] == "key"
+    timestamp = headers["request-timestamp"]
+    body = captured.data.decode("utf-8") if captured.data else ""
+    expected_signature = hmac.new(
+        b"secret",
+        f"{timestamp}POST/trading/balance{body}".encode(),
+        sha512,
+    ).hexdigest()
+    assert headers["api-hash"] == expected_signature
+
+
+def test_fetch_ohlcv_maps_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = ZondaSpotAdapter(ExchangeCredentials(key_id="public", environment=Environment.LIVE))
+
+    def fake_public_request(self, path: str, *, params=None, method="GET"):
+        assert path == "/trading/candle/history/BTC-PLN/86400"
+        assert params["from"] == 0
+        assert params["to"] == 100
+        return {
+            "status": "Ok",
+            "items": [
+                {
+                    "time": 1,
+                    "open": "10",
+                    "high": "12",
+                    "low": "9",
+                    "close": "11",
+                    "volume": "5",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(ZondaSpotAdapter, "_public_request", fake_public_request)
+
+    rows = adapter.fetch_ohlcv("BTC-PLN", "1d", start=0, end=100_000, limit=None)
+
+    assert rows == [[1000.0, 10.0, 12.0, 9.0, 11.0, 5.0]]
+
+
+def test_place_order_uses_private_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_payload: dict[str, object] | None = None
+
+    def fake_signed_request(self, method: str, path: str, *, params=None, data=None):
+        nonlocal captured_payload
+        assert method == "POST"
+        assert path == "/trading/offer"
+        captured_payload = dict(data or {})
+        return {"order": {"id": "123", "status": "new", "filledAmount": "0"}}
+
+    monkeypatch.setattr(ZondaSpotAdapter, "_signed_request", fake_signed_request)
+
+    credentials = ExchangeCredentials(
+        key_id="trade",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = ZondaSpotAdapter(credentials)
+
+    request = OrderRequest(
+        symbol="BTC-PLN",
+        side="buy",
+        quantity=1.5,
+        order_type="limit",
+        price=100.0,
+        time_in_force="GTC",
+        client_order_id="cli-1",
+    )
+
+    result = adapter.place_order(request)
+
+    assert captured_payload == {
+        "market": "BTC-PLN",
+        "side": "buy",
+        "type": "limit",
+        "amount": "1.5",
+        "price": "100.0",
+        "timeInForce": "GTC",
+        "clientOrderId": "cli-1",
+    }
+    assert result.order_id == "123"
+    assert result.status == "NEW"
+    assert result.filled_quantity == pytest.approx(0.0)
+
+
+def test_cancel_order_accepts_cancelled_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_signed_request(self, method: str, path: str, *, params=None, data=None):
+        assert method == "DELETE"
+        assert path == "/trading/order/XYZ"
+        return {"order": {"id": "XYZ", "status": "cancelled"}}
+
+    monkeypatch.setattr(ZondaSpotAdapter, "_signed_request", fake_signed_request)
+
+    credentials = ExchangeCredentials(
+        key_id="trade",
+        secret="secret",
+        permissions=("trade",),
+        environment=Environment.LIVE,
+    )
+    adapter = ZondaSpotAdapter(credentials)
+
+    adapter.cancel_order("XYZ")


### PR DESCRIPTION
## Summary
- add a reusable walk-forward optimizer with configurable rolling windows and scoring to prepare in/out-of-sample splits
- expose the new optimizer in the strategies package alongside dedicated exceptions for configuration errors
- cover the optimizer with unit tests validating segmentation, parameter selection and argument validation

## Testing
- python -m compileall bot_core/strategies/walkforward.py
- pytest tests/test_walkforward_optimizer.py

------
https://chatgpt.com/codex/tasks/task_e_68d7fdff8a58832aba7e15f29e548f4e