### PR TITLE
Add builder for daily trend paper-trading pipeline

### DIFF
--- a/bot_core/config/__init__.py
+++ b/bot_core/config/__init__.py
@@ -3,19 +3,29 @@
 from bot_core.config.loader import load_core_config
 from bot_core.config.models import (
     CoreConfig,
+    EmailChannelSettings,
     EnvironmentConfig,
     InstrumentConfig,
     InstrumentUniverseConfig,
+    MessengerChannelSettings,
     RiskProfileConfig,
     SMSProviderSettings,
+    SignalChannelSettings,
+    TelegramChannelSettings,
+    WhatsAppChannelSettings,
 )
 
 __all__ = [
     "CoreConfig",
     "EnvironmentConfig",
+    "EmailChannelSettings",
     "InstrumentConfig",
     "InstrumentUniverseConfig",
+    "MessengerChannelSettings",
     "RiskProfileConfig",
     "SMSProviderSettings",
+    "SignalChannelSettings",
+    "TelegramChannelSettings",
+    "WhatsAppChannelSettings",
     "load_core_config",
 ]

--- a/bot_core/config/loader.py
+++ b/bot_core/config/loader.py
@@ -202,6 +202,10 @@ def load_core_config(path: str | Path) -> CoreConfig:
             ip_allowlist=tuple(entry.get("ip_allowlist", ()) or ()),
             credential_purpose=str(entry.get("credential_purpose", "trading")),
             instrument_universe=entry.get("instrument_universe"),
+            adapter_settings={
+                str(key): value
+                for key, value in (entry.get("adapter_settings", {}) or {}).items()
+            },
         )
         for name, entry in raw.get("environments", {}).items()
     }

--- a/bot_core/config/models.py
+++ b/bot_core/config/models.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Mapping, Sequence
+from typing import Any, Mapping, Sequence
 
 from bot_core.exchanges.base import Environment
 
@@ -21,6 +21,7 @@ class EnvironmentConfig:
     ip_allowlist: Sequence[str] = field(default_factory=tuple)
     credential_purpose: str = "trading"
     instrument_universe: str | None = None
+    adapter_settings: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/bot_core/exchanges/binance/futures.py
+++ b/bot_core/exchanges/binance/futures.py
@@ -70,6 +70,7 @@ class BinanceFuturesAdapter(ExchangeAdapter):
         credentials: ExchangeCredentials,
         *,
         environment: Environment | None = None,
+        settings: Mapping[str, object] | None = None,
     ) -> None:
         super().__init__(credentials)
         self._environment = environment or credentials.environment
@@ -77,6 +78,7 @@ class BinanceFuturesAdapter(ExchangeAdapter):
         self._trading_base = _determine_trading_base(self._environment)
         self._permission_set = frozenset(perm.lower() for perm in self._credentials.permissions)
         self._ip_allowlist: tuple[str, ...] = ()
+        self._settings = dict(settings or {})
 
     def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:
         if ip_allowlist is None:

--- a/bot_core/exchanges/binance/spot.py
+++ b/bot_core/exchanges/binance/spot.py
@@ -128,17 +128,25 @@ class BinanceSpotAdapter(ExchangeAdapter):
         "_trading_base",
         "_ip_allowlist",
         "_permission_set",
+        "_settings",
     )
 
     name: str = "binance_spot"
 
-    def __init__(self, credentials: ExchangeCredentials, *, environment: Environment | None = None) -> None:
+    def __init__(
+        self,
+        credentials: ExchangeCredentials,
+        *,
+        environment: Environment | None = None,
+        settings: Mapping[str, object] | None = None,
+    ) -> None:
         super().__init__(credentials)
         self._environment = environment or credentials.environment
         self._public_base = _determine_public_base(self._environment)
         self._trading_base = _determine_trading_base(self._environment)
         self._ip_allowlist: tuple[str, ...] = ()
         self._permission_set = frozenset(perm.lower() for perm in self._credentials.permissions)
