### PR TITLE
Monitor luk OHLCV z eskalacją alertów

### DIFF
--- a/bot_core/data/ohlcv/__init__.py
+++ b/bot_core/data/ohlcv/__init__.py
@@ -2,6 +2,7 @@
 
 from bot_core.data.ohlcv.backfill import BackfillSummary, OHLCVBackfillService
 from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+from bot_core.data.ohlcv.gap_monitor import DataGapIncidentTracker, GapAlertPolicy
 from bot_core.data.ohlcv.parquet_storage import ParquetCacheStorage
 from bot_core.data.ohlcv.scheduler import OHLCVRefreshScheduler
 from bot_core.data.ohlcv.sqlite_storage import SQLiteCacheStorage
@@ -10,6 +11,8 @@ from bot_core.data.ohlcv.storage import DualCacheStorage
 __all__ = [
     "BackfillSummary",
     "CachedOHLCVSource",
+    "DataGapIncidentTracker",
+    "GapAlertPolicy",
     "OHLCVBackfillService",
     "OHLCVRefreshScheduler",
     "ParquetCacheStorage",

--- a/bot_core/data/ohlcv/gap_monitor.py
+++ b/bot_core/data/ohlcv/gap_monitor.py
@@ -1,0 +1,257 @@
+"""Monitor luk danych OHLCV z integracją alertów."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Mapping, MutableMapping, Sequence
+
+from bot_core.alerts import AlertMessage, AlertRouter
+
+_MILLISECONDS_IN_MINUTE = 60_000
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _interval_to_minutes(interval: str) -> int:
+    mapping = {
+        "1m": 1,
+        "3m": 3,
+        "5m": 5,
+        "15m": 15,
+        "30m": 30,
+        "1h": 60,
+        "2h": 120,
+        "4h": 240,
+        "6h": 360,
+        "8h": 480,
+        "12h": 720,
+        "1d": 1440,
+        "3d": 4320,
+        "1w": 10_080,
+        "1M": 43_200,
+    }
+    try:
+        return mapping[interval]
+    except KeyError as exc:  # pragma: no cover - walidacja configu na starcie
+        raise ValueError(f"Nieobsługiwany interwał: {interval}") from exc
+
+
+@dataclass(slots=True)
+class GapAlertPolicy:
+    """Parametry eskalacji luk danych."""
+
+    warning_gap_minutes: Mapping[str, int]
+    incident_threshold_count: int = 5
+    incident_window_minutes: int = 10
+    sms_escalation_minutes: int = 15
+
+    def warning_threshold_minutes(self, interval: str) -> int:
+        minutes = self.warning_gap_minutes.get(interval)
+        if minutes is not None:
+            return max(1, int(minutes))
+        # domyślnie przyjmujemy dwukrotność interwału jako bezpieczne okno
+        return max(1, _interval_to_minutes(interval) * 2)
+
+
+@dataclass(slots=True)
+class _GapState:
+    warnings: list[datetime] = field(default_factory=list)
+    incident_open: bool = False
+    incident_open_at: datetime | None = None
+    sms_escalated: bool = False
+
+    def register_warning(self, timestamp: datetime, *, window: timedelta) -> int:
+        self.warnings.append(timestamp)
+        cutoff = timestamp - window
+        self.warnings = [entry for entry in self.warnings if entry >= cutoff]
+        return len(self.warnings)
+
+    def reset(self) -> None:
+        self.warnings.clear()
+        self.incident_open = False
+        self.incident_open_at = None
+        self.sms_escalated = False
+
+
+@dataclass(slots=True)
+class DataGapIncidentTracker:
+    """Pilnuje luk w danych OHLCV i wysyła alerty zgodnie z polityką eskalacji."""
+
+    router: AlertRouter
+    metadata_provider: Callable[[], MutableMapping[str, str]]
+    policy: GapAlertPolicy
+    environment_name: str
+    exchange: str
+    clock: Callable[[], datetime] = _utc_now
+
+    _states: dict[tuple[str, str], _GapState] = field(default_factory=dict, init=False, repr=False)
+
+    def handle_summaries(
+        self,
+        *,
+        interval: str,
+        summaries: Sequence[object],
+        as_of_ms: int,
+    ) -> None:
+        if not summaries:
+            return
+        metadata = self.metadata_provider()
+        for summary in summaries:
+            symbol = getattr(summary, "symbol", None)
+            if not symbol:
+                continue
+            state = self._states.setdefault((symbol, interval), _GapState())
+            last_ts_key = f"last_timestamp::{symbol}::{interval}"
+            row_count_key = f"row_count::{symbol}::{interval}"
+            last_ts_raw = metadata.get(last_ts_key)
+            row_count_raw = metadata.get(row_count_key)
+
+            if last_ts_raw is None:
+                # brak danych – traktujemy jak incydent krytyczny
+                self._emit_alert(
+                    severity="critical",
+                    title=f"Brak danych OHLCV {symbol} {interval}",
+                    body=(
+                        "Manifest nie posiada wpisu last_timestamp – należy zweryfikować pipeline backfillu."
+                    ),
+                    context={
+                        "environment": self.environment_name,
+                        "exchange": self.exchange,
+                        "symbol": symbol,
+                        "interval": interval,
+                        "row_count": str(row_count_raw or "0"),
+                    },
+                )
+                continue
+
+            try:
+                last_ts_ms = int(float(last_ts_raw))
+            except (TypeError, ValueError):
+                self._emit_alert(
+                    severity="critical",
+                    title=f"Uszkodzona metadana OHLCV {symbol} {interval}",
+                    body="Wartość last_timestamp nie jest liczbą – konieczna ręczna interwencja.",
+                    context={
+                        "environment": self.environment_name,
+                        "exchange": self.exchange,
+                        "symbol": symbol,
+                        "interval": interval,
+                        "raw_value": str(last_ts_raw),
+                    },
+                )
+                continue
+
+            gap_ms = max(0, as_of_ms - last_ts_ms)
+            gap_minutes = gap_ms / _MILLISECONDS_IN_MINUTE
+            warning_threshold = self.policy.warning_threshold_minutes(interval)
+
+            now = self.clock()
+            if gap_minutes < warning_threshold:
+                if state.incident_open:
+                    duration = (
+                        (now - state.incident_open_at).total_seconds() / 60
+                        if state.incident_open_at
+                        else 0
+                    )
+                    self._emit_alert(
+                        severity="info",
+                        title=f"Incydent zamknięty – luka danych {symbol} {interval}",
+                        body=(
+                            "Dane OHLCV zostały uzupełnione. Zamykam incydent i resetuję licznik ostrzeżeń."
+                        ),
+                        context={
+                            "environment": self.environment_name,
+                            "exchange": self.exchange,
+                            "symbol": symbol,
+                            "interval": interval,
+                            "incident_minutes": f"{duration:.1f}",
+                            "gap_minutes": f"{gap_minutes:.1f}",
+                            "row_count": str(row_count_raw or "0"),
+                        },
+                    )
+                state.reset()
+                continue
+
+            window = timedelta(minutes=max(1, self.policy.incident_window_minutes))
+            warn_count = state.register_warning(now, window=window)
+
+            context = {
+                "environment": self.environment_name,
+                "exchange": self.exchange,
+                "symbol": symbol,
+                "interval": interval,
+                "gap_minutes": f"{gap_minutes:.1f}",
+                "row_count": str(row_count_raw or "0"),
+                "last_timestamp": datetime.fromtimestamp(last_ts_ms / 1000, tz=timezone.utc).isoformat(),
+            }
+
+            if not state.incident_open and warn_count >= self.policy.incident_threshold_count:
+                state.incident_open = True
+                state.incident_open_at = now
+                state.sms_escalated = False
+                self._emit_alert(
+                    severity="critical",
+                    title=f"INCIDENT – luka danych {symbol} {interval}",
+                    body=(
+                        "Wykryto powtarzające się luki w danych OHLCV. "
+                        "Incydent został otwarty i wymaga ręcznej analizy."
+                    ),
+                    context={
+                        **context,
+                        "warnings_in_window": str(warn_count),
+                        "window_minutes": str(self.policy.incident_window_minutes),
+                    },
+                )
+                continue
+
+            if state.incident_open:
+                assert state.incident_open_at is not None
+                elapsed = (now - state.incident_open_at).total_seconds() / 60
+                if (
+                    not state.sms_escalated
+                    and elapsed >= max(1, self.policy.sms_escalation_minutes)
+                ):
+                    state.sms_escalated = True
+                    self._emit_alert(
+                        severity="critical",
+                        title=f"Eskalacja SMS – luka danych {symbol} {interval}",
+                        body=(
+                            "Incydent trwa dłużej niż zakładany próg eskalacji. "
+                            "Wysyłam powiadomienie SMS zgodnie z polityką."
+                        ),
+                        context={**context, "incident_minutes": f"{elapsed:.1f}"},
+                    )
+                continue
+
+            # Ostrzeżenie Telegram – pojedynczy alert o dłuższej luce
+            self._emit_alert(
+                severity="warning",
+                title=f"Luka danych {symbol} {interval}",
+                body=(
+                    "Brak świec OHLCV od ponad wyznaczonego progu. Monitoruję dalsze próby synchronizacji."
+                ),
+                context={**context, "warnings_in_window": str(warn_count)},
+            )
+
+    def _emit_alert(
+        self,
+        *,
+        severity: str,
+        title: str,
+        body: str,
+        context: Mapping[str, str],
+    ) -> None:
+        message = AlertMessage(
+            category="data.ohlcv",
+            title=title,
+            body=body,
+            severity=severity,
+            context=dict(context),
+        )
+        self.router.dispatch(message)
+
+
+__all__ = ["GapAlertPolicy", "DataGapIncidentTracker"]
+

--- a/bot_core/runtime/bootstrap.py
+++ b/bot_core/runtime/bootstrap.py
@@ -131,7 +131,7 @@ def bootstrap_environment(
     )
     adapter.configure_network(ip_allowlist=environment.ip_allowlist or None)
 
-    alert_channels, alert_router, audit_log = _build_alert_channels(
+    alert_channels, alert_router, audit_log = build_alert_channels(
         core_config=core_config,
         environment=environment,
         secret_manager=secret_manager,
@@ -181,7 +181,7 @@ def _resolve_risk_profile(
         raise KeyError(f"Profil ryzyka '{profile_name}' nie istnieje w konfiguracji") from exc
 
 
-def _build_alert_channels(
+def build_alert_channels(
     *,
     core_config: CoreConfig,
     environment: EnvironmentConfig,
@@ -459,4 +459,4 @@ def _resolve_sms_provider(settings: SMSProviderSettings) -> SmsProviderConfig:
     )
 
 
-__all__ = ["BootstrapContext", "bootstrap_environment"]
+__all__ = ["BootstrapContext", "bootstrap_environment", "build_alert_channels"]

--- a/docs/runbooks/backfill.md
+++ b/docs/runbooks/backfill.md
@@ -6,6 +6,12 @@ z publicznych API giełd obsługiwanych przez platformę. Mechanizm korzysta z
 harmonogramu `OHLCVRefreshScheduler`, dzięki czemu po pierwszym backfillu
 możliwe jest cykliczne dogrywanie świeżych danych.
 
+Domyślne częstotliwości odświeżania zależą od interwału (np. `1d` co 24 h,
+`1h` co 15 min, `15m` co 5 min). W razie potrzeby można je nadpisać poprzez
+sekcję `environments.*.adapter_settings.ohlcv_refresh_overrides` w
+`config/core.yaml`, podając mapowanie `interwał -> sekundy` dla konkretnego
+środowiska.
+
 ## Obsługiwane giełdy
 
 Aktualna konfiguracja `core_multi_exchange` obejmuje następujące adaptery
@@ -38,3 +44,32 @@ python scripts/backfill.py --environment binance_paper --run-once
 
 Dla pracy ciągłej (backfill + inkrementalne odświeżanie) pomiń flagę `--run-once`
 i pozostaw proces działający w tle.
+
+## Monitoring luk danych i alerty
+
+Skrypt potrafi monitorować manifest SQLite i wysyłać alerty o długotrwałych
+lukach w danych OHLCV. Aby aktywować mechanizm, uruchom go z flagą
+`--enable-alerts`. W środowiskach headless (Linux bez środowiska graficznego)
+należy dodatkowo przekazać `--headless-passphrase` (oraz opcjonalnie
+`--headless-secrets-path`), aby `create_default_secret_storage` mogło otworzyć
+zaszyfrowany magazyn sekretów.
+
+Polityka eskalacji jest konfigurowalna poprzez sekcję
+`environments.*.adapter_settings.ohlcv_gap_alerts` w `config/core.yaml`.
+Przykład:
+
+```yaml
+ohlcv_gap_alerts:
+  warning_gap_minutes:
+    1d: 1800   # ostrzeżenie po ~30 godzinach braku świec dziennych
+    1h: 90     # ostrzeżenie po 90 minutach ciszy na interwale godzinowym
+    15m: 20    # ostrzeżenie po 20 minutach dla sanity-checków
+  incident_threshold_count: 5   # liczba ostrzeżeń w oknie, po której otwieramy incydent
+  incident_window_minutes: 10   # szerokość okna przesuwnego na eskalację (Telegram + e-mail)
+  sms_escalation_minutes: 15    # czas trwania incydentu po którym uruchamiamy SMS
+```
+
+Domyślne progi bazują na dwukrotności długości interwału i są bezpieczne dla
+środowiska demo/paper. Kanały alertowe (Telegram/e-mail/SMS) konfigurowane są
+tak jak dla runtime – wymagają obecności sekretów w natywnym keychainie lub
+zaszyfrowanym magazynie.

--- a/scripts/backfill.py
+++ b/scripts/backfill.py
@@ -9,11 +9,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
+from bot_core.alerts import DefaultAlertRouter
 from bot_core.config.loader import load_core_config
 from bot_core.config.models import CoreConfig, EnvironmentConfig, InstrumentUniverseConfig
 from bot_core.data.ohlcv import (
+    BackfillSummary,
     CachedOHLCVSource,
+    DataGapIncidentTracker,
     DualCacheStorage,
+    GapAlertPolicy,
     OHLCVBackfillService,
     OHLCVRefreshScheduler,
     ParquetCacheStorage,
@@ -26,10 +30,19 @@ from bot_core.exchanges.binance.spot import BinanceSpotAdapter
 from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
 from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
 from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
+from bot_core.runtime.bootstrap import build_alert_channels
+from bot_core.security import SecretManager, SecretStorageError, create_default_secret_storage
 
 _LOGGER = logging.getLogger(__name__)
 
 _MILLISECONDS_IN_DAY = 86_400_000
+
+
+_DEFAULT_REFRESH_SECONDS: Mapping[str, int] = {
+    "1d": 24 * 60 * 60,
+    "1h": 15 * 60,
+    "15m": 5 * 60,
+}
 
 
 @dataclass(slots=True)
@@ -37,6 +50,7 @@ class _IntervalPlan:
     symbols: set[str]
     backfill_start_ms: int
     incremental_lookback_ms: int
+    refresh_seconds: int
 
 
 def _build_public_source(exchange: str, environment: Environment) -> PublicAPIDataSource:
@@ -92,10 +106,13 @@ def _build_interval_plans(
     universe: InstrumentUniverseConfig,
     exchange_name: str,
     incremental_lookback_days: int,
+    refresh_overrides: Mapping[str, int] | None = None,
 ) -> tuple[dict[str, _IntervalPlan], set[str]]:
     plans: dict[str, _IntervalPlan] = {}
     symbols: set[str] = set()
     now_ms = _utc_now_ms()
+
+    overrides = {key: int(value) for key, value in (refresh_overrides or {}).items() if int(value) > 0}
 
     for instrument in universe.instruments:
         symbol = instrument.exchange_symbols.get(exchange_name)
@@ -107,7 +124,15 @@ def _build_interval_plans(
             start = now_ms - window.lookback_days * _MILLISECONDS_IN_DAY
             plan = plans.get(window.interval)
             if plan is None:
-                plan = _IntervalPlan(symbols=set(), backfill_start_ms=start, incremental_lookback_ms=0)
+                refresh_seconds = overrides.get(
+                    window.interval, _DEFAULT_REFRESH_SECONDS.get(window.interval, 0)
+                )
+                plan = _IntervalPlan(
+                    symbols=set(),
+                    backfill_start_ms=start,
+                    incremental_lookback_ms=0,
+                    refresh_seconds=refresh_seconds,
+                )
                 plans[window.interval] = plan
             plan.symbols.add(symbol)
             plan.backfill_start_ms = min(plan.backfill_start_ms, start)
@@ -116,6 +141,81 @@ def _build_interval_plans(
 
     return plans, symbols
 
+
+def _extract_gap_policy(environment: EnvironmentConfig) -> GapAlertPolicy:
+    settings: Mapping[str, object] = {}
+    if isinstance(environment.adapter_settings, Mapping):
+        candidate = environment.adapter_settings.get("ohlcv_gap_alerts")
+        if isinstance(candidate, Mapping):
+            settings = candidate
+
+    warnings_cfg = {}
+    raw_warnings = settings.get("warning_gap_minutes") if settings else None
+    if isinstance(raw_warnings, Mapping):
+        warnings_cfg = {
+            str(interval): max(1, int(value))
+            for interval, value in raw_warnings.items()
+            if value is not None and int(value) > 0
+        }
+
+    def _safe_int(key: str, default: int) -> int:
+        value = settings.get(key) if settings else None
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError):
+            return default
+
+    return GapAlertPolicy(
+        warning_gap_minutes=warnings_cfg,
+        incident_threshold_count=_safe_int("incident_threshold_count", 5),
+        incident_window_minutes=_safe_int("incident_window_minutes", 10),
+        sms_escalation_minutes=_safe_int("sms_escalation_minutes", 15),
+    )
+
+
+def _build_gap_callback(
+    gap_tracker: DataGapIncidentTracker | None,
+) -> Callable[[str, Sequence[BackfillSummary], int], None] | None:
+    if gap_tracker is None:
+        return None
+
+    def _callback(interval: str, summaries: Sequence[BackfillSummary], as_of_ms: int) -> None:
+        gap_tracker.handle_summaries(interval=interval, summaries=summaries, as_of_ms=as_of_ms)
+
+    return _callback
+
+
+def _initialize_alerting(
+    *,
+    args: argparse.Namespace,
+    config: CoreConfig,
+    environment: EnvironmentConfig,
+) -> tuple[DefaultAlertRouter | None, GapAlertPolicy | None, str]:
+    if not args.enable_alerts:
+        return None, None, "Alerty wyłączone flagą CLI"
+
+    try:
+        storage = create_default_secret_storage(
+            namespace=args.secret_namespace,
+            headless_passphrase=args.headless_passphrase,
+            headless_path=args.headless_secrets_path,
+        )
+    except SecretStorageError as exc:
+        return None, None, f"Nie udało się przygotować magazynu sekretów: {exc}"
+
+    secret_manager = SecretManager(storage, namespace=args.secret_namespace)
+
+    try:
+        _, router, _ = build_alert_channels(
+            core_config=config,
+            environment=environment,
+            secret_manager=secret_manager,
+        )
+    except SecretStorageError as exc:
+        return None, None, f"Nie udało się zbudować kanałów alertów: {exc}"
+
+    policy = _extract_gap_policy(environment)
+    return router, policy, "Kanały alertowe zainicjalizowane"
 
 def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Backfill danych OHLCV zgodnie z config/core.yaml")
@@ -144,6 +244,26 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         action="store_true",
         help="Wykonaj tylko pełny backfill i zakończ (bez harmonogramu)",
     )
+    parser.add_argument(
+        "--enable-alerts",
+        action="store_true",
+        help="Aktywuj wysyłkę alertów o lukach danych (wymaga skonfigurowanych sekretów)",
+    )
+    parser.add_argument(
+        "--secret-namespace",
+        default="dudzian.trading",
+        help="Namespace używany przy odczycie sekretów (keychain / plik szyfrowany)",
+    )
+    parser.add_argument(
+        "--headless-passphrase",
+        default=None,
+        help="Hasło do magazynu sekretów w środowiskach headless (Linux).",
+    )
+    parser.add_argument(
+        "--headless-secrets-path",
+        default=None,
+        help="Ścieżka do zaszyfrowanego magazynu sekretów w trybie headless.",
+    )
     return parser.parse_args(argv)
 
 
@@ -152,6 +272,7 @@ def _perform_backfill(
     service: OHLCVBackfillService,
     plans: Mapping[str, _IntervalPlan],
     end_timestamp: int,
+    gap_tracker: DataGapIncidentTracker | None = None,
 ) -> None:
     for interval, plan in plans.items():
         start = max(0, plan.backfill_start_ms)
@@ -168,6 +289,8 @@ def _perform_backfill(
             start=start,
             end=end_timestamp,
         )
+        if gap_tracker:
+            gap_tracker.handle_summaries(interval=interval, summaries=summaries, as_of_ms=end_timestamp)
         total = sum(summary.fetched_candles for summary in summaries)
         _LOGGER.info(
             "Zakończono backfill dla interval=%s – pobrano %s nowych świec",
@@ -183,15 +306,16 @@ async def _run_scheduler(
     refresh_seconds: int,
 ) -> None:
     for interval, plan in plans.items():
+        frequency = plan.refresh_seconds or refresh_seconds
         scheduler.add_job(
             symbols=tuple(sorted(plan.symbols)),
             interval=interval,
             lookback_ms=plan.incremental_lookback_ms or (_MILLISECONDS_IN_DAY * 1),
-            frequency_seconds=refresh_seconds,
+            frequency_seconds=frequency,
             name=f"{interval}:{len(plan.symbols)}",
         )
 
-    _LOGGER.info("Uruchamiam harmonogram odświeżania (co %s sekund)", refresh_seconds)
+    _LOGGER.info("Uruchamiam harmonogram odświeżania (domyślnie co %s sekund)", refresh_seconds)
     try:
         await scheduler.run_forever()
     finally:
@@ -210,10 +334,17 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     universe = _resolve_universe(config, environment)
 
+    refresh_overrides = {}
+    if isinstance(environment.adapter_settings, Mapping):
+        candidate = environment.adapter_settings.get("ohlcv_refresh_overrides")
+        if isinstance(candidate, Mapping):
+            refresh_overrides = candidate
+
     plans, symbols = _build_interval_plans(
         universe=universe,
         exchange_name=environment.exchange,
         incremental_lookback_days=max(1, args.incremental_lookback_days),
+        refresh_overrides=refresh_overrides,
     )
     if not plans:
         _LOGGER.warning("Brak instrumentów z zakresem backfill dla giełdy %s", environment.exchange)
@@ -224,6 +355,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     manifest_storage = SQLiteCacheStorage(cache_root / "ohlcv_manifest.sqlite", store_rows=False)
     storage = DualCacheStorage(primary=parquet_storage, manifest=manifest_storage)
 
+    alert_router, gap_policy, alert_message = _initialize_alerting(
+        args=args,
+        config=config,
+        environment=environment,
+    )
+    gap_tracker: DataGapIncidentTracker | None = None
+    if alert_router and gap_policy:
+        gap_tracker = DataGapIncidentTracker(
+            router=alert_router,
+            metadata_provider=storage.metadata,
+            policy=gap_policy,
+            environment_name=environment.name,
+            exchange=environment.exchange,
+        )
+        if alert_message:
+            _LOGGER.info(alert_message)
+    elif alert_message:
+        level = logging.INFO if not args.enable_alerts else logging.ERROR
+        _LOGGER.log(level, alert_message)
+
     upstream_source = _build_public_source(environment.exchange, environment.environment)
     upstream_source.exchange_adapter.configure_network(ip_allowlist=environment.ip_allowlist)
 
@@ -232,13 +383,21 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     backfill_service = OHLCVBackfillService(cached_source)
     now_ts = _utc_now_ms()
-    _perform_backfill(service=backfill_service, plans=plans, end_timestamp=now_ts)
+    _perform_backfill(
+        service=backfill_service,
+        plans=plans,
+        end_timestamp=now_ts,
+        gap_tracker=gap_tracker,
+    )
 
     if args.run_once:
         _LOGGER.info("Tryb run-once – kończę po pełnym backfillu")
         return 0
 
-    scheduler = OHLCVRefreshScheduler(backfill_service)
+    scheduler = OHLCVRefreshScheduler(
+        backfill_service,
+        on_job_complete=_build_gap_callback(gap_tracker),
+    )
     try:
         asyncio.run(
             _run_scheduler(

--- a/tests/test_backfill_cli.py
+++ b/tests/test_backfill_cli.py
@@ -1,7 +1,15 @@
-"""Tests for the backfill CLI helpers."""
-from __future__ import annotations
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from bot_core.config.loader import load_core_config
+from bot_core.config.models import (
+    InstrumentBackfillWindow,
+    InstrumentConfig,
+    InstrumentUniverseConfig,
+)
 from bot_core.exchanges.base import Environment
 from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
 from bot_core.exchanges.binance.spot import BinanceSpotAdapter
@@ -9,20 +17,14 @@ from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
 from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
 from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
 
-from scripts.backfill import _build_public_source
+import scripts.backfill as backfill
 
 
-def test_build_public_source_supports_core_multi_exchange() -> None:
+def test_build_public_source_supports_all_exchanges_from_universe():
     config = load_core_config("config/core.yaml")
     universe = config.instrument_universes["core_multi_exchange"]
 
-    exchanges = {
-        exchange_name
-        for instrument in universe.instruments
-        for exchange_name in instrument.exchange_symbols
-    }
-
-    expected_types = {
+    expected_adapters = {
         "binance_spot": BinanceSpotAdapter,
         "binance_futures": BinanceFuturesAdapter,
         "kraken_spot": KrakenSpotAdapter,
@@ -30,7 +32,101 @@ def test_build_public_source_supports_core_multi_exchange() -> None:
         "zonda_spot": ZondaSpotAdapter,
     }
 
+    exchanges = {
+        exchange_name
+        for instrument in universe.instruments
+        for exchange_name in instrument.exchange_symbols.keys()
+    }
+
     for exchange in exchanges:
-        public_source = _build_public_source(exchange, Environment.PAPER)
-        adapter_type = expected_types[exchange]
-        assert isinstance(public_source.exchange_adapter, adapter_type)
+        source = backfill._build_public_source(exchange, Environment.PAPER)
+        assert isinstance(source.exchange_adapter, expected_adapters[exchange])
+        assert source.exchange_adapter.credentials.key_id == "public"
+        assert source.exchange_adapter.credentials.environment == Environment.PAPER
+
+
+def test_build_interval_plans_assigns_refresh_seconds_and_lookbacks():
+    universe = InstrumentUniverseConfig(
+        name="test",
+        description="test",
+        instruments=(
+            InstrumentConfig(
+                name="BTC_USDT",
+                base_asset="BTC",
+                quote_asset="USDT",
+                categories=("core",),
+                exchange_symbols={"binance_spot": "BTCUSDT"},
+                backfill_windows=(
+                    InstrumentBackfillWindow(interval="1d", lookback_days=365),
+                    InstrumentBackfillWindow(interval="1h", lookback_days=30),
+                ),
+            ),
+        ),
+    )
+
+    plans, symbols = backfill._build_interval_plans(
+        universe=universe,
+        exchange_name="binance_spot",
+        incremental_lookback_days=7,
+        refresh_overrides={"1h": 120},
+    )
+
+    assert symbols == {"BTCUSDT"}
+    assert plans["1d"].refresh_seconds == backfill._DEFAULT_REFRESH_SECONDS["1d"]
+    assert plans["1d"].incremental_lookback_ms == 7 * backfill._MILLISECONDS_IN_DAY
+
+    assert plans["1h"].refresh_seconds == 120
+    assert plans["1h"].incremental_lookback_ms == 7 * backfill._MILLISECONDS_IN_DAY
+
+
+class _DummyScheduler:
+    def __init__(self) -> None:
+        self.jobs: list[dict] = []
+        self.stopped = False
+
+    def add_job(self, **kwargs):
+        self.jobs.append(kwargs)
+
+    async def run_forever(self):
+        return
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_run_scheduler_uses_interval_specific_frequency():
+    scheduler = _DummyScheduler()
+    plans = {
+        "1d": backfill._IntervalPlan(
+            symbols={"BTCUSDT"},
+            backfill_start_ms=0,
+            incremental_lookback_ms=backfill._MILLISECONDS_IN_DAY,
+            refresh_seconds=backfill._DEFAULT_REFRESH_SECONDS["1d"],
+        ),
+        "1h": backfill._IntervalPlan(
+            symbols={"ETHUSDT"},
+            backfill_start_ms=0,
+            incremental_lookback_ms=3 * backfill._MILLISECONDS_IN_DAY,
+            refresh_seconds=900,
+        ),
+    }
+
+    asyncio.run(
+        backfill._run_scheduler(
+            scheduler=scheduler,
+            plans=plans,
+            refresh_seconds=600,
+        )
+    )
+
+    assert scheduler.stopped is True
+    assert len(scheduler.jobs) == 2
+
+    job_daily = next(job for job in scheduler.jobs if job["interval"] == "1d")
+    job_hourly = next(job for job in scheduler.jobs if job["interval"] == "1h")
+
+    assert job_daily["frequency_seconds"] == backfill._DEFAULT_REFRESH_SECONDS["1d"]
+    assert job_daily["lookback_ms"] == backfill._MILLISECONDS_IN_DAY
+
+    assert job_hourly["frequency_seconds"] == 900
+    assert job_hourly["lookback_ms"] == 3 * backfill._MILLISECONDS_IN_DAY

--- a/tests/test_gap_monitor.py
+++ b/tests/test_gap_monitor.py
@@ -1,0 +1,150 @@
+from datetime import datetime, timedelta, timezone
+
+from bot_core.alerts import AlertMessage
+from bot_core.data.ohlcv.backfill import BackfillSummary
+from bot_core.data.ohlcv.gap_monitor import DataGapIncidentTracker, GapAlertPolicy
+
+
+class DummyRouter:
+    def __init__(self) -> None:
+        self.messages: list[AlertMessage] = []
+
+    def dispatch(self, message: AlertMessage) -> None:
+        self.messages.append(message)
+
+
+def _summary(symbol: str, interval: str, end: int) -> BackfillSummary:
+    return BackfillSummary(
+        symbol=symbol,
+        interval=interval,
+        requested_start=end - 600_000,
+        requested_end=end,
+        fetched_candles=0,
+        skipped_candles=0,
+    )
+
+
+def test_gap_tracker_sends_warning_on_threshold_exceeded() -> None:
+    router = DummyRouter()
+    now_ms = int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::BTCUSDT::1h": str(now_ms - 90 * 60_000),
+        "row_count::BTCUSDT::1h": "1200",
+    }
+    policy = GapAlertPolicy(warning_gap_minutes={"1h": 60})
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+    tracker.handle_summaries(interval="1h", summaries=[_summary("BTCUSDT", "1h", now_ms)], as_of_ms=now_ms)
+
+    assert len(router.messages) == 1
+    message = router.messages[0]
+    assert message.severity == "warning"
+    assert message.context["symbol"] == "BTCUSDT"
+    assert message.context["interval"] == "1h"
+
+
+def test_gap_tracker_opens_incident_after_repeated_warnings() -> None:
+    router = DummyRouter()
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    times = [base_time + timedelta(minutes=idx) for idx in range(3)]
+
+    def clock() -> datetime:
+        return times.pop(0)
+
+    now_ms = int((base_time + timedelta(minutes=30)).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::ETHUSDT::1h": str(now_ms - 180 * 60_000),
+        "row_count::ETHUSDT::1h": "600",
+    }
+    policy = GapAlertPolicy(
+        warning_gap_minutes={"1h": 60},
+        incident_threshold_count=3,
+        incident_window_minutes=10,
+        sms_escalation_minutes=15,
+    )
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=clock,
+    )
+
+    for _ in range(3):
+        tracker.handle_summaries(
+            interval="1h",
+            summaries=[_summary("ETHUSDT", "1h", now_ms)],
+            as_of_ms=now_ms,
+        )
+
+    assert len(router.messages) == 3
+    assert router.messages[-1].severity == "critical"
+    assert "INCIDENT" in router.messages[-1].title
+
+
+def test_gap_tracker_escalates_sms_and_recovers() -> None:
+    router = DummyRouter()
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    clock_times = [
+        base_time,
+        base_time + timedelta(minutes=2),
+        base_time + timedelta(minutes=4),
+        base_time + timedelta(minutes=20),
+        base_time + timedelta(minutes=40),
+    ]
+
+    def clock() -> datetime:
+        return clock_times.pop(0)
+
+    now_ms = int((base_time + timedelta(minutes=30)).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::SOLUSDT::15m": str(now_ms - 45 * 60_000),
+        "row_count::SOLUSDT::15m": "350",
+    }
+    policy = GapAlertPolicy(
+        warning_gap_minutes={"15m": 10},
+        incident_threshold_count=3,
+        incident_window_minutes=10,
+        sms_escalation_minutes=15,
+    )
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=clock,
+    )
+
+    for _ in range(3):
+        tracker.handle_summaries(
+            interval="15m",
+            summaries=[_summary("SOLUSDT", "15m", now_ms)],
+            as_of_ms=now_ms,
+        )
+
+    tracker.handle_summaries(
+        interval="15m",
+        summaries=[_summary("SOLUSDT", "15m", now_ms)],
+        as_of_ms=now_ms,
+    )
+
+    metadata["last_timestamp::SOLUSDT::15m"] = str(now_ms)
+    tracker.handle_summaries(
+        interval="15m",
+        summaries=[_summary("SOLUSDT", "15m", now_ms)],
+        as_of_ms=now_ms,
+    )
+
+    assert any("Eskalacja SMS" in msg.title for msg in router.messages)
+    assert router.messages[-1].severity == "info"
+    assert "Incydent zamknięty" in router.messages[-1].title
+


### PR DESCRIPTION
## Summary
- add a DataGapIncidentTracker and GapAlertPolicy to watch manifest metadata and escalate gaps via Telegram/e-mail/SMS
- extend the OHLCV scheduler and backfill CLI to emit gap alerts, initialize alert channels, and expose new CLI flags for secrets handling
- document the alert workflow in the backfill runbook and cover the tracker with unit tests

## Testing
- pytest --override-ini=addopts= tests/test_backfill_cli.py tests/test_gap_monitor.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a4edd8c4832a833101767f0e67e6