### PR TITLE
Handle monthly realtime interval distinctly

### DIFF
--- a/bot_core/runtime/realtime.py
+++ b/bot_core/runtime/realtime.py
@@ -33,7 +33,12 @@ _INTERVAL_SECONDS: dict[str, float] = {
 
 
 def _interval_seconds(interval: str, fallback: float) -> float:
-    return max(fallback, _INTERVAL_SECONDS.get(interval.lower(), fallback))
+    seconds = _INTERVAL_SECONDS.get(interval)
+    if seconds is None:
+        seconds = _INTERVAL_SECONDS.get(interval.lower())
+    if seconds is None:
+        seconds = fallback
+    return max(fallback, seconds)
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary
- ensure realtime interval parsing checks exact keys before lower-casing to distinguish 1m and 1M
- add regression test verifying the realtime runner computes the expected lookback for monthly intervals

## Testing
- pytest tests/test_runtime_realtime.py

------
https://chatgpt.com/codex/tasks/task_e_68d9625927f0832ab4ecf2b6226c1d69