### PR TITLE
Add Parquet OHLCV cache with SQLite manifest integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 *.so
 env/
 .venv/
+.coverage
+coverage.xml

--- a/bot_core/data/ohlcv/__init__.py
+++ b/bot_core/data/ohlcv/__init__.py
@@ -2,14 +2,18 @@
 
 from bot_core.data.ohlcv.backfill import BackfillSummary, OHLCVBackfillService
 from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+from bot_core.data.ohlcv.parquet_storage import ParquetCacheStorage
 from bot_core.data.ohlcv.scheduler import OHLCVRefreshScheduler
 from bot_core.data.ohlcv.sqlite_storage import SQLiteCacheStorage
+from bot_core.data.ohlcv.storage import DualCacheStorage
 
 __all__ = [
     "BackfillSummary",
     "CachedOHLCVSource",
     "OHLCVBackfillService",
     "OHLCVRefreshScheduler",
+    "ParquetCacheStorage",
     "PublicAPIDataSource",
     "SQLiteCacheStorage",
+    "DualCacheStorage",
 ]

--- a/bot_core/data/ohlcv/backfill.py
+++ b/bot_core/data/ohlcv/backfill.py
@@ -75,6 +75,13 @@ class OHLCVBackfillService:
     def _count_cached_rows(self, symbol: str, interval: str) -> int:
         key = self._source._cache_key(symbol, interval)  # pylint: disable=protected-access
         try:
+            metadata = self._storage.metadata()
+            stored = metadata.get(f"row_count::{symbol}::{interval}")
+            if stored is not None:
+                return int(stored)
+        except Exception:  # pragma: no cover - wspieramy różne implementacje storage
+            pass
+        try:
             rows = self._storage.read(key)["rows"]
         except KeyError:
             return 0

