### PR TITLE
Log OHLCV gap audits during backfill

### DIFF
--- a/bot_core/data/ohlcv/__init__.py
+++ b/bot_core/data/ohlcv/__init__.py
@@ -1,7 +1,9 @@
 """Moduły związane z danymi OHLCV."""
 
+from bot_core.data.ohlcv.audit import GapAuditLogger, GapAuditRecord, JSONLGapAuditLogger
 from bot_core.data.ohlcv.backfill import BackfillSummary, OHLCVBackfillService
 from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+from bot_core.data.ohlcv.gap_monitor import DataGapIncidentTracker, GapAlertPolicy
 from bot_core.data.ohlcv.parquet_storage import ParquetCacheStorage
 from bot_core.data.ohlcv.scheduler import OHLCVRefreshScheduler
 from bot_core.data.ohlcv.sqlite_storage import SQLiteCacheStorage
@@ -9,7 +11,12 @@ from bot_core.data.ohlcv.storage import DualCacheStorage
 
 __all__ = [
     "BackfillSummary",
+    "GapAuditLogger",
+    "GapAuditRecord",
+    "JSONLGapAuditLogger",
     "CachedOHLCVSource",
+    "DataGapIncidentTracker",
+    "GapAlertPolicy",
     "OHLCVBackfillService",
     "OHLCVRefreshScheduler",
     "ParquetCacheStorage",

--- a/bot_core/data/ohlcv/audit.py
+++ b/bot_core/data/ohlcv/audit.py
@@ -1,0 +1,71 @@
+"""Audyt jakości danych OHLCV."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol
+
+
+@dataclass(slots=True)
+class GapAuditRecord:
+    """Pojedynczy wpis audytowy opisujący stan danych dla symbolu/interwału."""
+
+    timestamp: datetime
+    environment: str
+    exchange: str
+    symbol: str
+    interval: str
+    status: str
+    gap_minutes: float | None
+    row_count: int | None
+    last_timestamp: str | None
+    warnings_in_window: int | None = None
+    incident_minutes: float | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "timestamp": self.timestamp.isoformat(),
+            "environment": self.environment,
+            "exchange": self.exchange,
+            "symbol": self.symbol,
+            "interval": self.interval,
+            "status": self.status,
+            "gap_minutes": None if self.gap_minutes is None else round(self.gap_minutes, 3),
+            "row_count": self.row_count,
+            "last_timestamp": self.last_timestamp,
+            "warnings_in_window": self.warnings_in_window,
+            "incident_minutes": None
+            if self.incident_minutes is None
+            else round(self.incident_minutes, 3),
+        }
+
+
+class GapAuditLogger(Protocol):
+    """Interfejs loggera przyjmującego wpisy audytowe luk danych."""
+
+    def log(self, record: GapAuditRecord) -> None:
+        ...  # pragma: no cover - protokół typów
+
+
+class JSONLGapAuditLogger:
+    """Logger zapisujący wpisy audytowe w pliku JSONL (append-only)."""
+
+    def __init__(self, path: str | Path, *, fsync: bool = False) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._fsync = fsync
+
+    def log(self, record: GapAuditRecord) -> None:
+        payload = json.dumps(record.to_dict(), ensure_ascii=False)
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(payload + "\n")
+            if self._fsync:
+                handle.flush()
+                os.fsync(handle.fileno())
+
+
+__all__ = ["GapAuditRecord", "GapAuditLogger", "JSONLGapAuditLogger"]
+

--- a/bot_core/data/ohlcv/gap_monitor.py
+++ b/bot_core/data/ohlcv/gap_monitor.py
@@ -1,0 +1,386 @@
+"""Monitor luk danych OHLCV z integracją alertów."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Mapping, MutableMapping, Sequence
+
+from bot_core.alerts import AlertMessage, AlertRouter
+from bot_core.data.ohlcv.audit import GapAuditLogger, GapAuditRecord
+
+_MILLISECONDS_IN_MINUTE = 60_000
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _interval_to_minutes(interval: str) -> int:
+    mapping = {
+        "1m": 1,
+        "3m": 3,
+        "5m": 5,
+        "15m": 15,
+        "30m": 30,
+        "1h": 60,
+        "2h": 120,
+        "4h": 240,
+        "6h": 360,
+        "8h": 480,
+        "12h": 720,
+        "1d": 1440,
+        "3d": 4320,
+        "1w": 10_080,
+        "1M": 43_200,
+    }
+    try:
+        return mapping[interval]
+    except KeyError as exc:  # pragma: no cover - walidacja configu na starcie
+        raise ValueError(f"Nieobsługiwany interwał: {interval}") from exc
+
+
+def _safe_int(value: object | None) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+@dataclass(slots=True)
+class GapAlertPolicy:
+    """Parametry eskalacji luk danych."""
+
+    warning_gap_minutes: Mapping[str, int]
+    incident_threshold_count: int = 5
+    incident_window_minutes: int = 10
+    sms_escalation_minutes: int = 15
+
+    def warning_threshold_minutes(self, interval: str) -> int:
+        minutes = self.warning_gap_minutes.get(interval)
+        if minutes is not None:
+            return max(1, int(minutes))
+        # domyślnie przyjmujemy dwukrotność interwału jako bezpieczne okno
+        return max(1, _interval_to_minutes(interval) * 2)
+
+
+@dataclass(slots=True)
+class _GapState:
+    warnings: list[datetime] = field(default_factory=list)
+    incident_open: bool = False
+    incident_open_at: datetime | None = None
+    sms_escalated: bool = False
+
+    def register_warning(self, timestamp: datetime, *, window: timedelta) -> int:
+        self.warnings.append(timestamp)
+        cutoff = timestamp - window
+        self.warnings = [entry for entry in self.warnings if entry >= cutoff]
+        return len(self.warnings)
+
+    def reset(self) -> None:
+        self.warnings.clear()
+        self.incident_open = False
+        self.incident_open_at = None
+        self.sms_escalated = False
+
+
+@dataclass(slots=True)
+class DataGapIncidentTracker:
+    """Pilnuje luk w danych OHLCV i wysyła alerty zgodnie z polityką eskalacji."""
+
+    router: AlertRouter
+    metadata_provider: Callable[[], MutableMapping[str, str]]
+    policy: GapAlertPolicy
+    environment_name: str
+    exchange: str
+    clock: Callable[[], datetime] = _utc_now
+    audit_logger: GapAuditLogger | None = None
+
+    _states: dict[tuple[str, str], _GapState] = field(default_factory=dict, init=False, repr=False)
+
+    def _log_audit(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        status: str,
+        gap_minutes: float | None,
+        row_count: int | None,
+        last_timestamp_iso: str | None,
+        warnings_in_window: int | None,
+        incident_minutes: float | None,
+        event_time: datetime,
+    ) -> None:
+        if not self.audit_logger:
+            return
+        record = GapAuditRecord(
+            timestamp=event_time,
+            environment=self.environment_name,
+            exchange=self.exchange,
+            symbol=symbol,
+            interval=interval,
+            status=status,
+            gap_minutes=gap_minutes,
+            row_count=row_count,
+            last_timestamp=last_timestamp_iso,
+            warnings_in_window=warnings_in_window,
+            incident_minutes=incident_minutes,
+        )
+        try:
+            self.audit_logger.log(record)
+        except Exception:  # pragma: no cover - logowanie nie może zatrzymać pipeline'u
+            pass
+
+    def handle_summaries(
+        self,
+        *,
+        interval: str,
+        summaries: Sequence[object],
+        as_of_ms: int,
+    ) -> None:
+        if not summaries:
+            return
+        metadata = self.metadata_provider()
+        for summary in summaries:
+            symbol = getattr(summary, "symbol", None)
+            if not symbol:
+                continue
+            state = self._states.setdefault((symbol, interval), _GapState())
+            last_ts_key = f"last_timestamp::{symbol}::{interval}"
+            row_count_key = f"row_count::{symbol}::{interval}"
+            last_ts_raw = metadata.get(last_ts_key)
+            row_count_raw = metadata.get(row_count_key)
+
+            if last_ts_raw is None:
+                event_time = self.clock()
+                row_count = _safe_int(row_count_raw)
+                # brak danych – traktujemy jak incydent krytyczny
+                self._emit_alert(
+                    severity="critical",
+                    title=f"Brak danych OHLCV {symbol} {interval}",
+                    body=(
+                        "Manifest nie posiada wpisu last_timestamp – należy zweryfikować pipeline backfillu."
+                    ),
+                    context={
+                        "environment": self.environment_name,
+                        "exchange": self.exchange,
+                        "symbol": symbol,
+                        "interval": interval,
+                        "row_count": str(row_count_raw or "0"),
+                    },
+                )
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="missing_metadata",
+                    gap_minutes=None,
+                    row_count=row_count,
+                    last_timestamp_iso=None,
+                    warnings_in_window=None,
+                    incident_minutes=None,
+                    event_time=event_time,
+                )
+                continue
+
+            try:
+                last_ts_ms = int(float(last_ts_raw))
+            except (TypeError, ValueError):
+                event_time = self.clock()
+                row_count = _safe_int(row_count_raw)
+                self._emit_alert(
+                    severity="critical",
+                    title=f"Uszkodzona metadana OHLCV {symbol} {interval}",
+                    body="Wartość last_timestamp nie jest liczbą – konieczna ręczna interwencja.",
+                    context={
+                        "environment": self.environment_name,
+                        "exchange": self.exchange,
+                        "symbol": symbol,
+                        "interval": interval,
+                        "raw_value": str(last_ts_raw),
+                    },
+                )
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="invalid_metadata",
+                    gap_minutes=None,
+                    row_count=row_count,
+                    last_timestamp_iso=str(last_ts_raw),
+                    warnings_in_window=None,
+                    incident_minutes=None,
+                    event_time=event_time,
+                )
+                continue
+
+            gap_ms = max(0, as_of_ms - last_ts_ms)
+            gap_minutes = gap_ms / _MILLISECONDS_IN_MINUTE
+            warning_threshold = self.policy.warning_threshold_minutes(interval)
+
+            now = self.clock()
+            row_count = _safe_int(row_count_raw)
+            last_timestamp_iso = datetime.fromtimestamp(last_ts_ms / 1000, tz=timezone.utc).isoformat()
+
+            if gap_minutes < warning_threshold:
+                warnings_in_window = len(state.warnings)
+                incident_minutes = (
+                    (now - state.incident_open_at).total_seconds() / 60
+                    if state.incident_open and state.incident_open_at
+                    else None
+                )
+                if state.incident_open:
+                    self._emit_alert(
+                        severity="info",
+                        title=f"Incydent zamknięty – luka danych {symbol} {interval}",
+                        body=(
+                            "Dane OHLCV zostały uzupełnione. Zamykam incydent i resetuję licznik ostrzeżeń."
+                        ),
+                        context={
+                            "environment": self.environment_name,
+                            "exchange": self.exchange,
+                            "symbol": symbol,
+                            "interval": interval,
+                            "incident_minutes": f"{incident_minutes:.1f}" if incident_minutes is not None else "0.0",
+                            "gap_minutes": f"{gap_minutes:.1f}",
+                            "row_count": str(row_count_raw or "0"),
+                        },
+                    )
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="ok",
+                    gap_minutes=gap_minutes,
+                    row_count=row_count,
+                    last_timestamp_iso=last_timestamp_iso,
+                    warnings_in_window=warnings_in_window,
+                    incident_minutes=incident_minutes,
+                    event_time=now,
+                )
+                state.reset()
+                continue
+
+            window = timedelta(minutes=max(1, self.policy.incident_window_minutes))
+            warn_count = state.register_warning(now, window=window)
+
+            context = {
+                "environment": self.environment_name,
+                "exchange": self.exchange,
+                "symbol": symbol,
+                "interval": interval,
+                "gap_minutes": f"{gap_minutes:.1f}",
+                "row_count": str(row_count_raw or "0"),
+                "last_timestamp": last_timestamp_iso,
+            }
+
+            if not state.incident_open and warn_count >= self.policy.incident_threshold_count:
+                state.incident_open = True
+                state.incident_open_at = now
+                state.sms_escalated = False
+                self._emit_alert(
+                    severity="critical",
+                    title=f"INCIDENT – luka danych {symbol} {interval}",
+                    body=(
+                        "Wykryto powtarzające się luki w danych OHLCV. "
+                        "Incydent został otwarty i wymaga ręcznej analizy."
+                    ),
+                    context={
+                        **context,
+                        "warnings_in_window": str(warn_count),
+                        "window_minutes": str(self.policy.incident_window_minutes),
+                    },
+                )
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="incident",
+                    gap_minutes=gap_minutes,
+                    row_count=row_count,
+                    last_timestamp_iso=last_timestamp_iso,
+                    warnings_in_window=warn_count,
+                    incident_minutes=0.0,
+                    event_time=now,
+                )
+                continue
+
+            if state.incident_open:
+                assert state.incident_open_at is not None
+                elapsed = (now - state.incident_open_at).total_seconds() / 60
+                if (
+                    not state.sms_escalated
+                    and elapsed >= max(1, self.policy.sms_escalation_minutes)
+                ):
+                    state.sms_escalated = True
+                    self._emit_alert(
+                        severity="critical",
+                        title=f"Eskalacja SMS – luka danych {symbol} {interval}",
+                        body=(
+                            "Incydent trwa dłużej niż zakładany próg eskalacji. "
+                            "Wysyłam powiadomienie SMS zgodnie z polityką."
+                        ),
+                        context={**context, "incident_minutes": f"{elapsed:.1f}"},
+                    )
+                    self._log_audit(
+                        symbol=symbol,
+                        interval=interval,
+                        status="sms_escalated",
+                        gap_minutes=gap_minutes,
+                        row_count=row_count,
+                        last_timestamp_iso=last_timestamp_iso,
+                        warnings_in_window=warn_count,
+                        incident_minutes=elapsed,
+                        event_time=now,
+                    )
+                    continue
+
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="incident",
+                    gap_minutes=gap_minutes,
+                    row_count=row_count,
+                    last_timestamp_iso=last_timestamp_iso,
+                    warnings_in_window=warn_count,
+                    incident_minutes=elapsed,
+                    event_time=now,
+                )
+                continue
+
+            # Ostrzeżenie Telegram – pojedynczy alert o dłuższej luce
+            self._emit_alert(
+                severity="warning",
+                title=f"Luka danych {symbol} {interval}",
+                body=(
+                    "Brak świec OHLCV od ponad wyznaczonego progu. Monitoruję dalsze próby synchronizacji."
+                ),
+                context={**context, "warnings_in_window": str(warn_count)},
+            )
+            self._log_audit(
+                symbol=symbol,
+                interval=interval,
+                status="warning",
+                gap_minutes=gap_minutes,
+                row_count=row_count,
+                last_timestamp_iso=last_timestamp_iso,
+                warnings_in_window=warn_count,
+                incident_minutes=None,
+                event_time=now,
+            )
+
+    def _emit_alert(
+        self,
+        *,
+        severity: str,
+        title: str,
+        body: str,
+        context: Mapping[str, str],
+    ) -> None:
+        message = AlertMessage(
+            category="data.ohlcv",
+            title=title,
+            body=body,
+            severity=severity,
+            context=dict(context),
+        )
+        self.router.dispatch(message)
+
+
+__all__ = ["GapAlertPolicy", "DataGapIncidentTracker"]
+

