### PR TITLE
Fix Zonda typing and interval handling, refresh architecture doc

### DIFF
--- a/bot_core/exchanges/zonda/spot.py
+++ b/bot_core/exchanges/zonda/spot.py
@@ -262,7 +262,7 @@ class ZondaSpotAdapter(ExchangeAdapter):
         self,
         path: str,
         *,
-        params: Optional[Mapping[str, object]] = None,
+        params: Mapping[str, object] | None = None,
         method: str = "GET",
     ) -> dict[str, object] | list[object]:
         query = f"?{urlencode(params or {})}" if params else ""
@@ -274,8 +274,8 @@ class ZondaSpotAdapter(ExchangeAdapter):
         method: str,
         path: str,
         *,
-        params: Optional[Mapping[str, object]] = None,
-        data: Optional[Mapping[str, object]] = None,
+        params: Mapping[str, object] | None = None,
+        data: Mapping[str, object] | None = None,
     ) -> dict[str, object] | list[object]:
         if not self._credentials.secret:
             raise RuntimeError("Poświadczenia Zonda wymagają secret do podpisywania żądań prywatnych.")
@@ -299,7 +299,7 @@ class ZondaSpotAdapter(ExchangeAdapter):
         )
 
         query = f"?{urlencode(params)}" if params else ""
-        data_bytes: Optional[bytes] = None
+        data_bytes: bytes | None = None
         if body:
             data_bytes = body.encode("utf-8")
             headers["Content-Type"] = "application/json"

--- a/bot_core/runtime/realtime.py
+++ b/bot_core/runtime/realtime.py
@@ -33,9 +33,14 @@ _INTERVAL_SECONDS: dict[str, float] = {
 
 
 def _interval_seconds(interval: str, fallback: float) -> float:
-    seconds = _INTERVAL_SECONDS.get(interval)
+    """Mapuje tekstowy interwał na liczbę sekund respektując wielkość liter."""
+
+    key = interval.strip()
+    seconds = _INTERVAL_SECONDS.get(key)
     if seconds is None:
-        seconds = _INTERVAL_SECONDS.get(interval.lower())
+        lowered = key.lower()
+        if lowered != key:
+            seconds = _INTERVAL_SECONDS.get(lowered)
     if seconds is None:
         seconds = fallback
     return max(fallback, seconds)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,12 @@ Adaptery giełdowe (`BinanceSpotAdapter`, `BinanceFuturesAdapter`, `KrakenSpotAd
 
 ### `bot_core/data`
 
-Warstwa danych obejmuje `PublicAPIDataSource`, `CachedOHLCVSource` i usługi backfillu. Źródła potrafią normalizować świeczki OHLCV, deduplikować zapisy oraz synchronizować się z cache (domyślnie `SQLiteCacheStorage` w trybie WAL). Dane są indeksowane per środowisko i giełdę, co umożliwia równoległe testy demo/paper oraz szybkie odtwarzanie historii na potrzeby kontroli ryzyka.
+Warstwa danych obejmuje `PublicAPIDataSource`, `CachedOHLCVSource` i usługi backfillu. Moduł pracuje dwuwarstwowo:
+
+1. **Parquet jako źródło prawdy** – backfill zapisuje świeczki OHLCV do plików partycjonowanych według `exchange/symbol/granularity/year/month`. Format kolumnowy zapewnia dobrą kompresję, szybkie skany dla backtestów i łatwą integrację z Pandas/Polars.
+2. **Manifest w SQLite** – lekka baza (`SQLiteCacheStorage`) przechowuje indeks metadanych (zakresy czasowe, wersje paczek, stany backfillu). Dzięki temu runtime odnajduje właściwe segmenty Parquet bez konieczności wczytywania wszystkich plików.
+
+Źródła normalizują świeczki do UTC, deduplikują zapisy i stosują kontrolowany backoff, aby nie przekraczać limitów publicznych API giełd. Dane są indeksowane per środowisko i giełdę, co umożliwia równoległe testy demo/paper oraz szybkie odtwarzanie historii na potrzeby kontroli ryzyka.
 
 ### `bot_core/risk`
 
@@ -41,7 +46,7 @@ Moduł ryzyka (`RiskProfile`, `ThresholdRiskEngine`, `RiskRepository`) wymusza l
 
 ### `bot_core/alerts`
 
-`AlertRouter`, `AlertChannel` i `FileAlertAuditLog` obsługują powiadomienia (Telegram, e-mail, SMS, Signal, WhatsApp, Messenger) z kontrolą throttlingu i pełnym audytem zdarzeń (`channel="__suppressed__"` dla zdławionych komunikatów). Alerty są elementem procesów bezpieczeństwa – incydenty krytyczne muszą zostać potwierdzone i przekazane do zespołu bezpieczeństwa w ciągu 24h.
+`AlertRouter`, `AlertChannel` i `FileAlertAuditLog` obsługują powiadomienia (Telegram, e-mail, SMS, Signal, WhatsApp, Messenger) z kontrolą throttlingu i pełnym audytem zdarzeń (`channel="__suppressed__"` dla zdławionych komunikatów). Warstwa SMS jest modułowa: na starcie korzystamy z lokalnych operatorów (Orange Polska jako referencyjny, następnie inni dostawcy w PL i IS), a globalny agregator (Twilio/Vonage/MessageBird) działa jako fallback ciągłości działania. Alerty są elementem procesów bezpieczeństwa – incydenty krytyczne muszą zostać potwierdzone i przekazane do zespołu bezpieczeństwa w ciągu 24h.
 
 ### `bot_core/runtime`
 
@@ -49,7 +54,7 @@ Moduł ryzyka (`RiskProfile`, `ThresholdRiskEngine`, `RiskRepository`) wymusza l
 
 ### `bot_core/security`
 
-`SecretManager` i `KeyringSecretStorage` przechowują poświadczenia poza repozytorium, rozdzielając klucze `read` i `trade` dla każdego środowiska. Moduł implementuje rotację kluczy, walidację środowisk (paper/live/testnet) oraz integruje się z politykami IP allowlist. Wszystkie operacje są logowane i dostępne w dziennikach audytu wykorzystywanych przez compliance.
+`SecretManager` i `KeyringSecretStorage` przechowują poświadczenia poza repozytorium, rozdzielając klucze `read` i `trade` dla każdego środowiska. Moduł implementuje rotację kluczy co 90 dni (z natychmiastową wymianą po zmianie uprawnień lub incydencie), walidację środowisk (paper/live/testnet) oraz integruje się z politykami IP allowlist. Klucze przechowujemy natywnie (Windows Credential Manager, macOS Keychain, GNOME Keyring/zaszyfrowany magazyn `age` w trybie headless). Wszystkie operacje są logowane i dostępne w dziennikach audytu wykorzystywanych przez compliance.
 
 ## Mechanizmy bezpieczeństwa i compliance
 


### PR DESCRIPTION
## Summary
- align Zonda spot adapter request helpers with proper Mapping-typed parameters to avoid lowercase typing errors
- tighten realtime interval parsing to respect uppercase monthly intervals and document the behavior
- extend the architecture overview with the Parquet + SQLite data design, SMS rollout strategy, and 90-day key rotation policy

## Testing
- pytest --override-ini=addopts= tests/test_zonda_spot_adapter.py
- pytest --override-ini=addopts= tests/test_runtime_realtime.py
- pyright *(interrupted: manual stop after prolonged execution)*

------
https://chatgpt.com/codex/tasks/task_e_68d95db7eb54832a907813af8d9093c6