+        self._settings = dict(settings or {})
 
     def _public_request(
         self,

--- a/bot_core/exchanges/kraken/futures.py
+++ b/bot_core/exchanges/kraken/futures.py
@@ -50,7 +50,13 @@ class KrakenFuturesAdapter(ExchangeAdapter):
 
     name = "kraken_futures"
 
-    def __init__(self, credentials: ExchangeCredentials, *, environment: Environment) -> None:
+    def __init__(
+        self,
+        credentials: ExchangeCredentials,
+        *,
+        environment: Environment,
+        settings: Mapping[str, object] | None = None,
+    ) -> None:
         super().__init__(credentials)
         self._environment = environment
         try:
@@ -60,6 +66,7 @@ class KrakenFuturesAdapter(ExchangeAdapter):
         self._permission_set = frozenset(str(perm).lower() for perm in credentials.permissions)
         self._ip_allowlist: Sequence[str] | None = None
         self._http_timeout = 20
+        self._settings = dict(settings or {})
 
     # ------------------------------------------------------------------
     # Konfiguracja sieci

--- a/bot_core/exchanges/zonda/spot.py
+++ b/bot_core/exchanges/zonda/spot.py
@@ -89,10 +89,16 @@ class _OrderPayload:
 class ZondaSpotAdapter(ExchangeAdapter):
     """Adapter REST obsługujący podstawowe operacje tradingowe Zonda."""
 
-    __slots__ = ("_environment", "_base_url", "_ip_allowlist", "_permission_set")
+    __slots__ = ("_environment", "_base_url", "_ip_allowlist", "_permission_set", "_settings")
     name: str = "zonda_spot"
 
-    def __init__(self, credentials: ExchangeCredentials, *, environment: Environment | None = None) -> None:
+    def __init__(
+        self,
+        credentials: ExchangeCredentials,
+        *,
+        environment: Environment | None = None,
+        settings: Mapping[str, object] | None = None,
+    ) -> None:
         super().__init__(credentials)
         self._environment = environment or credentials.environment
         try:
@@ -101,6 +107,7 @@ class ZondaSpotAdapter(ExchangeAdapter):
             raise ValueError(f"Nieobsługiwane środowisko Zonda: {self._environment}") from exc
         self._ip_allowlist: tuple[str, ...] = ()
         self._permission_set = frozenset(perm.lower() for perm in credentials.permissions)
+        self._settings = dict(settings or {})
 
     # --- HTTP ----------------------------------------------------------------
 

--- a/bot_core/runtime/__init__.py
+++ b/bot_core/runtime/__init__.py
@@ -13,6 +13,12 @@ try:
 except Exception:
     _DailyTrendController = None  # type: ignore
 
+try:
+    from bot_core.runtime.pipeline import DailyTrendPipeline, build_daily_trend_pipeline  # type: ignore
+except Exception:  # pragma: no cover - starsze gałęzie mogą nie mieć modułu pipeline
+    DailyTrendPipeline = None  # type: ignore
+    build_daily_trend_pipeline = None  # type: ignore
+
 __all__ = ["BootstrapContext", "bootstrap_environment"]
 
 # Eksportuj tylko te kontrolery, które są dostępne w danej gałęzi.
@@ -23,3 +29,6 @@ if _TradingController is not None:
 if _DailyTrendController is not None:
     DailyTrendController = _DailyTrendController  # type: ignore
     __all__.append("DailyTrendController")
+
+if DailyTrendPipeline is not None and build_daily_trend_pipeline is not None:
+    __all__.extend(["DailyTrendPipeline", "build_daily_trend_pipeline"])

--- a/config/core.yaml
+++ b/config/core.yaml
@@ -264,6 +264,8 @@ environments:
     alert_channels: ["telegram:primary", "email:ops"]
     ip_allowlist: []
     instrument_universe: core_multi_exchange
+    adapter_settings:
+      valuation_asset: ZUSD
 
   kraken_live:
     exchange: kraken_spot
@@ -274,6 +276,8 @@ environments:
     alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
     ip_allowlist: []
     instrument_universe: core_multi_exchange
+    adapter_settings:
+      valuation_asset: ZEUR
 
   kraken_futures_paper:
     exchange: kraken_futures

--- a/docs/architecture/phase1_foundation.md
+++ b/docs/architecture/phase1_foundation.md
@@ -78,6 +78,11 @@ oraz zakresem uprawnień. Struktura przygotowuje grunt pod rozdzielenie kluczy `
 w Windows Credential Manager/macOS Keychain/Linux keyring (`keychain_key` w konfiguracji). Metoda
 `configure_network` umożliwi egzekwowanie IP allowlist.
 
+Sekcja środowisk w `core.yaml` została rozszerzona o pole `adapter_settings`, dzięki któremu możemy
+przekazywać parametry specyficzne dla danej giełdy bez łamania ogólnego kontraktu adapterów. Przykład:
+`kraken_live` korzysta z `valuation_asset: ZEUR`, co powoduje, że `KrakenSpotAdapter` raportuje kapitał
+w walucie referencyjnej EUR zgodnie z wymaganiami risk engine'u i raportowania P&L.
+
 ## Dane rynkowe
 
 `PublicAPIDataSource` zostanie połączony z adapterami do pobierania danych OHLCV z publicznych API.

--- a/tests/test_controller_daily_trend.py
+++ b/tests/test_controller_daily_trend.py
@@ -102,6 +102,9 @@ def _core_config(runtime: ControllerRuntimeConfig, environment_name: str, risk_p
         sms_providers={},
         telegram_channels={},
         email_channels={},
+        signal_channels={},
+        whatsapp_channels={},
+        messenger_channels={},
         runtime_controllers={"daily_trend": runtime},
     )
 

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -156,6 +156,7 @@ def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
     assert snapshot["telegram:primary"]["status"] == "ok"
 
     assert context.risk_engine.should_liquidate(profile_name="balanced") is False
+    assert context.adapter_settings == {}
 
 
 def test_bootstrap_environment_supports_zonda(tmp_path: Path) -> None:
@@ -212,3 +213,4 @@ def test_bootstrap_environment_supports_zonda(tmp_path: Path) -> None:
     assert context.adapter.name == "zonda_spot"
     assert context.credentials.key_id == "zonda-key"
     assert context.environment.exchange == "zonda_spot"
+    assert context.adapter_settings == {}

--- a/tests/test_runtime_pipeline.py
+++ b/tests/test_runtime_pipeline.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Optional, Protocol, Sequence
+
+import pytest
+
+from bot_core.execution.paper import PaperTradingExecutionService
+from bot_core.exchanges.base import AccountSnapshot, Environment, ExchangeAdapter, ExchangeCredentials, OrderRequest, OrderResult
+from bot_core.runtime import build_daily_trend_pipeline
+from bot_core.security import SecretManager, SecretStorage
+from bot_core.strategies.daily_trend import DailyTrendMomentumStrategy
+
+
+class _InMemorySecretStorage(SecretStorage):
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    def get_secret(self, key: str) -> Optional[str]:
+        return self._store.get(key)
+
+    def set_secret(self, key: str, value: str) -> None:
+        self._store[key] = value
+
+    def delete_secret(self, key: str) -> None:
+        self._store.pop(key, None)
+
+
+@dataclass(slots=True)
+class _OhlcvFixture:
+    symbol: str
+    rows: Sequence[Sequence[float]]
+
+
+class _FakeStream(Protocol):
+    def close(self) -> None:  # pragma: no cover - wymagane przez interfejs
+        ...
+
+
+class FakeExchangeAdapter(ExchangeAdapter):
+    name = "fake_exchange"
+
+    def __init__(self, credentials: ExchangeCredentials, *, fixtures: Sequence[_OhlcvFixture]) -> None:
+        super().__init__(credentials)
+        self._fixtures = {fixture.symbol: fixture.rows for fixture in fixtures}
+
+    def configure_network(self, *, ip_allowlist: Optional[Sequence[str]] = None) -> None:  # noqa: D401, ARG002
+        return None
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        return AccountSnapshot(
+            balances={"USDT": 0.0},
+            total_equity=0.0,
+            available_margin=0.0,
+            maintenance_margin=0.0,
+        )
+
+    def fetch_symbols(self) -> Iterable[str]:  # pragma: no cover - nieużywane w teście
+        return tuple(self._fixtures.keys())
+
+    def fetch_ohlcv(
+        self,
+        symbol: str,
+        interval: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Sequence[Sequence[float]]:
+        rows = list(self._fixtures.get(symbol, ()))
+        if start is not None:
+            rows = [row for row in rows if float(row[0]) >= start]
+        if end is not None:
+            rows = [row for row in rows if float(row[0]) <= end]
+        if limit is not None:
+            rows = rows[:limit]
+        return rows
+
+    def place_order(self, request: OrderRequest) -> OrderResult:  # pragma: no cover - pipeline używa paper tradingu
+        raise NotImplementedError
+
+    def cancel_order(self, order_id: str, *, symbol: Optional[str] = None) -> None:  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+    def stream_public_data(self, *, channels: Sequence[str]) -> _FakeStream:  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+    def stream_private_data(self, *, channels: Sequence[str]) -> _FakeStream:  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+
+@pytest.fixture()
+def pipeline_fixture(tmp_path: Path) -> tuple[Path, FakeExchangeAdapter, SecretManager]:
+    candles = [
+        [1_600_000_000_000, 100.0, 105.0, 95.0, 102.0, 12.0],
+        [1_600_086_400_000, 102.0, 107.0, 101.0, 104.0, 11.0],
+    ]
+    adapter = FakeExchangeAdapter(
+        ExchangeCredentials(key_id="public", environment=Environment.PAPER),
+        fixtures=(_OhlcvFixture(symbol="BTCUSDT", rows=candles),),
+    )
+
+    config = {
+        "risk_profiles": {
+            "balanced": {
+                "max_daily_loss_pct": 0.015,
+                "max_position_pct": 0.05,
+                "target_volatility": 0.11,
+                "max_leverage": 3.0,
+                "stop_loss_atr_multiple": 1.5,
+                "max_open_positions": 5,
+                "hard_drawdown_pct": 0.1,
+            }
+        },
+        "runtime": {
+            "controllers": {"daily_trend_core": {"tick_seconds": 86400, "interval": "1d"}}
+        },
+        "strategies": {
+            "core_daily_trend": {
+                "engine": "daily_trend_momentum",
+                "parameters": {
+                    "fast_ma": 3,
+                    "slow_ma": 5,
+                    "breakout_lookback": 4,
+                    "momentum_window": 3,
+                    "atr_window": 3,
+                    "atr_multiplier": 1.5,
+                    "min_trend_strength": 0.0,
+                    "min_momentum": 0.0,
+                },
+            }
+        },
+        "instrument_universes": {
+            "core_universe": {
+                "description": "fixture",
+                "instruments": {
+                    "BTC_USDT": {
+                        "base_asset": "BTC",
+                        "quote_asset": "USDT",
+                        "categories": [],
+                        "exchanges": {"fake_exchange": "BTCUSDT"},
+                        "backfill": [{"interval": "1d", "lookback_days": 10}],
+                    }
+                },
+            }
+        },
+        "environments": {
+            "fake_paper": {
+                "exchange": "fake_exchange",
+                "environment": "paper",
+                "keychain_key": "fake_key",
+                "data_cache_path": str(tmp_path / "data"),
+                "risk_profile": "balanced",
+                "alert_channels": [],
+                "instrument_universe": "core_universe",
+                "adapter_settings": {
+                    "paper_trading": {
+                        "valuation_asset": "USDT",
+                        "position_size": 0.1,
+                        "initial_balances": {"USDT": 10_000},
+                        "default_market": {"min_quantity": 0.001, "min_notional": 10.0},
+                    }
+                },
+            }
+        },
+        "alerts": {},
+    }
+
+    config_path = tmp_path / "core.yaml"
+
+    # Zamieniamy strukturę na YAML kompatybilny z loaderem.
+    import yaml  # type: ignore
+
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    storage = _InMemorySecretStorage()
+    manager = SecretManager(storage)
+    manager.store_exchange_credentials(
+        "fake_key",
+        ExchangeCredentials(key_id="public", secret="sekret", environment=Environment.PAPER),
+    )
+    return config_path, adapter, manager
+
+
+def test_build_daily_trend_pipeline(pipeline_fixture: tuple[Path, FakeExchangeAdapter, SecretManager]) -> None:
+    config_path, adapter, manager = pipeline_fixture
+
+    pipeline = build_daily_trend_pipeline(
+        environment_name="fake_paper",
+        strategy_name="core_daily_trend",
+        controller_name="daily_trend_core",
+        config_path=config_path,
+        secret_manager=manager,
+        adapter_factories={"fake_exchange": lambda credentials, **_: adapter},
+    )
+
+    assert pipeline.controller.symbols == ("BTCUSDT",)
+    snapshot = pipeline.controller.account_loader()
+    assert snapshot.total_equity == pytest.approx(10_000.0)
+    assert snapshot.available_margin == pytest.approx(10_000.0)
+    assert isinstance(pipeline.execution_service, PaperTradingExecutionService)
+    assert isinstance(pipeline.strategy, DailyTrendMomentumStrategy)
+
+    balances = pipeline.execution_service.balances()
+    assert balances["USDT"] == 10_000.0


### PR DESCRIPTION
## Summary
- introduce a `DailyTrendPipeline` builder that assembles bootstrap, cached OHLCV data and paper execution for trend-following environments
- expose the builder from the runtime package so desktop clients can bootstrap the paper pipeline easily
- add an integration-style unit test covering the builder with a fake exchange adapter and in-memory secret storage

## Testing
- PYTHONPATH=. pytest -c /dev/null tests/test_runtime_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d83f96529c832a9a18002871b057ac