--- a/bot_core/exchanges/base.py
+++ b/bot_core/exchanges/base.py
@@ -47,6 +47,7 @@ class OrderRequest:
     price: Optional[float] = None
     time_in_force: Optional[str] = None
     client_order_id: Optional[str] = None
+    metadata: Mapping[str, object] | None = None
 
 
 @dataclass(slots=True)

--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -165,7 +165,7 @@ def create_trading_controller(
     alert_router: DefaultAlertRouter,
     *,
     health_check_interval: float | int | timedelta = 3600,
-    order_metadata_defaults: Mapping[str, str] | None = None,
+    order_metadata_defaults: Mapping[str, object] | None = None,
 ) -> "TradingController":
     """Buduje TradingController spięty z komponentami pipeline'u."""
     if TradingController is None:

--- a/docs/runbooks/backfill.md
+++ b/docs/runbooks/backfill.md
@@ -6,6 +6,12 @@ z publicznych API giełd obsługiwanych przez platformę. Mechanizm korzysta z
 harmonogramu `OHLCVRefreshScheduler`, dzięki czemu po pierwszym backfillu
 możliwe jest cykliczne dogrywanie świeżych danych.
 
+Domyślne częstotliwości odświeżania zależą od interwału (np. `1d` co 24 h,
+`1h` co 15 min, `15m` co 5 min). W razie potrzeby można je nadpisać poprzez
+sekcję `environments.*.adapter_settings.ohlcv_refresh_overrides` w
+`config/core.yaml`, podając mapowanie `interwał -> sekundy` dla konkretnego
+środowiska.
+
 ## Obsługiwane giełdy
 
 Aktualna konfiguracja `core_multi_exchange` obejmuje następujące adaptery