--- a/bot_core/data/ohlcv/parquet_storage.py
+++ b/bot_core/data/ohlcv/parquet_storage.py
@@ -1,0 +1,203 @@
+"""Magazyn świec OHLCV zapisujący dane w formacie Parquet."""
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import MutableMapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from bot_core.data.base import CacheStorage
+
+_COLUMNS: tuple[str, ...] = ("open_time", "open", "high", "low", "close", "volume")
+_PARTITION_FILENAME = "data.parquet"
+_METADATA_FILENAME = "metadata.json"
+
+
+class _ParquetMetadata(MutableMapping[str, str]):
+    """Lekka mapa klucz→wartość przechowywana w pliku JSON."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        self._data: dict[str, str] = self._load()
+
+    def _load(self) -> dict[str, str]:
+        try:
+            with self._path.open("r", encoding="utf-8") as handle:
+                raw = json.load(handle)
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError:
+            return {}
+        return {str(key): str(value) for key, value in raw.items()}
+
+    def _flush(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            json.dump(self._data, handle, ensure_ascii=False, separators=(",", ":"))
+            handle.write("\n")
+        tmp_path.replace(self._path)
+
+    def __getitem__(self, key: str) -> str:
+        with self._lock:
+            if key not in self._data:
+                raise KeyError(key)
+            return self._data[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        with self._lock:
+            self._data[str(key)] = str(value)
+            self._flush()
+
+    def __delitem__(self, key: str) -> None:
+        with self._lock:
+            if key not in self._data:
+                raise KeyError(key)
+            del self._data[key]
+            self._flush()
+
+    def __iter__(self):
+        with self._lock:
+            return iter(dict(self._data))
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._data)
+
+
+class ParquetCacheStorage(CacheStorage):
+    """CacheStorage zapisujący świeczki w strukturze exchange/symbol/interval/year/month."""
+
+    def __init__(self, base_path: str | Path, *, namespace: str) -> None:
+        self._base_path = Path(base_path)
+        self._namespace = namespace
+        self._base_path.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+
+    def _root(self) -> Path:
+        return self._base_path / self._namespace
+
+    def _symbol_dir(self, symbol: str, interval: str) -> Path:
+        return self._root() / symbol / interval
+
+    def _partition_path(self, symbol: str, interval: str, timestamp_ms: float) -> Path:
+        dt = datetime.fromtimestamp(float(timestamp_ms) / 1000.0, tz=timezone.utc)
+        base = self._symbol_dir(symbol, interval)
+        year_dir = base / f"year={dt.year:04d}"
+        month_dir = year_dir / f"month={dt.month:02d}"
+        return month_dir / _PARTITION_FILENAME
+
+    def _columns_mapping(self, columns: Sequence[str]) -> dict[str, int]:
+        mapping: dict[str, int] = {}
+        for index, name in enumerate(columns):
+            mapping[name] = index
+        missing = [column for column in _COLUMNS if column not in mapping]
+        if missing:
+            raise ValueError(f"Brak kolumn wymaganych przez ParquetCacheStorage: {missing}")
+        return mapping
+
+    def _normalize_row(self, row: Sequence[float], mapping: Mapping[str, int]) -> list[float]:
+        return [float(row[mapping[column]]) for column in _COLUMNS]
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        symbol, interval = key.split("::", maxsplit=1)
+        base = self._symbol_dir(symbol, interval)
+        if not base.exists():
+            raise KeyError(key)
+
+        rows: list[list[float]] = []
+        for year_dir in sorted(base.glob("year=*")):
+            for month_dir in sorted(year_dir.glob("month=*")):
+                file_path = month_dir / _PARTITION_FILENAME
+                if not file_path.exists():
+                    continue
+                table = pq.read_table(file_path)
+                data = table.to_pydict()
+                if not data:
+                    continue
+                open_times = [float(value) for value in data.get("open_time", [])]
+                if not open_times:
+                    continue
+                length = len(open_times)
+                columns_data = {column: [float(value) for value in data.get(column, [])] for column in _COLUMNS}
+                for idx in range(length):
+                    rows.append([columns_data[column][idx] for column in _COLUMNS])
+
+        if not rows:
+            raise KeyError(key)
+
+        rows.sort(key=lambda item: item[0])
+        return {"columns": _COLUMNS, "rows": rows}
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        symbol, interval = key.split("::", maxsplit=1)
+        rows = payload.get("rows", [])
+        if not rows:
+            return
+
+        columns = payload.get("columns", _COLUMNS)
+        mapping = self._columns_mapping(columns)
+        partitions: dict[tuple[int, int], dict[float, list[float]]] = {}
+
+        for row in rows:
+            if not row:
+                continue
+            normalized = self._normalize_row(row, mapping)
+            timestamp = normalized[0]
+            dt = datetime.fromtimestamp(timestamp / 1000.0, tz=timezone.utc)
+            bucket = (dt.year, dt.month)
+            partition = partitions.setdefault(bucket, {})
+            partition[timestamp] = normalized
+
+        for _, partition_rows in sorted(partitions.items(), key=lambda item: item[0]):
+            sample_timestamp = next(iter(partition_rows))
+            partition_path = self._partition_path(symbol, interval, sample_timestamp)
+            with self._lock:
+                existing: dict[float, list[float]] = {}
+                if partition_path.exists():
+                    table = pq.read_table(partition_path)
+                    data = table.to_pydict()
+                    open_times = [float(value) for value in data.get("open_time", [])]
+                    for idx, open_time in enumerate(open_times):
+                        existing[open_time] = [float(data[column][idx]) for column in _COLUMNS]
+
+                existing.update(partition_rows)
+                sorted_keys = sorted(existing)
+                payload_dict = {
+                    column: [existing[key][index] for key in sorted_keys]
+                    for index, column in enumerate(_COLUMNS)
+                }
+                table = pa.table(payload_dict)
+                partition_path.parent.mkdir(parents=True, exist_ok=True)
+                pq.write_table(table, partition_path)
+
+    def metadata(self) -> MutableMapping[str, str]:
+        return _ParquetMetadata(self._root() / _METADATA_FILENAME)
+
+    def latest_timestamp(self, key: str) -> float | None:
+        symbol, interval = key.split("::", maxsplit=1)
+        base = self._symbol_dir(symbol, interval)
+        if not base.exists():
+            return None
+
+        for year_dir in sorted(base.glob("year=*"), reverse=True):
+            for month_dir in sorted(year_dir.glob("month=*"), reverse=True):
+                file_path = month_dir / _PARTITION_FILENAME
+                if not file_path.exists():
+                    continue
+                table = pq.read_table(file_path, columns=["open_time"])
+                if table.num_rows == 0:
+                    continue
+                values = [float(value.as_py()) for value in table.column("open_time")]
+                if values:
+                    return max(values)
+        return None
+
+
+__all__ = ["ParquetCacheStorage"]

--- a/bot_core/data/ohlcv/sqlite_storage.py
+++ b/bot_core/data/ohlcv/sqlite_storage.py
@@ -48,14 +48,15 @@ class _SQLiteMetadata(MutableMapping[str, str]):
 
 
 class SQLiteCacheStorage(CacheStorage):
-    """Przechowuje dane OHLCV w lokalnej bazie SQLite."""
+    """Przechowuje dane OHLCV lub pełni rolę manifestu metadanych."""
 
-    def __init__(self, database_path: str | Path) -> None:
+    def __init__(self, database_path: str | Path, *, store_rows: bool = True) -> None:
         path = Path(database_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         self._connection = sqlite3.connect(path, detect_types=sqlite3.PARSE_DECLTYPES)
         self._connection.execute("PRAGMA journal_mode=WAL")
         self._connection.execute("PRAGMA synchronous=NORMAL")
+        self._store_rows = store_rows
         self._initialize()
 
     def _initialize(self) -> None:
@@ -85,6 +86,8 @@ class SQLiteCacheStorage(CacheStorage):
             )
 
     def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        if not self._store_rows:
+            raise KeyError(key)
         symbol, interval = key.split("::", maxsplit=1)
         cursor = self._connection.execute(
             """
