### PR TITLE
Add Kraken futures and Zonda backfill support

### DIFF
--- a/docs/runbooks/backfill.md
+++ b/docs/runbooks/backfill.md
@@ -1,0 +1,40 @@
+# Backfill danych OHLCV
+
+Skrypt `scripts/backfill.py` automatyzuje pobieranie oraz odświeżanie danych OHLCV
+z publicznych API giełd obsługiwanych przez platformę. Mechanizm korzysta z
+`PublicAPIDataSource`, lokalnej pamięci podręcznej Parquet/SQLite oraz
+harmonogramu `OHLCVRefreshScheduler`, dzięki czemu po pierwszym backfillu
+możliwe jest cykliczne dogrywanie świeżych danych.
+
+## Obsługiwane giełdy
+
+Aktualna konfiguracja `core_multi_exchange` obejmuje następujące adaptery
+publicznych API:
+
+- `binance_spot` – `BinanceSpotAdapter`
+- `binance_futures` – `BinanceFuturesAdapter`
+- `kraken_spot` – `KrakenSpotAdapter`
+- `kraken_futures` – `KrakenFuturesAdapter`
+- `zonda_spot` – `ZondaSpotAdapter`
+
+Skrypt automatycznie dobiera właściwy adapter na podstawie pola `exchange`
+ze wskazanego środowiska w `config/core.yaml`.
+
+## Wymagania sieciowe
+
+Część giełd (w szczególności Binance i Kraken) wymaga skonfigurowania listy
+zaufanych adresów IP (IP allowlist) dla kluczy API wykorzystywanych nawet do
+publicznych zapytań REST. Upewnij się, że każdy wpis `environments.*.ip_allowlist`
+w `config/core.yaml` obejmuje adres hosta, na którym uruchamiany jest backfill,
+w przeciwnym razie żądania mogą być odrzucane.
+
+## Uruchomienie
+
+Przykładowe uruchomienie pełnego backfillu dla środowiska `binance_paper`:
+
+```bash
+python scripts/backfill.py --environment binance_paper --run-once
+```
+
+Dla pracy ciągłej (backfill + inkrementalne odświeżanie) pomiń flagę `--run-once`
+i pozostaw proces działający w tle.

--- a/scripts/backfill.py
+++ b/scripts/backfill.py
@@ -23,7 +23,9 @@ from bot_core.data.ohlcv import (
 from bot_core.exchanges.base import Environment, ExchangeCredentials
 from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
 from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
 from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
+from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +49,18 @@ def _build_public_source(exchange: str, environment: Environment) -> PublicAPIDa
         ),
         "kraken_spot": lambda env: PublicAPIDataSource(
             exchange_adapter=KrakenSpotAdapter(ExchangeCredentials(key_id="public", environment=env), environment=env)
+        ),
+        "kraken_futures": lambda env: PublicAPIDataSource(
+            exchange_adapter=KrakenFuturesAdapter(
+                ExchangeCredentials(key_id="public", environment=env),
+                environment=env,
+            )
+        ),
+        "zonda_spot": lambda env: PublicAPIDataSource(
+            exchange_adapter=ZondaSpotAdapter(
+                ExchangeCredentials(key_id="public", environment=env),
+                environment=env,
+            )
         ),
     }
     try:

--- a/tests/test_backfill_cli.py
+++ b/tests/test_backfill_cli.py
@@ -1,0 +1,36 @@
+"""Tests for the backfill CLI helpers."""
+from __future__ import annotations
+
+from bot_core.config.loader import load_core_config
+from bot_core.exchanges.base import Environment
+from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
+from bot_core.exchanges.binance.spot import BinanceSpotAdapter
+from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
+from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
+from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
+
+from scripts.backfill import _build_public_source
+
+
+def test_build_public_source_supports_core_multi_exchange() -> None:
+    config = load_core_config("config/core.yaml")
+    universe = config.instrument_universes["core_multi_exchange"]
+
+    exchanges = {
+        exchange_name
+        for instrument in universe.instruments
+        for exchange_name in instrument.exchange_symbols
+    }
+
+    expected_types = {
+        "binance_spot": BinanceSpotAdapter,
+        "binance_futures": BinanceFuturesAdapter,
+        "kraken_spot": KrakenSpotAdapter,
+        "kraken_futures": KrakenFuturesAdapter,
+        "zonda_spot": ZondaSpotAdapter,
+    }
+
+    for exchange in exchanges:
+        public_source = _build_public_source(exchange, Environment.PAPER)
+        adapter_type = expected_types[exchange]
+        assert isinstance(public_source.exchange_adapter, adapter_type)


### PR DESCRIPTION
## Summary
- extend the backfill CLI to provide public data sources for Kraken Futures and Zonda Spot
- document backfill usage, including supported exchanges and IP allowlist requirements
- add a regression test ensuring all exchanges in the core multi-exchange universe are supported

## Testing
- pytest --override-ini addopts=


------
https://chatgpt.com/codex/tasks/task_e_68d9aab401ec832aa4d91c518162721f