### PR TITLE
Persist risk engine state between sessions

### DIFF
--- a/bot_core/exchanges/zonda/spot.py
+++ b/bot_core/exchanges/zonda/spot.py
@@ -262,7 +262,7 @@ class ZondaSpotAdapter(ExchangeAdapter):
         self,
         path: str,
         *,
-        params: Optional[Mapping[str, object]] = None,
+        params: Mapping[str, object] | None = None,
         method: str = "GET",
     ) -> dict[str, object] | list[object]:
         query = f"?{urlencode(params or {})}" if params else ""
@@ -274,8 +274,8 @@ class ZondaSpotAdapter(ExchangeAdapter):
         method: str,
         path: str,
         *,
-        params: Optional[Mapping[str, object]] = None,
-        data: Optional[Mapping[str, object]] = None,
+        params: Mapping[str, object] | None = None,
+        data: Mapping[str, object] | None = None,
     ) -> dict[str, object] | list[object]:
         if not self._credentials.secret:
             raise RuntimeError("Poświadczenia Zonda wymagają secret do podpisywania żądań prywatnych.")
@@ -299,7 +299,7 @@ class ZondaSpotAdapter(ExchangeAdapter):
         )
 
         query = f"?{urlencode(params)}" if params else ""
-        data_bytes: Optional[bytes] = None
+        data_bytes: bytes | None = None
         if body:
             data_bytes = body.encode("utf-8")
             headers["Content-Type"] = "application/json"

--- a/bot_core/risk/__init__.py
+++ b/bot_core/risk/__init__.py
@@ -2,6 +2,7 @@
 
 from bot_core.risk.base import RiskCheckResult, RiskEngine, RiskProfile, RiskRepository
 from bot_core.risk.engine import InMemoryRiskRepository, ThresholdRiskEngine
+from bot_core.risk.repository import FileRiskRepository
 from bot_core.risk.profiles.aggressive import AggressiveProfile
 from bot_core.risk.profiles.balanced import BalancedProfile
 from bot_core.risk.profiles.conservative import ConservativeProfile
