### PR TITLE
Add ATR-aware position sizing limits to risk engine

### DIFF
--- a/bot_core/exchanges/base.py
+++ b/bot_core/exchanges/base.py
@@ -47,6 +47,8 @@ class OrderRequest:
     price: Optional[float] = None
     time_in_force: Optional[str] = None
     client_order_id: Optional[str] = None
+    stop_price: Optional[float] = None
+    atr: Optional[float] = None
 
 
 @dataclass(slots=True)

--- a/bot_core/runtime/bootstrap.py
+++ b/bot_core/runtime/bootstrap.py
@@ -44,8 +44,11 @@ from bot_core.exchanges.base import (
 from bot_core.exchanges.binance import BinanceFuturesAdapter, BinanceSpotAdapter
 from bot_core.exchanges.kraken import KrakenFuturesAdapter, KrakenSpotAdapter
 from bot_core.exchanges.zonda import ZondaSpotAdapter
-from bot_core.risk.base import RiskRepository
+from bot_core.risk.base import RiskProfile, RiskRepository
 from bot_core.risk.engine import ThresholdRiskEngine
+from bot_core.risk.profiles.aggressive import AggressiveProfile
+from bot_core.risk.profiles.balanced import BalancedProfile
+from bot_core.risk.profiles.conservative import ConservativeProfile
 from bot_core.risk.profiles.manual import ManualProfile
 from bot_core.risk.repository import FileRiskRepository
 from bot_core.security import SecretManager, SecretStorageError
@@ -61,6 +64,13 @@ _DEFAULT_ADAPTERS: Mapping[str, ExchangeAdapterFactory] = {
     "kraken_spot": KrakenSpotAdapter,
     "kraken_futures": KrakenFuturesAdapter,
     "zonda_spot": ZondaSpotAdapter,
+}
+
+
+_PROFILE_CLASS_BY_NAME: Mapping[str, type[RiskProfile]] = {
+    "conservative": ConservativeProfile,
+    "balanced": BalancedProfile,
+    "aggressive": AggressiveProfile,
 }
 
 
@@ -99,16 +109,7 @@ def bootstrap_environment(
     risk_repository_path = Path(environment.data_cache_path) / "risk_state"
     risk_repository = FileRiskRepository(risk_repository_path)
     risk_engine = ThresholdRiskEngine(repository=risk_repository)
-    profile = ManualProfile(
-        name=risk_profile_config.name,
-        max_positions=risk_profile_config.max_open_positions,
-        max_leverage=risk_profile_config.max_leverage,
-        drawdown_limit=risk_profile_config.hard_drawdown_pct,
-        daily_loss_limit=risk_profile_config.max_daily_loss_pct,
-        max_position_pct=risk_profile_config.max_position_pct,
-        target_volatility=risk_profile_config.target_volatility,
-        stop_loss_atr_multiple=risk_profile_config.stop_loss_atr_multiple,
-    )
+    profile = _build_risk_profile(risk_profile_config)
     risk_engine.register_profile(profile)
 
     credentials = secret_manager.load_exchange_credentials(
@@ -179,6 +180,36 @@ def _resolve_risk_profile(
         return profiles[profile_name]
     except KeyError as exc:
         raise KeyError(f"Profil ryzyka '{profile_name}' nie istnieje w konfiguracji") from exc
+
+
+def _build_risk_profile(config: RiskProfileConfig) -> RiskProfile:
+    profile_key = config.name.lower()
+    if profile_key == "manual":
+        return ManualProfile(
+            name=config.name,
+            max_positions=config.max_open_positions,
+            max_leverage=config.max_leverage,
+            drawdown_limit=config.hard_drawdown_pct,
+            daily_loss_limit=config.max_daily_loss_pct,
+            max_position_pct=config.max_position_pct,
+            target_volatility=config.target_volatility,
+            stop_loss_atr_multiple=config.stop_loss_atr_multiple,
+        )
+
+    profile_class = _PROFILE_CLASS_BY_NAME.get(profile_key)
+    if profile_class is not None:
+        return profile_class()
+
+    return ManualProfile(
+        name=config.name,
+        max_positions=config.max_open_positions,
+        max_leverage=config.max_leverage,
+        drawdown_limit=config.hard_drawdown_pct,
+        daily_loss_limit=config.max_daily_loss_pct,
+        max_position_pct=config.max_position_pct,
+        target_volatility=config.target_volatility,
+        stop_loss_atr_multiple=config.stop_loss_atr_multiple,
+    )
 
 
 def _build_alert_channels(

--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -857,9 +857,13 @@ class DailyTrendController:
         order_type = str(metadata.get("order_type", "market"))
         time_in_force = metadata.get("time_in_force")
         client_order_id = metadata.get("client_order_id")
+        stop_price_raw = metadata.get("stop_price")
+        atr_raw = metadata.get("atr")
 
         tif_str = str(time_in_force) if time_in_force is not None else None
         client_id_str = str(client_order_id) if client_order_id is not None else None
+        stop_price = float(stop_price_raw) if stop_price_raw is not None else None
+        atr = float(atr_raw) if atr_raw is not None else None
 
         return OrderRequest(
             symbol=snapshot.symbol,
@@ -869,6 +873,8 @@ class DailyTrendController:
             price=price,
             time_in_force=tif_str,
             client_order_id=client_id_str,
+            stop_price=stop_price,
+            atr=atr,
         )
 
     def _to_snapshots(

--- a/tests/test_pipeline_paper.py
+++ b/tests/test_pipeline_paper.py
@@ -243,6 +243,8 @@ def test_paper_pipeline_executes_and_alerts(tmp_path: Path) -> None:
         quantity=quantity,
         order_type="market",
         price=price,
+        stop_price=price - atr * profile.stop_loss_atr_multiple(),
+        atr=atr,
     )
 
     check = risk_engine.apply_pre_trade_checks(order, account=account, profile_name=profile.name)

--- a/tests/test_risk_engine.py
+++ b/tests/test_risk_engine.py
@@ -38,13 +38,28 @@ def _snapshot(equity: float) -> AccountSnapshot:
     )
 
 
-def _order(price: float) -> OrderRequest:
+def _order(
+    price: float,
+    *,
+    atr: float = 100.0,
+    side: str = "buy",
+    stop_multiple: float = 2.0,
+    quantity: float = 0.01,
+) -> OrderRequest:
+    side_normalized = side.lower()
+    stop_distance = atr * stop_multiple
+    if side_normalized == "buy":
+        stop_price = price - stop_distance
+    else:
+        stop_price = price + stop_distance
     return OrderRequest(
         symbol="BTCUSDT",
-        side="buy",
-        quantity=0.01,
+        side=side_normalized,
+        quantity=quantity,
         order_type="limit",
         price=price,
+        stop_price=stop_price,
+        atr=atr,
     )
 
 
@@ -115,6 +130,8 @@ def test_margin_check_blocks_when_available_margin_is_too_low() -> None:
         quantity=0.05,
         order_type="limit",
         price=20_000.0,
+        stop_price=20_000.0 - 400.0,
+        atr=200.0,
     )
 
     result = engine.apply_pre_trade_checks(
@@ -160,6 +177,8 @@ def test_margin_check_passes_when_leverage_covers_notional() -> None:
         quantity=0.05,
         order_type="limit",
         price=20_000.0,
+        stop_price=20_000.0 - 400.0,
+        atr=200.0,
     )
 
     result = engine.apply_pre_trade_checks(
@@ -169,6 +188,112 @@ def test_margin_check_passes_when_leverage_covers_notional() -> None:
     )
 
     assert result.allowed is True
+
+
+@pytest.mark.parametrize(
+    ("atr", "target_vol", "equity", "price"),
+    [
+        (150.0, 0.02, 20_000.0, 28_000.0),
+        (250.0, 0.01, 15_000.0, 24_000.0),
+    ],
+)
+def test_target_volatility_limits_position_size(
+    atr: float, target_vol: float, equity: float, price: float
+) -> None:
+    profile = ManualProfile(
+        name="volatility-aware",
+        max_positions=5,
+        max_leverage=10.0,
+        drawdown_limit=0.5,
+        daily_loss_limit=0.5,
+        max_position_pct=5.0,
+        target_volatility=target_vol,
+        stop_loss_atr_multiple=2.0,
+    )
+
+    engine = ThresholdRiskEngine(clock=lambda: datetime(2024, 1, 1, 12, 0, 0))
+    engine.register_profile(profile)
+
+    snapshot = _snapshot(equity)
+    risk_budget = target_vol * equity
+    expected_quantity = risk_budget / (atr * profile.stop_loss_atr_multiple())
+
+    oversized_order = _order(
+        price,
+        atr=atr,
+        quantity=expected_quantity * 1.5,
+        stop_multiple=profile.stop_loss_atr_multiple(),
+    )
+    result = engine.apply_pre_trade_checks(
+        oversized_order,
+        account=snapshot,
+        profile_name=profile.name,
+    )
+
+    assert result.allowed is False
+    assert result.adjustments is not None
+    assert result.adjustments["max_quantity"] == pytest.approx(expected_quantity, rel=1e-6)
+
+    allowed_order = _order(
+        price,
+        atr=atr,
+        quantity=expected_quantity * 0.95,
+        stop_multiple=profile.stop_loss_atr_multiple(),
+    )
+    allowed_result = engine.apply_pre_trade_checks(
+        allowed_order,
+        account=snapshot,
+        profile_name=profile.name,
+    )
+
+    assert allowed_result.allowed is True
+
+
+def test_stop_loss_must_match_atr_multiple(manual_profile: ManualProfile) -> None:
+    engine = ThresholdRiskEngine(clock=lambda: datetime(2024, 1, 1, 12, 0, 0))
+    engine.register_profile(manual_profile)
+
+    snapshot = _snapshot(5_000.0)
+    price = 25_000.0
+    atr = 120.0
+
+    mismatched_stop = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.05,
+        order_type="limit",
+        price=price,
+        stop_price=price - atr * manual_profile.stop_loss_atr_multiple() * 0.8,
+        atr=atr,
+    )
+
+    result = engine.apply_pre_trade_checks(
+        mismatched_stop,
+        account=snapshot,
+        profile_name=manual_profile.name,
+    )
+
+    assert result.allowed is False
+    assert "ATR" in (result.reason or "")
+
+    missing_stop = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=0.05,
+        order_type="limit",
+        price=price,
+        stop_price=None,
+        atr=atr,
+    )
+
+    missing_result = engine.apply_pre_trade_checks(
+        missing_stop,
+        account=snapshot,
+        profile_name=manual_profile.name,
+    )
+
+    assert missing_result.allowed is False
+    assert "stop loss" in (missing_result.reason or "").lower()
 
 
 def test_on_fill_normalizes_position_side_and_allows_growth(manual_profile: ManualProfile) -> None:
@@ -182,6 +307,8 @@ def test_on_fill_normalizes_position_side_and_allows_growth(manual_profile: Manu
         quantity=0.05,
         order_type="limit",
         price=30_000.0,
+        stop_price=30_000.0 - 400.0,
+        atr=200.0,
     )
 
     first_check = engine.apply_pre_trade_checks(request, account=snapshot, profile_name=manual_profile.name)

--- a/tests/test_risk_profiles.py
+++ b/tests/test_risk_profiles.py
@@ -87,7 +87,15 @@ def test_risk_engine_accepts_atr_informed_order(btc_daily_atr_series: list[float
     )
 
     quantity = _recommended_quantity(profile=profile, atr=atr, equity=equity, price=price, risk_pct=0.012)
-    order = OrderRequest(symbol="BTCUSDT", side="buy", quantity=quantity, order_type="market", price=price)
+    order = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=quantity,
+        order_type="market",
+        price=price,
+        stop_price=price - atr * profile.stop_loss_atr_multiple(),
+        atr=atr,
+    )
 
     check = engine.apply_pre_trade_checks(order, account=account, profile_name=profile.name)
     assert check.allowed, check.reason
@@ -99,6 +107,8 @@ def test_risk_engine_accepts_atr_informed_order(btc_daily_atr_series: list[float
         quantity=oversized_quantity,
         order_type="market",
         price=price,
+        stop_price=price - atr * profile.stop_loss_atr_multiple(),
+        atr=atr,
     )
 
     denial = engine.apply_pre_trade_checks(oversized_order, account=account, profile_name=profile.name)

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -147,7 +147,15 @@ def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
     assert isinstance(context.risk_engine, ThresholdRiskEngine)
     assert isinstance(context.risk_repository, FileRiskRepository)
     result = context.risk_engine.apply_pre_trade_checks(
-        OrderRequest(symbol="BTCUSDT", side="buy", quantity=0.2, order_type="limit", price=100.0),
+        OrderRequest(
+            symbol="BTCUSDT",
+            side="buy",
+            quantity=0.2,
+            order_type="limit",
+            price=100.0,
+            stop_price=100.0 - 1.0 * 1.5,
+            atr=1.0,
+        ),
         account=AccountSnapshot(
             balances={"USDT": 1000.0},
             total_equity=1000.0,


### PR DESCRIPTION
## Summary
- map configured risk profile names onto the dedicated profile implementations during bootstrap
- extend order requests and the daily trend controller to propagate ATR and stop-loss metadata to the risk engine
- enforce target-volatility position sizing and stop-loss validation in the risk engine with comprehensive unit coverage

## Testing
- pytest tests/test_risk_engine.py tests/test_risk_profiles.py

------
https://chatgpt.com/codex/tasks/task_e_68d9aace0ac8832aa477c8b7fe0e6d56