@@ -38,3 +44,38 @@ python scripts/backfill.py --environment binance_paper --run-once
 
 Dla pracy ciągłej (backfill + inkrementalne odświeżanie) pomiń flagę `--run-once`
 i pozostaw proces działający w tle.
+
+## Monitoring luk danych i alerty
+
+Skrypt potrafi monitorować manifest SQLite i wysyłać alerty o długotrwałych
+lukach w danych OHLCV. Aby aktywować mechanizm, uruchom go z flagą
+`--enable-alerts`. W środowiskach headless (Linux bez środowiska graficznego)
+należy dodatkowo przekazać `--headless-passphrase` (oraz opcjonalnie
+`--headless-secrets-path`), aby `create_default_secret_storage` mogło otworzyć
+zaszyfrowany magazyn sekretów.
+
+Polityka eskalacji jest konfigurowalna poprzez sekcję
+`environments.*.adapter_settings.ohlcv_gap_alerts` w `config/core.yaml`.
+Przykład:
+
+```yaml
+ohlcv_gap_alerts:
+  warning_gap_minutes:
+    1d: 1800   # ostrzeżenie po ~30 godzinach braku świec dziennych
+    1h: 90     # ostrzeżenie po 90 minutach ciszy na interwale godzinowym
+    15m: 20    # ostrzeżenie po 20 minutach dla sanity-checków
+  incident_threshold_count: 5   # liczba ostrzeżeń w oknie, po której otwieramy incydent
+  incident_window_minutes: 10   # szerokość okna przesuwnego na eskalację (Telegram + e-mail)
+  sms_escalation_minutes: 15    # czas trwania incydentu po którym uruchamiamy SMS
+```
+
+Domyślne progi bazują na dwukrotności długości interwału i są bezpieczne dla
+środowiska demo/paper. Kanały alertowe (Telegram/e-mail/SMS) konfigurowane są
+tak jak dla runtime – wymagają obecności sekretów w natywnym keychainie lub
+zaszyfrowanym magazynie.
+
+Każdy przebieg backfillu zapisuje ponadto wpisy audytowe luk do pliku
+`<data_cache_path>/audit/<environment>_ohlcv_gaps.jsonl`, gdzie utrwalane są
+ostatni znany znacznik czasu, liczba świec oraz status (`ok`, `warning`,
+`incident`, `sms_escalated`). Plik jest w formacie JSONL i można go trzymać w
+retencji ≥24 miesięcy na potrzeby audytu operacyjnego.