@@ -11,6 +12,7 @@ __all__ = [
     "AggressiveProfile",
     "BalancedProfile",
     "ConservativeProfile",
+    "FileRiskRepository",
     "InMemoryRiskRepository",
     "ManualProfile",
     "RiskCheckResult",

--- a/bot_core/risk/repository.py
+++ b/bot_core/risk/repository.py
@@ -1,0 +1,82 @@
+"""Implementacje repozytoriów stanu ryzyka."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+from bot_core.risk.base import RiskRepository
+
+
+def _sanitize_profile_name(name: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+    return sanitized or "profile"
+
+
+def _normalize_state(state: Mapping[str, object]) -> Mapping[str, object]:
+    def _convert(value: object) -> object:
+        if isinstance(value, Mapping):
+            return {str(k): _convert(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [_convert(item) for item in value]
+        return value
+
+    return {str(key): _convert(value) for key, value in state.items()}
+
+
+class FileRiskRepository(RiskRepository):
+    """Przechowuje stan profili ryzyka w plikach JSON z atomowym zapisem."""
+
+    def __init__(
+        self,
+        directory: str | Path,
+        *,
+        encoding: str = "utf-8",
+        fsync: bool = False,
+    ) -> None:
+        self._base_path = Path(directory)
+        self._base_path.mkdir(parents=True, exist_ok=True)
+        self._encoding = encoding
+        self._fsync = fsync
+        self._lock = threading.Lock()
+
+    def load(self, profile: str) -> Mapping[str, object] | None:
+        path = self._path_for(profile)
+        try:
+            with self._lock:
+                with path.open("r", encoding=self._encoding) as handle:
+                    data = json.load(handle)
+        except FileNotFoundError:
+            return None
+        except (OSError, json.JSONDecodeError):
+            return None
+
+        if isinstance(data, Mapping):
+            return {str(key): value for key, value in data.items()}
+        return None
+
+    def store(self, profile: str, state: Mapping[str, object]) -> None:
+        path = self._path_for(profile)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        payload: MutableMapping[str, object] = dict(_normalize_state(state))
+        serialized = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+        with self._lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with tmp_path.open("w", encoding=self._encoding) as handle:
+                handle.write(serialized)
+                handle.write("\n")
+                handle.flush()
+                if self._fsync:
+                    os.fsync(handle.fileno())
+            os.replace(tmp_path, path)
+
+    def _path_for(self, profile: str) -> Path:
+        filename = f"{_sanitize_profile_name(profile)}.json"
+        return self._base_path / filename
+
+
+__all__ = ["FileRiskRepository"]

--- a/bot_core/runtime/realtime.py
+++ b/bot_core/runtime/realtime.py
@@ -1,12 +1,15 @@
 """Pętla czasu rzeczywistego dla strategii dziennych."""
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Callable, Sequence
 
 from bot_core.exchanges.base import OrderResult
 from bot_core.runtime.controller import ControllerSignal, DailyTrendController, TradingController
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -33,10 +36,20 @@ _INTERVAL_SECONDS: dict[str, float] = {
 
 
 def _interval_seconds(interval: str, fallback: float) -> float:
-    seconds = _INTERVAL_SECONDS.get(interval)
+    """Mapuje tekstowy interwał na liczbę sekund respektując wielkość liter."""
+
+    key = interval.strip()
+    seconds = _INTERVAL_SECONDS.get(key)
     if seconds is None:
-        seconds = _INTERVAL_SECONDS.get(interval.lower())
+        lowered = key.lower()
+        if lowered != key:
+            seconds = _INTERVAL_SECONDS.get(lowered)
     if seconds is None:
+        _LOGGER.warning(
+            "Nieznany interwał %s – używam wartości zapasowej %.2f s.",
+            interval,
+            fallback,
+        )
         seconds = fallback
     return max(fallback, seconds)
 

--- a/tests/test_risk_engine.py
+++ b/tests/test_risk_engine.py
@@ -11,6 +11,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from bot_core.exchanges.base import AccountSnapshot, OrderRequest
 from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.repository import FileRiskRepository
 from bot_core.risk.profiles.manual import ManualProfile
 
 
@@ -84,4 +85,127 @@ def test_daily_loss_limit_blocks_on_first_day(manual_profile: ManualProfile) -> 
 
     assert second_result.allowed is False
     assert "Przekroczono dzienny limit straty." in (second_result.reason or "")
+
+
+def test_margin_check_blocks_when_available_margin_is_too_low() -> None:
+    low_leverage_profile = ManualProfile(
+        name="low-margin",
+        max_positions=5,
+        max_leverage=1.0,
+        drawdown_limit=0.5,
+        daily_loss_limit=0.5,
+        max_position_pct=1.0,
+        target_volatility=0.2,
+        stop_loss_atr_multiple=2.0,
+    )
+
+    engine = ThresholdRiskEngine(clock=lambda: datetime(2024, 1, 1, 12, 0, 0))
+    engine.register_profile(low_leverage_profile)
+
+    snapshot = AccountSnapshot(
+        balances={"USDT": 1_000.0},
+        total_equity=1_000.0,
+        available_margin=500.0,
+        maintenance_margin=150.0,
+    )
+
+    request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.05,
+        order_type="limit",
+        price=20_000.0,
+    )
+
+    result = engine.apply_pre_trade_checks(
+        request,
+        account=snapshot,
+        profile_name=low_leverage_profile.name,
+    )
+
+    assert result.allowed is False
+    assert result.reason == "Niewystarczający wolny margines na otwarcie lub powiększenie pozycji."
+    assert result.adjustments is not None
+    max_quantity = result.adjustments.get("max_quantity") if result.adjustments else None
+    assert max_quantity is not None
+    # Dostępny margines po uwzględnieniu maintenance to 350 USDT.
+    assert max_quantity == pytest.approx(350.0 / 20_000.0, rel=1e-6)
+
+
+def test_margin_check_passes_when_leverage_covers_notional() -> None:
+    leveraged_profile = ManualProfile(
+        name="leveraged",
+        max_positions=5,
+        max_leverage=4.0,
+        drawdown_limit=0.5,
+        daily_loss_limit=0.5,
+        max_position_pct=1.0,
+        target_volatility=0.2,
+        stop_loss_atr_multiple=2.0,
+    )
+
+    engine = ThresholdRiskEngine(clock=lambda: datetime(2024, 1, 1, 12, 0, 0))
+    engine.register_profile(leveraged_profile)
+
+    snapshot = AccountSnapshot(
+        balances={"USDT": 1_000.0},
+        total_equity=1_000.0,
+        available_margin=500.0,
+        maintenance_margin=150.0,
+    )
+
+    request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.05,
+        order_type="limit",
+        price=20_000.0,
+    )
+
+    result = engine.apply_pre_trade_checks(
+        request,
+        account=snapshot,
+        profile_name=leveraged_profile.name,
+    )
+
+    assert result.allowed is True
+
+
+def test_file_risk_repository_persists_state(tmp_path: Path, manual_profile: ManualProfile) -> None:
+    repository = FileRiskRepository(tmp_path)
+
+    clock = lambda: datetime(2024, 1, 1, 12, 0, 0)
+    engine = ThresholdRiskEngine(repository=repository, clock=clock)
+    engine.register_profile(manual_profile)
+
+    snapshot = _snapshot(1_000.0)
+    request = _order(20_000.0)
+
+    result = engine.apply_pre_trade_checks(
+        request,
+        account=snapshot,
+        profile_name=manual_profile.name,
+    )
+    assert result.allowed is True
+
+    engine.on_fill(
+        profile_name=manual_profile.name,
+        symbol="BTCUSDT",
+        side="buy",
+        position_value=500.0,
+        pnl=-15.0,
+        timestamp=datetime(2024, 1, 1, 13, 0, 0),
+    )
+
+    # Now instantiate a new engine sharing the same repository – state should persist.
+    new_engine = ThresholdRiskEngine(repository=repository, clock=lambda: datetime(2024, 1, 1, 14, 0, 0))
+    new_engine.register_profile(manual_profile)
+
+    state = new_engine._states[manual_profile.name]
+    assert state.start_of_day_equity == pytest.approx(1_000.0)
+    assert state.daily_realized_pnl == pytest.approx(-15.0)
+    assert "BTCUSDT" in state.positions
+    btc_position = state.positions["BTCUSDT"]
+    assert btc_position.side == "buy"
+    assert btc_position.notional == pytest.approx(500.0)
 

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -18,6 +18,7 @@ from bot_core.exchanges.base import (
     OrderResult,
 )
 from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.repository import FileRiskRepository
 from bot_core.runtime import BootstrapContext, bootstrap_environment
 from bot_core.security import SecretManager, SecretStorage
 
@@ -140,6 +141,7 @@ def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
     assert context.adapter.credentials.key_id == "paper-key"
 
     assert isinstance(context.risk_engine, ThresholdRiskEngine)
+    assert isinstance(context.risk_repository, FileRiskRepository)
     result = context.risk_engine.apply_pre_trade_checks(
         OrderRequest(symbol="BTCUSDT", side="buy", quantity=0.2, order_type="limit", price=100.0),
         account=AccountSnapshot(
@@ -172,6 +174,8 @@ def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
 
     assert context.risk_engine.should_liquidate(profile_name="balanced") is False
     assert context.adapter_settings == {}
+    risk_state_path = Path("./var/data/binance_paper/risk_state/balanced.json")
+    assert risk_state_path.parent.exists()
 
 
 def test_bootstrap_environment_supports_zonda(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a file-backed RiskRepository that atomically stores profile state on disk
- wire the persistent repository into bootstrap so paper/live environments survive restarts
- document the risk-state directory and extend tests to cover persistence and bootstrap wiring

## Testing
- pytest --override-ini=addopts= tests/test_risk_engine.py
- pytest --override-ini=addopts= tests/test_runtime_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_68d95db7eb54832a907813af8d9093c6