@@ -100,8 +103,15 @@ class SQLiteCacheStorage(CacheStorage):
 
     def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
         symbol, interval = key.split("::", maxsplit=1)
-        rows = payload.get("rows", [])
+        rows = [tuple(row) for row in payload.get("rows", []) if row]
         if not rows:
+            return
+        # Aktualizujemy metadane manifestu niezależnie od tego, czy przechowujemy świeczki.
+        max_timestamp = max(float(row[0]) for row in rows)
+        metadata = self.metadata()
+        metadata[f"last_timestamp::{symbol}::{interval}"] = str(int(max_timestamp))
+        metadata[f"row_count::{symbol}::{interval}"] = str(len(rows))
+        if not self._store_rows:
             return
         with self._connection:
             self._connection.executemany(
@@ -135,6 +145,15 @@ class SQLiteCacheStorage(CacheStorage):
 
     def latest_timestamp(self, key: str) -> float | None:
         symbol, interval = key.split("::", maxsplit=1)
+        if not self._store_rows:
+            metadata = self.metadata()
+            value = metadata.get(f"last_timestamp::{symbol}::{interval}")
+            if value is None:
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):  # pragma: no cover - niepoprawny wpis metadanych
+                return None
         cursor = self._connection.execute(
             """
             SELECT MAX(open_time) FROM ohlcv

--- a/bot_core/data/ohlcv/storage.py
+++ b/bot_core/data/ohlcv/storage.py
@@ -1,0 +1,34 @@
+"""Dodatkowe implementacje CacheStorage."""
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Mapping, Sequence
+
+from bot_core.data.base import CacheStorage
+
+
+class DualCacheStorage(CacheStorage):
+    """Łączy magazyn danych (np. Parquet) oraz manifest metadanych (SQLite)."""
+
+    def __init__(self, primary: CacheStorage, manifest: CacheStorage) -> None:
+        self._primary = primary
+        self._manifest = manifest
+
+    def read(self, key: str) -> Mapping[str, Sequence[Sequence[float]]]:
+        return self._primary.read(key)
+
+    def write(self, key: str, payload: Mapping[str, Sequence[Sequence[float]]]) -> None:
+        self._primary.write(key, payload)
+        self._manifest.write(key, payload)
+
+    def metadata(self) -> MutableMapping[str, str]:
+        return self._manifest.metadata()
+
+    def latest_timestamp(self, key: str) -> float | None:
+        timestamp = self._manifest.latest_timestamp(key)
+        if timestamp is not None:
+            return timestamp
+        return self._primary.latest_timestamp(key)
+
+
+__all__ = ["DualCacheStorage"]

--- a/bot_core/exchanges/zonda/spot.py
+++ b/bot_core/exchanges/zonda/spot.py
@@ -262,7 +262,7 @@ class ZondaSpotAdapter(ExchangeAdapter):
         self,
         path: str,
         *,
-        params: Optional[Mapping[str, object]] = None,
+        params: Mapping[str, object] | None = None,
         method: str = "GET",
     ) -> dict[str, object] | list[object]:
         query = f"?{urlencode(params or {})}" if params else ""
@@ -274,8 +274,8 @@ class ZondaSpotAdapter(ExchangeAdapter):
         method: str,
         path: str,
         *,
-        params: Optional[Mapping[str, object]] = None,
-        data: Optional[Mapping[str, object]] = None,
+        params: Mapping[str, object] | None = None,
+        data: Mapping[str, object] | None = None,
     ) -> dict[str, object] | list[object]:
         if not self._credentials.secret:
             raise RuntimeError("Poświadczenia Zonda wymagają secret do podpisywania żądań prywatnych.")
@@ -299,7 +299,7 @@ class ZondaSpotAdapter(ExchangeAdapter):
         )
 
         query = f"?{urlencode(params)}" if params else ""
-        data_bytes: Optional[bytes] = None
+        data_bytes: bytes | None = None
         if body:
             data_bytes = body.encode("utf-8")
             headers["Content-Type"] = "application/json"

--- a/bot_core/risk/__init__.py
+++ b/bot_core/risk/__init__.py
@@ -2,6 +2,7 @@
 
 from bot_core.risk.base import RiskCheckResult, RiskEngine, RiskProfile, RiskRepository
 from bot_core.risk.engine import InMemoryRiskRepository, ThresholdRiskEngine
+from bot_core.risk.repository import FileRiskRepository
 from bot_core.risk.profiles.aggressive import AggressiveProfile
 from bot_core.risk.profiles.balanced import BalancedProfile
 from bot_core.risk.profiles.conservative import ConservativeProfile
@@ -11,6 +12,7 @@ __all__ = [
     "AggressiveProfile",
     "BalancedProfile",
     "ConservativeProfile",
+    "FileRiskRepository",
     "InMemoryRiskRepository",
     "ManualProfile",
     "RiskCheckResult",

--- a/bot_core/risk/repository.py
+++ b/bot_core/risk/repository.py
@@ -1,0 +1,82 @@
+"""Implementacje repozytoriów stanu ryzyka."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+from bot_core.risk.base import RiskRepository
+
+
+def _sanitize_profile_name(name: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+    return sanitized or "profile"
+
+
+def _normalize_state(state: Mapping[str, object]) -> Mapping[str, object]:
+    def _convert(value: object) -> object:
+        if isinstance(value, Mapping):
+            return {str(k): _convert(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [_convert(item) for item in value]
+        return value
+
+    return {str(key): _convert(value) for key, value in state.items()}
+
+
+class FileRiskRepository(RiskRepository):
+    """Przechowuje stan profili ryzyka w plikach JSON z atomowym zapisem."""
+
+    def __init__(
+        self,
+        directory: str | Path,
+        *,
+        encoding: str = "utf-8",
+        fsync: bool = False,
+    ) -> None:
+        self._base_path = Path(directory)
+        self._base_path.mkdir(parents=True, exist_ok=True)
+        self._encoding = encoding
+        self._fsync = fsync
+        self._lock = threading.Lock()
+
+    def load(self, profile: str) -> Mapping[str, object] | None:
+        path = self._path_for(profile)
+        try:
+            with self._lock:
+                with path.open("r", encoding=self._encoding) as handle:
+                    data = json.load(handle)
+        except FileNotFoundError:
+            return None
+        except (OSError, json.JSONDecodeError):
+            return None
+
+        if isinstance(data, Mapping):
+            return {str(key): value for key, value in data.items()}
+        return None
+
+    def store(self, profile: str, state: Mapping[str, object]) -> None:
+        path = self._path_for(profile)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        payload: MutableMapping[str, object] = dict(_normalize_state(state))
+        serialized = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+        with self._lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with tmp_path.open("w", encoding=self._encoding) as handle:
+                handle.write(serialized)
+                handle.write("\n")
+                handle.flush()
+                if self._fsync:
+                    os.fsync(handle.fileno())
+            os.replace(tmp_path, path)
+
+    def _path_for(self, profile: str) -> Path:
+        filename = f"{_sanitize_profile_name(profile)}.json"
+        return self._base_path / filename
+
+
+__all__ = ["FileRiskRepository"]

--- a/bot_core/runtime/realtime.py
+++ b/bot_core/runtime/realtime.py
@@ -1,12 +1,15 @@
 """Pętla czasu rzeczywistego dla strategii dziennych."""
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Callable, Sequence
 
 from bot_core.exchanges.base import OrderResult
 from bot_core.runtime.controller import ControllerSignal, DailyTrendController, TradingController
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -33,10 +36,20 @@ _INTERVAL_SECONDS: dict[str, float] = {
 
 
 def _interval_seconds(interval: str, fallback: float) -> float:
-    seconds = _INTERVAL_SECONDS.get(interval)
+    """Mapuje tekstowy interwał na liczbę sekund respektując wielkość liter."""
+
+    key = interval.strip()
+    seconds = _INTERVAL_SECONDS.get(key)
     if seconds is None:
-        seconds = _INTERVAL_SECONDS.get(interval.lower())
+        lowered = key.lower()
+        if lowered != key:
+            seconds = _INTERVAL_SECONDS.get(lowered)
     if seconds is None:
+        _LOGGER.warning(
+            "Nieznany interwał %s – używam wartości zapasowej %.2f s.",
+            interval,
+            fallback,
+        )
         seconds = fallback
     return max(fallback, seconds)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,12 @@ testpaths = ["tests"]
 filterwarnings = [
   "ignore::DeprecationWarning",
 ]
+[project]
+name = "dudzian-bot"
+version = "0.1.0"
+description = "Modułowy bot tradingowy"
+requires-python = ">=3.10"
+dependencies = [
+  "pyarrow>=21.0.0",
+]
+

--- a/tests/test_parquet_storage.py
+++ b/tests/test_parquet_storage.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+
+import pyarrow.parquet as pq
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.data.ohlcv import ParquetCacheStorage, DualCacheStorage, SQLiteCacheStorage
+
+
+def _timestamp(year: int, month: int, day: int) -> float:
+    return datetime(year, month, day, tzinfo=timezone.utc).timestamp() * 1000
+
+
+def _payload(*timestamps: float) -> dict[str, object]:
+    rows = []
+    for index, ts in enumerate(timestamps, start=1):
+        rows.append([ts, float(index), float(index + 1), float(index + 2), float(index + 3), float(index + 4)])
+    return {
+        "columns": ("open_time", "open", "high", "low", "close", "volume"),
+        "rows": rows,
+    }
+
+
+def test_parquet_storage_writes_partitioned_files(tmp_path) -> None:
+    storage = ParquetCacheStorage(tmp_path, namespace="binance_spot")
+    key = "BTCUSDT::1d"
+    storage.write(key, _payload(_timestamp(2024, 1, 1), _timestamp(2024, 2, 1)))
+
+    jan_file = tmp_path / "binance_spot" / "BTCUSDT" / "1d" / "year=2024" / "month=01" / "data.parquet"
+    feb_file = tmp_path / "binance_spot" / "BTCUSDT" / "1d" / "year=2024" / "month=02" / "data.parquet"
+
+    assert jan_file.exists()
+    assert feb_file.exists()
+
+    read_payload = storage.read(key)
+    assert len(read_payload["rows"]) == 2
+    assert read_payload["rows"][0][0] == _timestamp(2024, 1, 1)
+    assert read_payload["rows"][1][0] == _timestamp(2024, 2, 1)
+
+
+def test_parquet_storage_deduplicates_rows(tmp_path) -> None:
+    storage = ParquetCacheStorage(tmp_path, namespace="binance_spot")
+    key = "ETHUSDT::1d"
+    ts = _timestamp(2024, 3, 1)
+    storage.write(key, _payload(ts))
+
+    updated_payload = _payload(ts)
+    updated_payload["rows"][0][4] = 99.0
+    storage.write(key, updated_payload)
+
+    read_payload = storage.read(key)
+    assert len(read_payload["rows"]) == 1
+    assert read_payload["rows"][0][4] == 99.0
+
+
+def test_parquet_latest_timestamp_reads_last_partition(tmp_path) -> None:
+    storage = ParquetCacheStorage(tmp_path, namespace="kraken_spot")
+    key = "SOLUSDT::1h"
+    ts1 = _timestamp(2023, 12, 1)
+    ts2 = _timestamp(2024, 1, 15)
+    storage.write(key, _payload(ts1, ts2))
+
+    assert storage.latest_timestamp(key) == ts2
+
+
+def test_dual_cache_storage_updates_manifest(tmp_path) -> None:
+    parquet_storage = ParquetCacheStorage(tmp_path / "parquet", namespace="zonda_spot")
+    manifest_storage = SQLiteCacheStorage(tmp_path / "manifest.sqlite3", store_rows=False)
+    storage = DualCacheStorage(primary=parquet_storage, manifest=manifest_storage)
+    key = "BTCPLN::1d"
+    ts = _timestamp(2024, 5, 1)
+
+    storage.write(key, _payload(ts))
+
+    # Dane powinny być możliwe do odczytu z warstwy Parquet.
+    read_payload = storage.read(key)
+    assert read_payload["rows"][0][0] == ts
+
+    # Manifest przechowuje ostatni znacznik czasu oraz liczbę świec.
+    manifest_metadata = manifest_storage.metadata()
+    assert manifest_metadata.get(f"row_count::BTCPLN::1d") == "1"
+    assert storage.latest_timestamp(key) == ts
+
+    # Plik Parquet istnieje i zawiera pojedynczy rekord.
+    parquet_file = tmp_path / "parquet" / "zonda_spot" / "BTCPLN" / "1d" / "year=2024" / "month=05" / "data.parquet"
+    table = pq.read_table(parquet_file)
+    assert table.num_rows == 1

--- a/tests/test_risk_engine.py
+++ b/tests/test_risk_engine.py
@@ -11,6 +11,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from bot_core.exchanges.base import AccountSnapshot, OrderRequest
 from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.repository import FileRiskRepository
 from bot_core.risk.profiles.manual import ManualProfile
 
 
@@ -84,4 +85,127 @@ def test_daily_loss_limit_blocks_on_first_day(manual_profile: ManualProfile) -> 
 
     assert second_result.allowed is False
     assert "Przekroczono dzienny limit straty." in (second_result.reason or "")
+
+
+def test_margin_check_blocks_when_available_margin_is_too_low() -> None:
+    low_leverage_profile = ManualProfile(
+        name="low-margin",
+        max_positions=5,
+        max_leverage=1.0,
+        drawdown_limit=0.5,
+        daily_loss_limit=0.5,
+        max_position_pct=1.0,
+        target_volatility=0.2,
+        stop_loss_atr_multiple=2.0,
+    )
+
+    engine = ThresholdRiskEngine(clock=lambda: datetime(2024, 1, 1, 12, 0, 0))
+    engine.register_profile(low_leverage_profile)
+
+    snapshot = AccountSnapshot(
+        balances={"USDT": 1_000.0},
+        total_equity=1_000.0,
+        available_margin=500.0,
+        maintenance_margin=150.0,
+    )
+
+    request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.05,
+        order_type="limit",
+        price=20_000.0,
+    )
+
+    result = engine.apply_pre_trade_checks(
+        request,
+        account=snapshot,
+        profile_name=low_leverage_profile.name,
+    )
+
+    assert result.allowed is False
+    assert result.reason == "Niewystarczający wolny margines na otwarcie lub powiększenie pozycji."
+    assert result.adjustments is not None
+    max_quantity = result.adjustments.get("max_quantity") if result.adjustments else None
+    assert max_quantity is not None
+    # Dostępny margines po uwzględnieniu maintenance to 350 USDT.
+    assert max_quantity == pytest.approx(350.0 / 20_000.0, rel=1e-6)
+
+
+def test_margin_check_passes_when_leverage_covers_notional() -> None:
+    leveraged_profile = ManualProfile(
+        name="leveraged",
+        max_positions=5,
+        max_leverage=4.0,
+        drawdown_limit=0.5,
+        daily_loss_limit=0.5,
+        max_position_pct=1.0,
+        target_volatility=0.2,
+        stop_loss_atr_multiple=2.0,
+    )
+
+    engine = ThresholdRiskEngine(clock=lambda: datetime(2024, 1, 1, 12, 0, 0))
+    engine.register_profile(leveraged_profile)
+
+    snapshot = AccountSnapshot(
+        balances={"USDT": 1_000.0},
+        total_equity=1_000.0,
+        available_margin=500.0,
+        maintenance_margin=150.0,
+    )
+
+    request = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.05,
+        order_type="limit",
+        price=20_000.0,
+    )
+
+    result = engine.apply_pre_trade_checks(
+        request,
+        account=snapshot,
+        profile_name=leveraged_profile.name,
+    )
+
+    assert result.allowed is True
+
+
+def test_file_risk_repository_persists_state(tmp_path: Path, manual_profile: ManualProfile) -> None:
+    repository = FileRiskRepository(tmp_path)
+
+    clock = lambda: datetime(2024, 1, 1, 12, 0, 0)
+    engine = ThresholdRiskEngine(repository=repository, clock=clock)
+    engine.register_profile(manual_profile)
+
+    snapshot = _snapshot(1_000.0)
+    request = _order(20_000.0)
+
+    result = engine.apply_pre_trade_checks(
+        request,
+        account=snapshot,
+        profile_name=manual_profile.name,
+    )
+    assert result.allowed is True
+
+    engine.on_fill(
+        profile_name=manual_profile.name,
+        symbol="BTCUSDT",
+        side="buy",
+        position_value=500.0,
+        pnl=-15.0,
+        timestamp=datetime(2024, 1, 1, 13, 0, 0),
+    )
+
+    # Now instantiate a new engine sharing the same repository – state should persist.
+    new_engine = ThresholdRiskEngine(repository=repository, clock=lambda: datetime(2024, 1, 1, 14, 0, 0))
+    new_engine.register_profile(manual_profile)
+
+    state = new_engine._states[manual_profile.name]
+    assert state.start_of_day_equity == pytest.approx(1_000.0)
+    assert state.daily_realized_pnl == pytest.approx(-15.0)
+    assert "BTCUSDT" in state.positions
+    btc_position = state.positions["BTCUSDT"]
+    assert btc_position.side == "buy"
+    assert btc_position.notional == pytest.approx(500.0)
 

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -18,6 +18,7 @@ from bot_core.exchanges.base import (
     OrderResult,
 )
 from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.repository import FileRiskRepository
 from bot_core.runtime import BootstrapContext, bootstrap_environment
 from bot_core.security import SecretManager, SecretStorage
 
@@ -140,6 +141,7 @@ def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
     assert context.adapter.credentials.key_id == "paper-key"
 
     assert isinstance(context.risk_engine, ThresholdRiskEngine)
+    assert isinstance(context.risk_repository, FileRiskRepository)
     result = context.risk_engine.apply_pre_trade_checks(
         OrderRequest(symbol="BTCUSDT", side="buy", quantity=0.2, order_type="limit", price=100.0),
         account=AccountSnapshot(
@@ -172,6 +174,8 @@ def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
 
     assert context.risk_engine.should_liquidate(profile_name="balanced") is False
     assert context.adapter_settings == {}
+    risk_state_path = Path("./var/data/binance_paper/risk_state/balanced.json")
+    assert risk_state_path.parent.exists()
 
 
 def test_bootstrap_environment_supports_zonda(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- implement a Parquet-backed OHLCV cache with JSON metadata and a DualCacheStorage facade for manifest support
- extend the SQLite cache to operate as a metadata manifest and teach the backfill service to read stored row counts
- switch the backfill CLI to the new storage stack, add the pyarrow dependency, and cover the flow with dedicated tests

## Testing
- pytest tests/test_parquet_storage.py tests/test_ohlcv_backfill.py

------
https://chatgpt.com/codex/tasks/task_e_68d95db7eb54832a907813af8d9093c6