--- a/tests/test_backfill_cli.py
+++ b/tests/test_backfill_cli.py
@@ -1,7 +1,15 @@
-"""Tests for the backfill CLI helpers."""
-from __future__ import annotations
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from bot_core.config.loader import load_core_config
+from bot_core.config.models import (
+    InstrumentBackfillWindow,
+    InstrumentConfig,
+    InstrumentUniverseConfig,
+)
 from bot_core.exchanges.base import Environment
 from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
 from bot_core.exchanges.binance.spot import BinanceSpotAdapter
@@ -9,20 +17,14 @@ from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
 from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
 from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
 
-from scripts.backfill import _build_public_source
+import scripts.backfill as backfill
 
 
-def test_build_public_source_supports_core_multi_exchange() -> None:
+def test_build_public_source_supports_all_exchanges_from_universe():
     config = load_core_config("config/core.yaml")
     universe = config.instrument_universes["core_multi_exchange"]
 
-    exchanges = {
-        exchange_name
-        for instrument in universe.instruments
-        for exchange_name in instrument.exchange_symbols
-    }
-
-    expected_types = {
+    expected_adapters = {
         "binance_spot": BinanceSpotAdapter,
         "binance_futures": BinanceFuturesAdapter,
         "kraken_spot": KrakenSpotAdapter,
@@ -30,7 +32,101 @@ def test_build_public_source_supports_core_multi_exchange() -> None:
         "zonda_spot": ZondaSpotAdapter,
     }
 
+    exchanges = {
+        exchange_name
+        for instrument in universe.instruments
+        for exchange_name in instrument.exchange_symbols.keys()
+    }
+
     for exchange in exchanges:
-        public_source = _build_public_source(exchange, Environment.PAPER)
-        adapter_type = expected_types[exchange]
-        assert isinstance(public_source.exchange_adapter, adapter_type)
+        source = backfill._build_public_source(exchange, Environment.PAPER)
+        assert isinstance(source.exchange_adapter, expected_adapters[exchange])
+        assert source.exchange_adapter.credentials.key_id == "public"
+        assert source.exchange_adapter.credentials.environment == Environment.PAPER
+
+
+def test_build_interval_plans_assigns_refresh_seconds_and_lookbacks():
+    universe = InstrumentUniverseConfig(
+        name="test",
+        description="test",
+        instruments=(
+            InstrumentConfig(
+                name="BTC_USDT",
+                base_asset="BTC",
+                quote_asset="USDT",
+                categories=("core",),
+                exchange_symbols={"binance_spot": "BTCUSDT"},
+                backfill_windows=(
+                    InstrumentBackfillWindow(interval="1d", lookback_days=365),
+                    InstrumentBackfillWindow(interval="1h", lookback_days=30),
+                ),
+            ),
+        ),
+    )
+
+    plans, symbols = backfill._build_interval_plans(
+        universe=universe,
+        exchange_name="binance_spot",
+        incremental_lookback_days=7,
+        refresh_overrides={"1h": 120},
+    )
+
+    assert symbols == {"BTCUSDT"}
+    assert plans["1d"].refresh_seconds == backfill._DEFAULT_REFRESH_SECONDS["1d"]
+    assert plans["1d"].incremental_lookback_ms == 7 * backfill._MILLISECONDS_IN_DAY
+
+    assert plans["1h"].refresh_seconds == 120
+    assert plans["1h"].incremental_lookback_ms == 7 * backfill._MILLISECONDS_IN_DAY
+
+
+class _DummyScheduler:
+    def __init__(self) -> None:
+        self.jobs: list[dict] = []
+        self.stopped = False
+
+    def add_job(self, **kwargs):
+        self.jobs.append(kwargs)
+
+    async def run_forever(self):
+        return
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_run_scheduler_uses_interval_specific_frequency():
+    scheduler = _DummyScheduler()
+    plans = {
+        "1d": backfill._IntervalPlan(
+            symbols={"BTCUSDT"},
+            backfill_start_ms=0,
+            incremental_lookback_ms=backfill._MILLISECONDS_IN_DAY,
+            refresh_seconds=backfill._DEFAULT_REFRESH_SECONDS["1d"],
+        ),
+        "1h": backfill._IntervalPlan(
+            symbols={"ETHUSDT"},
+            backfill_start_ms=0,
+            incremental_lookback_ms=3 * backfill._MILLISECONDS_IN_DAY,
+            refresh_seconds=900,
+        ),
+    }
+
+    asyncio.run(
+        backfill._run_scheduler(
+            scheduler=scheduler,
+            plans=plans,
+            refresh_seconds=600,
+        )
+    )
+
+    assert scheduler.stopped is True
+    assert len(scheduler.jobs) == 2
+
+    job_daily = next(job for job in scheduler.jobs if job["interval"] == "1d")
+    job_hourly = next(job for job in scheduler.jobs if job["interval"] == "1h")
+
+    assert job_daily["frequency_seconds"] == backfill._DEFAULT_REFRESH_SECONDS["1d"]
+    assert job_daily["lookback_ms"] == backfill._MILLISECONDS_IN_DAY
+
+    assert job_hourly["frequency_seconds"] == 900
+    assert job_hourly["lookback_ms"] == 3 * backfill._MILLISECONDS_IN_DAY

--- a/tests/test_gap_audit.py
+++ b/tests/test_gap_audit.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from bot_core.data.ohlcv.audit import GapAuditRecord, JSONLGapAuditLogger
+
+
+def test_jsonl_gap_audit_logger_appends(tmp_path) -> None:
+    path = tmp_path / "audit.jsonl"
+    logger = JSONLGapAuditLogger(path)
+    record = GapAuditRecord(
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        environment="demo",
+        exchange="binance_spot",
+        symbol="BTCUSDT",
+        interval="1h",
+        status="warning",
+        gap_minutes=30.0,
+        row_count=1200,
+        last_timestamp="2024-01-01T00:00:00+00:00",
+        warnings_in_window=1,
+        incident_minutes=None,
+    )
+
+    logger.log(record)
+
+    content = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(content) == 1
+    payload = json.loads(content[0])
+    assert payload["status"] == "warning"
+    assert payload["symbol"] == "BTCUSDT"

--- a/tests/test_gap_monitor.py
+++ b/tests/test_gap_monitor.py
@@ -1,0 +1,202 @@
+from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
+
+from bot_core.alerts import AlertMessage
+from bot_core.data.ohlcv.audit import GapAuditRecord
+from bot_core.data.ohlcv.backfill import BackfillSummary
+from bot_core.data.ohlcv.gap_monitor import DataGapIncidentTracker, GapAlertPolicy
+
+
+class DummyRouter:
+    def __init__(self) -> None:
+        self.messages: list[AlertMessage] = []
+
+    def dispatch(self, message: AlertMessage) -> None:
+        self.messages.append(message)
+
+
+class DummyAuditLogger:
+    def __init__(self) -> None:
+        self.records: list[GapAuditRecord] = []
+
+    def log(self, record: GapAuditRecord) -> None:
+        self.records.append(record)
+
+
+def _summary(symbol: str, interval: str, end: int) -> BackfillSummary:
+    return BackfillSummary(
+        symbol=symbol,
+        interval=interval,
+        requested_start=end - 600_000,
+        requested_end=end,
+        fetched_candles=0,
+        skipped_candles=0,
+    )
+
+
+def test_gap_tracker_sends_warning_on_threshold_exceeded() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    now_ms = int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::BTCUSDT::1h": str(now_ms - 90 * 60_000),
+        "row_count::BTCUSDT::1h": "1200",
+    }
+    policy = GapAlertPolicy(warning_gap_minutes={"1h": 60})
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc),
+        audit_logger=audit,
+    )
+
+    tracker.handle_summaries(interval="1h", summaries=[_summary("BTCUSDT", "1h", now_ms)], as_of_ms=now_ms)
+
+    assert len(router.messages) == 1
+    message = router.messages[0]
+    assert message.severity == "warning"
+    assert message.context["symbol"] == "BTCUSDT"
+    assert message.context["interval"] == "1h"
+
+    assert len(audit.records) == 1
+    record = audit.records[0]
+    assert record.status == "warning"
+    assert record.symbol == "BTCUSDT"
+    assert record.interval == "1h"
+
+
+def test_gap_tracker_opens_incident_after_repeated_warnings() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    times = [base_time + timedelta(minutes=idx) for idx in range(3)]
+
+    def clock() -> datetime:
+        return times.pop(0)
+
+    now_ms = int((base_time + timedelta(minutes=30)).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::ETHUSDT::1h": str(now_ms - 180 * 60_000),
+        "row_count::ETHUSDT::1h": "600",
+    }
+    policy = GapAlertPolicy(
+        warning_gap_minutes={"1h": 60},
+        incident_threshold_count=3,
+        incident_window_minutes=10,
+        sms_escalation_minutes=15,
+    )
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=clock,
+        audit_logger=audit,
+    )
+
+    for _ in range(3):
+        tracker.handle_summaries(
+            interval="1h",
+            summaries=[_summary("ETHUSDT", "1h", now_ms)],
+            as_of_ms=now_ms,
+        )
+
+    assert len(router.messages) == 3
+    assert router.messages[-1].severity == "critical"
+    assert "INCIDENT" in router.messages[-1].title
+
+    statuses = [record.status for record in audit.records]
+    assert statuses.count("warning") == 2
+    assert statuses[-1] == "incident"
+
+
+def test_gap_tracker_escalates_sms_and_recovers() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    clock_times = [
+        base_time,
+        base_time + timedelta(minutes=2),
+        base_time + timedelta(minutes=4),
+        base_time + timedelta(minutes=20),
+        base_time + timedelta(minutes=40),
+    ]
+
+    def clock() -> datetime:
+        return clock_times.pop(0)
+
+    now_ms = int((base_time + timedelta(minutes=30)).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::SOLUSDT::15m": str(now_ms - 45 * 60_000),
+        "row_count::SOLUSDT::15m": "350",
+    }
+    policy = GapAlertPolicy(
+        warning_gap_minutes={"15m": 10},
+        incident_threshold_count=3,
+        incident_window_minutes=10,
+        sms_escalation_minutes=15,
+    )
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=clock,
+        audit_logger=audit,
+    )
+
+    for _ in range(3):
+        tracker.handle_summaries(
+            interval="15m",
+            summaries=[_summary("SOLUSDT", "15m", now_ms)],
+            as_of_ms=now_ms,
+        )
+
+    tracker.handle_summaries(
+        interval="15m",
+        summaries=[_summary("SOLUSDT", "15m", now_ms)],
+        as_of_ms=now_ms,
+    )
+
+    metadata["last_timestamp::SOLUSDT::15m"] = str(now_ms)
+    tracker.handle_summaries(
+        interval="15m",
+        summaries=[_summary("SOLUSDT", "15m", now_ms)],
+        as_of_ms=now_ms,
+    )
+
+    assert any("Eskalacja SMS" in msg.title for msg in router.messages)
+    assert router.messages[-1].severity == "info"
+    assert "Incydent zamknięty" in router.messages[-1].title
+
+    statuses = [record.status for record in audit.records]
+    assert "sms_escalated" in statuses
+    assert statuses[-1] == "ok"
+
+
+def test_gap_tracker_audit_records_missing_metadata() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    now_ms = int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    metadata: dict[str, str] = {"row_count::BTCPLN::1h": "42"}
+    policy = GapAlertPolicy(warning_gap_minutes={})
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="paper",
+        exchange="zonda_spot",
+        clock=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc),
+        audit_logger=audit,
+    )
+
+    tracker.handle_summaries(interval="1h", summaries=[_summary("BTCPLN", "1h", now_ms)], as_of_ms=now_ms)
+
+    assert router.messages[-1].severity == "critical"
+    assert audit.records[-1].status == "missing_metadata"
+

--- a/tests/test_pipeline_paper.py
+++ b/tests/test_pipeline_paper.py
@@ -243,6 +243,12 @@ def test_paper_pipeline_executes_and_alerts(tmp_path: Path) -> None:
         quantity=quantity,
         order_type="market",
         price=price,
+        metadata={
+            "atr": atr,
+            "stop_price": float(signal.metadata["stop_price"]),
+            "quantity": quantity,
+            "price": price,
+        },
     )
 
     check = risk_engine.apply_pre_trade_checks(order, account=account, profile_name=profile.name)

--- a/tests/test_risk_profiles.py
+++ b/tests/test_risk_profiles.py
@@ -87,7 +87,20 @@ def test_risk_engine_accepts_atr_informed_order(btc_daily_atr_series: list[float
     )
 
     quantity = _recommended_quantity(profile=profile, atr=atr, equity=equity, price=price, risk_pct=0.012)
-    order = OrderRequest(symbol="BTCUSDT", side="buy", quantity=quantity, order_type="market", price=price)
+    stop_price = price - atr * profile.stop_loss_atr_multiple()
+    order = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=quantity,
+        order_type="market",
+        price=price,
+        metadata={
+            "atr": atr,
+            "stop_price": stop_price,
+            "quantity": quantity,
+            "price": price,
+        },
+    )
 
     check = engine.apply_pre_trade_checks(order, account=account, profile_name=profile.name)
     assert check.allowed, check.reason
@@ -99,6 +112,12 @@ def test_risk_engine_accepts_atr_informed_order(btc_daily_atr_series: list[float
         quantity=oversized_quantity,
         order_type="market",
         price=price,
+        metadata={
+            "atr": atr,
+            "stop_price": stop_price,
+            "quantity": oversized_quantity,
+            "price": price,
+        },
     )
 
     denial = engine.apply_pre_trade_checks(oversized_order, account=account, profile_name=profile.name)

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -147,7 +147,19 @@ def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
     assert isinstance(context.risk_engine, ThresholdRiskEngine)
     assert isinstance(context.risk_repository, FileRiskRepository)
     result = context.risk_engine.apply_pre_trade_checks(
-        OrderRequest(symbol="BTCUSDT", side="buy", quantity=0.2, order_type="limit", price=100.0),
+        OrderRequest(
+            symbol="BTCUSDT",
+            side="buy",
+            quantity=0.2,
+            order_type="limit",
+            price=100.0,
+            metadata={
+                "atr": 5.0,
+                "stop_price": 90.0,
+                "quantity": 0.2,
+                "price": 100.0,
+            },
+        ),
         account=AccountSnapshot(
             balances={"USDT": 1000.0},
             total_equity=1000.0,


### PR DESCRIPTION
## Summary
- add a JSONL-based OHLCV gap audit logger and expose it through the data module
- integrate the incident tracker with audit logging and wire the backfill CLI to persist audit entries alongside alerts
- extend the documentation and unit tests to cover audit records, SMS escalation, and JSONL logging

## Testing
- PYTHONPATH=. pytest --override-ini=addopts= tests/test_gap_monitor.py tests/test_gap_audit.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a4edd8c4832a833101767f0e67e6