### PR TITLE
Send manifest health alerts from backfill CLI

### DIFF
--- a/bot_core/data/ohlcv/__init__.py
+++ b/bot_core/data/ohlcv/__init__.py
@@ -1,7 +1,14 @@
 """Moduły związane z danymi OHLCV."""
 
+from bot_core.data.ohlcv.audit import GapAuditLogger, GapAuditRecord, JSONLGapAuditLogger
 from bot_core.data.ohlcv.backfill import BackfillSummary, OHLCVBackfillService
 from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+from bot_core.data.ohlcv.gap_monitor import DataGapIncidentTracker, GapAlertPolicy
+from bot_core.data.ohlcv.manifest_report import (
+    ManifestEntry,
+    generate_manifest_report,
+    summarize_status,
+)
 from bot_core.data.ohlcv.parquet_storage import ParquetCacheStorage
 from bot_core.data.ohlcv.scheduler import OHLCVRefreshScheduler
 from bot_core.data.ohlcv.sqlite_storage import SQLiteCacheStorage
@@ -9,11 +16,19 @@ from bot_core.data.ohlcv.storage import DualCacheStorage
 
 __all__ = [
     "BackfillSummary",
+    "GapAuditLogger",
+    "GapAuditRecord",
+    "JSONLGapAuditLogger",
     "CachedOHLCVSource",
+    "DataGapIncidentTracker",
+    "GapAlertPolicy",
+    "ManifestEntry",
     "OHLCVBackfillService",
     "OHLCVRefreshScheduler",
     "ParquetCacheStorage",
     "PublicAPIDataSource",
+    "generate_manifest_report",
+    "summarize_status",
     "SQLiteCacheStorage",
     "DualCacheStorage",
 ]

--- a/bot_core/data/ohlcv/audit.py
+++ b/bot_core/data/ohlcv/audit.py
@@ -1,0 +1,146 @@
+"""Audyt jakości danych OHLCV."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Protocol
+
+
+@dataclass(slots=True)
+class GapAuditRecord:
+    """Pojedynczy wpis audytowy opisujący stan danych dla symbolu/interwału."""
+
+    timestamp: datetime
+    environment: str
+    exchange: str
+    symbol: str
+    interval: str
+    status: str
+    gap_minutes: float | None
+    row_count: int | None
+    last_timestamp: str | None
+    warnings_in_window: int | None = None
+    incident_minutes: float | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "timestamp": self.timestamp.isoformat(),
+            "environment": self.environment,
+            "exchange": self.exchange,
+            "symbol": self.symbol,
+            "interval": self.interval,
+            "status": self.status,
+            "gap_minutes": None if self.gap_minutes is None else round(self.gap_minutes, 3),
+            "row_count": self.row_count,
+            "last_timestamp": self.last_timestamp,
+            "warnings_in_window": self.warnings_in_window,
+            "incident_minutes": None
+            if self.incident_minutes is None
+            else round(self.incident_minutes, 3),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "GapAuditRecord":
+        """Buduje wpis audytowy z danych JSON (np. z pliku JSONL)."""
+
+        raw_timestamp = payload.get("timestamp")
+        if not isinstance(raw_timestamp, str):
+            raise ValueError("Pole 'timestamp' musi być tekstem w formacie ISO 8601")
+
+        timestamp = datetime.fromisoformat(raw_timestamp)
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+
+        def _maybe_float(key: str) -> float | None:
+            value = payload.get(key)
+            if value is None:
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                raise ValueError(f"Pole '{key}' musi być liczbą zmiennoprzecinkową lub null") from None
+
+        def _maybe_int(key: str) -> int | None:
+            value = payload.get(key)
+            if value is None:
+                return None
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                raise ValueError(f"Pole '{key}' musi być liczbą całkowitą lub null") from None
+
+        environment = str(payload.get("environment", ""))
+        exchange = str(payload.get("exchange", ""))
+        symbol = str(payload.get("symbol", ""))
+        interval = str(payload.get("interval", ""))
+        status = str(payload.get("status", ""))
+
+        last_timestamp_raw = payload.get("last_timestamp")
+        last_timestamp = None
+        if last_timestamp_raw is not None:
+            last_timestamp = str(last_timestamp_raw)
+
+        warnings_in_window = payload.get("warnings_in_window")
+        warnings_value = None
+        if warnings_in_window is not None:
+            try:
+                warnings_value = int(warnings_in_window)
+            except (TypeError, ValueError) as exc:  # pragma: no cover - walidacja wejścia
+                raise ValueError("Pole 'warnings_in_window' musi być liczbą całkowitą") from exc
+
+        return cls(
+            timestamp=timestamp,
+            environment=environment,
+            exchange=exchange,
+            symbol=symbol,
+            interval=interval,
+            status=status,
+            gap_minutes=_maybe_float("gap_minutes"),
+            row_count=_maybe_int("row_count"),
+            last_timestamp=last_timestamp,
+            warnings_in_window=warnings_value,
+            incident_minutes=_maybe_float("incident_minutes"),
+        )
+
+    @classmethod
+    def from_json(cls, line: str) -> "GapAuditRecord":
+        """Buduje wpis audytowy na podstawie pojedynczego wiersza JSONL."""
+
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:  # pragma: no cover - walidacja wejścia
+            raise ValueError("Niepoprawny wiersz JSONL") from exc
+        if not isinstance(payload, Mapping):
+            raise ValueError("Wiersz JSONL musi być obiektem JSON")
+        return cls.from_dict(payload)
+
+
+class GapAuditLogger(Protocol):
+    """Interfejs loggera przyjmującego wpisy audytowe luk danych."""
+
+    def log(self, record: GapAuditRecord) -> None:
+        ...  # pragma: no cover - protokół typów
+
+
+class JSONLGapAuditLogger:
+    """Logger zapisujący wpisy audytowe w pliku JSONL (append-only)."""
+
+    def __init__(self, path: str | Path, *, fsync: bool = False) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._fsync = fsync
+
+    def log(self, record: GapAuditRecord) -> None:
+        payload = json.dumps(record.to_dict(), ensure_ascii=False)
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(payload + "\n")
+            if self._fsync:
+                handle.flush()
+                os.fsync(handle.fileno())
+
+
+__all__ = ["GapAuditRecord", "GapAuditLogger", "JSONLGapAuditLogger"]
+

--- a/bot_core/data/ohlcv/gap_monitor.py
+++ b/bot_core/data/ohlcv/gap_monitor.py
@@ -1,0 +1,406 @@
+"""Monitor luk danych OHLCV z integracją alertów."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Mapping, MutableMapping, Sequence
+
+from bot_core.alerts import AlertMessage, AlertRouter
+from bot_core.data.ohlcv.audit import GapAuditLogger, GapAuditRecord
+
+_MILLISECONDS_IN_MINUTE = 60_000
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _interval_to_minutes(interval: str) -> int:
+    mapping = {
+        "1m": 1,
+        "3m": 3,
+        "5m": 5,
+        "15m": 15,
+        "30m": 30,
+        "1h": 60,
+        "2h": 120,
+        "4h": 240,
+        "6h": 360,
+        "8h": 480,
+        "12h": 720,
+        "1d": 1440,
+        "3d": 4320,
+        "1w": 10_080,
+        "1M": 43_200,
+    }
+    try:
+        return mapping[interval]
+    except KeyError as exc:  # pragma: no cover - walidacja configu na starcie
+        raise ValueError(f"Nieobsługiwany interwał: {interval}") from exc
+
+
+def _safe_int(value: object | None) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+@dataclass(slots=True)
+class GapAlertPolicy:
+    """Parametry eskalacji luk danych."""
+
+    warning_gap_minutes: Mapping[str, int]
+    incident_threshold_count: int = 5
+    incident_window_minutes: int = 10
+    sms_escalation_minutes: int = 15
+    warning_throttle_minutes: int = 5
+
+    def warning_threshold_minutes(self, interval: str) -> int:
+        minutes = self.warning_gap_minutes.get(interval)
+        if minutes is not None:
+            return max(1, int(minutes))
+        # domyślnie przyjmujemy dwukrotność interwału jako bezpieczne okno
+        return max(1, _interval_to_minutes(interval) * 2)
+
+
+@dataclass(slots=True)
+class _GapState:
+    warnings: list[datetime] = field(default_factory=list)
+    incident_open: bool = False
+    incident_open_at: datetime | None = None
+    sms_escalated: bool = False
+    last_warning_alert: datetime | None = None
+
+    def register_warning(self, timestamp: datetime, *, window: timedelta) -> int:
+        self.warnings.append(timestamp)
+        cutoff = timestamp - window
+        self.warnings = [entry for entry in self.warnings if entry >= cutoff]
+        return len(self.warnings)
+
+    def reset(self) -> None:
+        self.warnings.clear()
+        self.incident_open = False
+        self.incident_open_at = None
+        self.sms_escalated = False
+        self.last_warning_alert = None
+
+
+@dataclass(slots=True)
+class DataGapIncidentTracker:
+    """Pilnuje luk w danych OHLCV i wysyła alerty zgodnie z polityką eskalacji."""
+
+    router: AlertRouter
+    metadata_provider: Callable[[], MutableMapping[str, str]]
+    policy: GapAlertPolicy
+    environment_name: str
+    exchange: str
+    clock: Callable[[], datetime] = _utc_now
+    audit_logger: GapAuditLogger | None = None
+
+    _states: dict[tuple[str, str], _GapState] = field(default_factory=dict, init=False, repr=False)
+
+    def _log_audit(
+        self,
+        *,
+        symbol: str,
+        interval: str,
+        status: str,
+        gap_minutes: float | None,
+        row_count: int | None,
+        last_timestamp_iso: str | None,
+        warnings_in_window: int | None,
+        incident_minutes: float | None,
+        event_time: datetime,
+    ) -> None:
+        if not self.audit_logger:
+            return
+        record = GapAuditRecord(
+            timestamp=event_time,
+            environment=self.environment_name,
+            exchange=self.exchange,
+            symbol=symbol,
+            interval=interval,
+            status=status,
+            gap_minutes=gap_minutes,
+            row_count=row_count,
+            last_timestamp=last_timestamp_iso,
+            warnings_in_window=warnings_in_window,
+            incident_minutes=incident_minutes,
+        )
+        try:
+            self.audit_logger.log(record)
+        except Exception:  # pragma: no cover - logowanie nie może zatrzymać pipeline'u
+            pass
+
+    def handle_summaries(
+        self,
+        *,
+        interval: str,
+        summaries: Sequence[object],
+        as_of_ms: int,
+    ) -> None:
+        if not summaries:
+            return
+        metadata = self.metadata_provider()
+        for summary in summaries:
+            symbol = getattr(summary, "symbol", None)
+            if not symbol:
+                continue
+            state = self._states.setdefault((symbol, interval), _GapState())
+            last_ts_key = f"last_timestamp::{symbol}::{interval}"
+            row_count_key = f"row_count::{symbol}::{interval}"
+            last_ts_raw = metadata.get(last_ts_key)
+            row_count_raw = metadata.get(row_count_key)
+
+            if last_ts_raw is None:
+                event_time = self.clock()
+                row_count = _safe_int(row_count_raw)
+                # brak danych – traktujemy jak incydent krytyczny
+                self._emit_alert(
+                    severity="critical",
+                    title=f"Brak danych OHLCV {symbol} {interval}",
+                    body=(
+                        "Manifest nie posiada wpisu last_timestamp – należy zweryfikować pipeline backfillu."
+                    ),
+                    context={
+                        "environment": self.environment_name,
+                        "exchange": self.exchange,
+                        "symbol": symbol,
+                        "interval": interval,
+                        "row_count": str(row_count_raw or "0"),
+                    },
+                )
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="missing_metadata",
+                    gap_minutes=None,
+                    row_count=row_count,
+                    last_timestamp_iso=None,
+                    warnings_in_window=None,
+                    incident_minutes=None,
+                    event_time=event_time,
+                )
+                continue
+
+            try:
+                last_ts_ms = int(float(last_ts_raw))
+            except (TypeError, ValueError):
+                event_time = self.clock()
+                row_count = _safe_int(row_count_raw)
+                self._emit_alert(
+                    severity="critical",
+                    title=f"Uszkodzona metadana OHLCV {symbol} {interval}",
+                    body="Wartość last_timestamp nie jest liczbą – konieczna ręczna interwencja.",
+                    context={
+                        "environment": self.environment_name,
+                        "exchange": self.exchange,
+                        "symbol": symbol,
+                        "interval": interval,
+                        "raw_value": str(last_ts_raw),
+                    },
+                )
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="invalid_metadata",
+                    gap_minutes=None,
+                    row_count=row_count,
+                    last_timestamp_iso=str(last_ts_raw),
+                    warnings_in_window=None,
+                    incident_minutes=None,
+                    event_time=event_time,
+                )
+                continue
+
+            gap_ms = max(0, as_of_ms - last_ts_ms)
+            gap_minutes = gap_ms / _MILLISECONDS_IN_MINUTE
+            warning_threshold = self.policy.warning_threshold_minutes(interval)
+
+            now = self.clock()
+            row_count = _safe_int(row_count_raw)
+            last_timestamp_iso = datetime.fromtimestamp(last_ts_ms / 1000, tz=timezone.utc).isoformat()
+
+            if gap_minutes < warning_threshold:
+                warnings_in_window = len(state.warnings)
+                incident_minutes = (
+                    (now - state.incident_open_at).total_seconds() / 60
+                    if state.incident_open and state.incident_open_at
+                    else None
+                )
+                if state.incident_open:
+                    self._emit_alert(
+                        severity="info",
+                        title=f"Incydent zamknięty – luka danych {symbol} {interval}",
+                        body=(
+                            "Dane OHLCV zostały uzupełnione. Zamykam incydent i resetuję licznik ostrzeżeń."
+                        ),
+                        context={
+                            "environment": self.environment_name,
+                            "exchange": self.exchange,
+                            "symbol": symbol,
+                            "interval": interval,
+                            "incident_minutes": f"{incident_minutes:.1f}" if incident_minutes is not None else "0.0",
+                            "gap_minutes": f"{gap_minutes:.1f}",
+                            "row_count": str(row_count_raw or "0"),
+                        },
+                    )
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="ok",
+                    gap_minutes=gap_minutes,
+                    row_count=row_count,
+                    last_timestamp_iso=last_timestamp_iso,
+                    warnings_in_window=warnings_in_window,
+                    incident_minutes=incident_minutes,
+                    event_time=now,
+                )
+                state.reset()
+                continue
+
+            window = timedelta(minutes=max(1, self.policy.incident_window_minutes))
+            warn_count = state.register_warning(now, window=window)
+
+            context = {
+                "environment": self.environment_name,
+                "exchange": self.exchange,
+                "symbol": symbol,
+                "interval": interval,
+                "gap_minutes": f"{gap_minutes:.1f}",
+                "row_count": str(row_count_raw or "0"),
+                "last_timestamp": last_timestamp_iso,
+            }
+
+            if not state.incident_open and warn_count >= self.policy.incident_threshold_count:
+                state.incident_open = True
+                state.incident_open_at = now
+                state.sms_escalated = False
+                state.last_warning_alert = None
+                self._emit_alert(
+                    severity="critical",
+                    title=f"INCIDENT – luka danych {symbol} {interval}",
+                    body=(
+                        "Wykryto powtarzające się luki w danych OHLCV. "
+                        "Incydent został otwarty i wymaga ręcznej analizy."
+                    ),
+                    context={
+                        **context,
+                        "warnings_in_window": str(warn_count),
+                        "window_minutes": str(self.policy.incident_window_minutes),
+                    },
+                )
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="incident",
+                    gap_minutes=gap_minutes,
+                    row_count=row_count,
+                    last_timestamp_iso=last_timestamp_iso,
+                    warnings_in_window=warn_count,
+                    incident_minutes=0.0,
+                    event_time=now,
+                )
+                continue
+
+            if state.incident_open:
+                assert state.incident_open_at is not None
+                elapsed = (now - state.incident_open_at).total_seconds() / 60
+                if (
+                    not state.sms_escalated
+                    and elapsed >= max(1, self.policy.sms_escalation_minutes)
+                ):
+                    state.sms_escalated = True
+                    self._emit_alert(
+                        severity="critical",
+                        title=f"Eskalacja SMS – luka danych {symbol} {interval}",
+                        body=(
+                            "Incydent trwa dłużej niż zakładany próg eskalacji. "
+                            "Wysyłam powiadomienie SMS zgodnie z polityką."
+                        ),
+                        context={**context, "incident_minutes": f"{elapsed:.1f}"},
+                    )
+                    self._log_audit(
+                        symbol=symbol,
+                        interval=interval,
+                        status="sms_escalated",
+                        gap_minutes=gap_minutes,
+                        row_count=row_count,
+                        last_timestamp_iso=last_timestamp_iso,
+                        warnings_in_window=warn_count,
+                        incident_minutes=elapsed,
+                        event_time=now,
+                    )
+                    continue
+
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="incident",
+                    gap_minutes=gap_minutes,
+                    row_count=row_count,
+                    last_timestamp_iso=last_timestamp_iso,
+                    warnings_in_window=warn_count,
+                    incident_minutes=elapsed,
+                    event_time=now,
+                )
+                continue
+
+            # Ostrzeżenie Telegram – pojedynczy alert o dłuższej luce
+            throttle_window = timedelta(minutes=max(1, self.policy.warning_throttle_minutes))
+            if state.last_warning_alert and (now - state.last_warning_alert) < throttle_window:
+                self._log_audit(
+                    symbol=symbol,
+                    interval=interval,
+                    status="warning_suppressed",
+                    gap_minutes=gap_minutes,
+                    row_count=row_count,
+                    last_timestamp_iso=last_timestamp_iso,
+                    warnings_in_window=warn_count,
+                    incident_minutes=None,
+                    event_time=now,
+                )
+                continue
+
+            state.last_warning_alert = now
+            self._emit_alert(
+                severity="warning",
+                title=f"Luka danych {symbol} {interval}",
+                body=(
+                    "Brak świec OHLCV od ponad wyznaczonego progu. Monitoruję dalsze próby synchronizacji."
+                ),
+                context={**context, "warnings_in_window": str(warn_count)},
+            )
+            self._log_audit(
+                symbol=symbol,
+                interval=interval,
+                status="warning",
+                gap_minutes=gap_minutes,
+                row_count=row_count,
+                last_timestamp_iso=last_timestamp_iso,
+                warnings_in_window=warn_count,
+                incident_minutes=None,
+                event_time=now,
+            )
+
+    def _emit_alert(
+        self,
+        *,
+        severity: str,
+        title: str,
+        body: str,
+        context: Mapping[str, str],
+    ) -> None:
+        message = AlertMessage(
+            category="data.ohlcv",
+            title=title,
+            body=body,
+            severity=severity,
+            context=dict(context),
+        )
+        self.router.dispatch(message)
+
+
+__all__ = ["GapAlertPolicy", "DataGapIncidentTracker"]
+

--- a/bot_core/data/ohlcv/manifest_report.py
+++ b/bot_core/data/ohlcv/manifest_report.py
@@ -1,0 +1,186 @@
+"""Raport stanu manifestu danych OHLCV na podstawie SQLite."""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from bot_core.config.models import InstrumentUniverseConfig
+
+
+@dataclass(slots=True)
+class ManifestEntry:
+    """Pojedynczy wpis raportu z manifestu danych OHLCV."""
+
+    symbol: str
+    interval: str
+    row_count: int | None
+    last_timestamp_ms: int | None
+    last_timestamp_iso: str | None
+    gap_minutes: float | None
+    threshold_minutes: int | None
+    status: str
+
+
+def _interval_to_minutes(interval: str) -> int:
+    mapping = {
+        "1m": 1,
+        "3m": 3,
+        "5m": 5,
+        "15m": 15,
+        "30m": 30,
+        "1h": 60,
+        "2h": 120,
+        "4h": 240,
+        "6h": 360,
+        "8h": 480,
+        "12h": 720,
+        "1d": 1440,
+        "3d": 4320,
+        "1w": 10_080,
+        "1M": 43_200,
+    }
+    try:
+        return mapping[interval]
+    except KeyError as exc:  # pragma: no cover - walidacja konfiguracji
+        raise ValueError(f"Nieobsługiwany interwał: {interval}") from exc
+
+
+def _default_threshold_minutes(interval: str) -> int:
+    return max(1, _interval_to_minutes(interval) * 2)
+
+
+def _parse_int(value: object | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _load_metadata(path: Path) -> Mapping[str, str]:
+    if not path.exists():
+        return {}
+    connection = sqlite3.connect(path)
+    try:
+        cursor = connection.execute("SELECT key, value FROM metadata")
+        return {str(row[0]): str(row[1]) for row in cursor.fetchall()}
+    finally:
+        connection.close()
+
+
+def _expected_pairs(
+    universe: InstrumentUniverseConfig,
+    exchange_name: str,
+) -> set[tuple[str, str]]:
+    pairs: set[tuple[str, str]] = set()
+    for instrument in universe.instruments:
+        symbol = instrument.exchange_symbols.get(exchange_name)
+        if not symbol:
+            continue
+        for window in instrument.backfill_windows:
+            pairs.add((symbol, window.interval))
+    return pairs
+
+
+def generate_manifest_report(
+    *,
+    manifest_path: str | Path,
+    universe: InstrumentUniverseConfig,
+    exchange_name: str,
+    as_of: datetime | None = None,
+    warning_thresholds: Mapping[str, int] | None = None,
+) -> list[ManifestEntry]:
+    """Buduje raport stanu manifestu SQLite dla wskazanego uniwersum."""
+
+    snapshot = _load_metadata(Path(manifest_path))
+    pairs = _expected_pairs(universe, exchange_name)
+    if not pairs:
+        return []
+
+    as_of_dt = (as_of or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    rows: list[ManifestEntry] = []
+
+    for symbol, interval in sorted(pairs):
+        last_key = f"last_timestamp::{symbol}::{interval}"
+        row_key = f"row_count::{symbol}::{interval}"
+        raw_last = snapshot.get(last_key)
+        raw_rows = snapshot.get(row_key)
+
+        row_count = _parse_int(raw_rows)
+        threshold = None
+        if warning_thresholds and interval in warning_thresholds:
+            threshold = max(1, int(warning_thresholds[interval]))
+        else:
+            try:
+                threshold = _default_threshold_minutes(interval)
+            except ValueError:
+                threshold = None
+
+        if raw_last is None:
+            rows.append(
+                ManifestEntry(
+                    symbol=symbol,
+                    interval=interval,
+                    row_count=row_count,
+                    last_timestamp_ms=None,
+                    last_timestamp_iso=None,
+                    gap_minutes=None,
+                    threshold_minutes=threshold,
+                    status="missing_metadata",
+                )
+            )
+            continue
+
+        last_ts = _parse_int(raw_last)
+        if last_ts is None:
+            rows.append(
+                ManifestEntry(
+                    symbol=symbol,
+                    interval=interval,
+                    row_count=row_count,
+                    last_timestamp_ms=None,
+                    last_timestamp_iso=str(raw_last),
+                    gap_minutes=None,
+                    threshold_minutes=threshold,
+                    status="invalid_metadata",
+                )
+            )
+            continue
+
+        last_dt = datetime.fromtimestamp(last_ts / 1000, tz=timezone.utc)
+        gap_minutes = max(0.0, (as_of_dt - last_dt).total_seconds() / 60)
+
+        status = "ok"
+        if threshold is None:
+            status = "unknown"
+        elif gap_minutes >= threshold:
+            status = "warning"
+
+        rows.append(
+            ManifestEntry(
+                symbol=symbol,
+                interval=interval,
+                row_count=row_count,
+                last_timestamp_ms=last_ts,
+                last_timestamp_iso=last_dt.isoformat(),
+                gap_minutes=gap_minutes,
+                threshold_minutes=threshold,
+                status=status,
+            )
+        )
+
+    return rows
+
+
+def summarize_status(entries: Sequence[ManifestEntry]) -> Mapping[str, int]:
+    summary: dict[str, int] = {}
+    for entry in entries:
+        summary[entry.status] = summary.get(entry.status, 0) + 1
+    return summary
+
+
+__all__ = ["ManifestEntry", "generate_manifest_report", "summarize_status"]

--- a/bot_core/exchanges/base.py
+++ b/bot_core/exchanges/base.py
@@ -47,6 +47,7 @@ class OrderRequest:
     price: Optional[float] = None
     time_in_force: Optional[str] = None
     client_order_id: Optional[str] = None
+    metadata: Mapping[str, object] | None = None
 
 
 @dataclass(slots=True)

--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -164,7 +164,7 @@ class TradingController:
     portfolio_id: str
     environment: str
     risk_profile: str
-    order_metadata_defaults: Mapping[str, str] | None = None
+    order_metadata_defaults: Mapping[str, object] | None = None
     clock: Callable[[], datetime] = _now
     health_check_interval: timedelta | float | int = timedelta(hours=1)
     execution_metadata: Mapping[str, str] | None = None
@@ -197,7 +197,7 @@ class TradingController:
             environment=self.environment,
             metadata=metadata,
         )
-        self._order_defaults = {str(k): str(v) for k, v in (self.order_metadata_defaults or {}).items()}
+        self._order_defaults = dict(self.order_metadata_defaults or {})
         self._last_health_report = self._clock()
         self._liquidation_alerted = False
         self._metrics = self.metrics_registry or get_global_metrics_registry()
@@ -502,13 +502,13 @@ class TradingController:
         return adjusted_request, new_result
 
     def _build_order_request(self, signal: StrategySignal) -> OrderRequest:
-        metadata = dict(self._order_defaults)
+        metadata_source: dict[str, object] = dict(self._order_defaults)
         # w StrategySignal.metadata spodziewamy się m.in. quantity/price/order_type/time_in_force/client_order_id
         for k, v in signal.metadata.items():
-            metadata[str(k)] = str(v)
+            metadata_source[str(k)] = v
 
         try:
-            quantity = float(metadata["quantity"])
+            quantity = float(metadata_source["quantity"])
         except KeyError as exc:
             raise ValueError("Sygnał nie zawiera wielkości zlecenia (quantity)") from exc
         except ValueError as exc:
@@ -517,12 +517,27 @@ class TradingController:
         if quantity <= 0:
             raise ValueError("Wielkość zlecenia musi być dodatnia")
 
-        price_value = metadata.get("price")
+        price_value = metadata_source.get("price")
         price = float(price_value) if price_value is not None else None
 
-        order_type = (metadata.get("order_type") or "market").upper()
-        time_in_force = metadata.get("time_in_force")
-        client_order_id = metadata.get("client_order_id")
+        order_type = str(metadata_source.get("order_type") or "market").upper()
+        time_in_force_raw = metadata_source.get("time_in_force")
+        client_order_id_raw = metadata_source.get("client_order_id")
+
+        order_metadata: dict[str, object] = dict(metadata_source)
+        order_metadata["quantity"] = quantity
+        if price is not None:
+            order_metadata["price"] = price
+        if "stop_price" in order_metadata:
+            try:
+                order_metadata["stop_price"] = float(order_metadata["stop_price"])
+            except (TypeError, ValueError):
+                raise ValueError("stop_price w metadanych musi być liczbą zmiennoprzecinkową")
+        if "atr" in order_metadata:
+            try:
+                order_metadata["atr"] = float(order_metadata["atr"])
+            except (TypeError, ValueError):
+                raise ValueError("atr w metadanych musi być liczbą zmiennoprzecinkową")
 
         return OrderRequest(
             symbol=signal.symbol,
@@ -530,8 +545,9 @@ class TradingController:
             quantity=quantity,
             order_type=order_type,
             price=price,
-            time_in_force=time_in_force,
-            client_order_id=client_order_id,
+            time_in_force=str(time_in_force_raw) if time_in_force_raw is not None else None,
+            client_order_id=str(client_order_id_raw) if client_order_id_raw is not None else None,
+            metadata=order_metadata,
         )
 
     def _emit_signal_alert(self, signal: StrategySignal) -> None:
@@ -803,6 +819,8 @@ class DailyTrendController:
             if not risk_result.allowed:
                 adjusted_qty = _extract_adjusted_quantity(base_request.quantity, risk_result.adjustments)
                 if adjusted_qty is not None:
+                    adjusted_metadata = dict(base_request.metadata or {})
+                    adjusted_metadata["quantity"] = float(adjusted_qty)
                     adjusted_request = OrderRequest(
                         symbol=base_request.symbol,
                         side=base_request.side,
@@ -811,6 +829,7 @@ class DailyTrendController:
                         price=base_request.price,
                         time_in_force=base_request.time_in_force,
                         client_order_id=base_request.client_order_id,
+                        metadata=adjusted_metadata,
                     )
                     second_result = self.risk_engine.apply_pre_trade_checks(
                         adjusted_request,
@@ -851,15 +870,38 @@ class DailyTrendController:
 
     def _build_order_request(self, snapshot: MarketSnapshot, signal: StrategySignal) -> OrderRequest:
         side = signal.side.lower()
-        metadata = dict(signal.metadata)
-        quantity = float(metadata.get("quantity", self.position_size))
-        price = float(metadata.get("price", snapshot.close))
-        order_type = str(metadata.get("order_type", "market"))
-        time_in_force = metadata.get("time_in_force")
-        client_order_id = metadata.get("client_order_id")
+        metadata_source: dict[str, object] = dict(signal.metadata)
+        metadata_source.setdefault("quantity", float(self.position_size))
+        metadata_source.setdefault("price", float(snapshot.close))
+        metadata_source.setdefault("order_type", "market")
 
-        tif_str = str(time_in_force) if time_in_force is not None else None
-        client_id_str = str(client_order_id) if client_order_id is not None else None
+        quantity_raw = metadata_source.get("quantity")
+        price_raw = metadata_source.get("price")
+        time_in_force_raw = metadata_source.get("time_in_force")
+        client_order_id_raw = metadata_source.get("client_order_id")
+
+        quantity = float(quantity_raw) if quantity_raw is not None else float(self.position_size)
+        price = float(price_raw) if price_raw is not None else float(snapshot.close)
+        order_type = str(metadata_source.get("order_type") or "market")
+
+        tif_str = str(time_in_force_raw) if time_in_force_raw is not None else None
+        client_id_str = str(client_order_id_raw) if client_order_id_raw is not None else None
+
+        order_metadata: dict[str, object] = dict(metadata_source)
+        order_metadata["quantity"] = quantity
+        order_metadata["price"] = price
+
+        if "stop_price" in order_metadata:
+            try:
+                order_metadata["stop_price"] = float(order_metadata["stop_price"])
+            except (TypeError, ValueError):
+                order_metadata.pop("stop_price", None)
+
+        if "atr" in order_metadata:
+            try:
+                order_metadata["atr"] = float(order_metadata["atr"])
+            except (TypeError, ValueError):
+                order_metadata.pop("atr", None)
 
         return OrderRequest(
             symbol=snapshot.symbol,
@@ -869,6 +911,7 @@ class DailyTrendController:
             price=price,
             time_in_force=tif_str,
             client_order_id=client_id_str,
+            metadata=order_metadata,
         )
 
     def _to_snapshots(

--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -165,7 +165,7 @@ def create_trading_controller(
     alert_router: DefaultAlertRouter,
     *,
     health_check_interval: float | int | timedelta = 3600,
-    order_metadata_defaults: Mapping[str, str] | None = None,
+    order_metadata_defaults: Mapping[str, object] | None = None,
 ) -> "TradingController":
     """Buduje TradingController spięty z komponentami pipeline'u."""
     if TradingController is None:

--- a/docs/runbooks/backfill.md
+++ b/docs/runbooks/backfill.md
@@ -6,6 +6,12 @@ z publicznych API giełd obsługiwanych przez platformę. Mechanizm korzysta z
 harmonogramu `OHLCVRefreshScheduler`, dzięki czemu po pierwszym backfillu
 możliwe jest cykliczne dogrywanie świeżych danych.
 
+Domyślne częstotliwości odświeżania zależą od interwału (np. `1d` co 24 h,
+`1h` co 15 min, `15m` co 5 min). W razie potrzeby można je nadpisać poprzez
+sekcję `environments.*.adapter_settings.ohlcv_refresh_overrides` w
+`config/core.yaml`, podając mapowanie `interwał -> sekundy` dla konkretnego
+środowiska.
+
 ## Obsługiwane giełdy
 
 Aktualna konfiguracja `core_multi_exchange` obejmuje następujące adaptery
@@ -38,3 +44,88 @@ python scripts/backfill.py --environment binance_paper --run-once
 
 Dla pracy ciągłej (backfill + inkrementalne odświeżanie) pomiń flagę `--run-once`
 i pozostaw proces działający w tle.
+
+## Monitoring luk danych i alerty
+
+Skrypt potrafi monitorować manifest SQLite i wysyłać alerty o długotrwałych
+lukach w danych OHLCV. Aby aktywować mechanizm, uruchom go z flagą
+`--enable-alerts`. W środowiskach headless (Linux bez środowiska graficznego)
+należy dodatkowo przekazać `--headless-passphrase` (oraz opcjonalnie
+`--headless-secrets-path`), aby `create_default_secret_storage` mogło otworzyć
+zaszyfrowany magazyn sekretów.
+
+Polityka eskalacji jest konfigurowalna poprzez sekcję
+`environments.*.adapter_settings.ohlcv_gap_alerts` w `config/core.yaml`.
+Przykład:
+
+```yaml
+ohlcv_gap_alerts:
+  warning_gap_minutes:
+    1d: 1800   # ostrzeżenie po ~30 godzinach braku świec dziennych
+    1h: 90     # ostrzeżenie po 90 minutach ciszy na interwale godzinowym
+    15m: 20    # ostrzeżenie po 20 minutach dla sanity-checków
+  incident_threshold_count: 5   # liczba ostrzeżeń w oknie, po której otwieramy incydent
+  incident_window_minutes: 10   # szerokość okna przesuwnego na eskalację (Telegram + e-mail)
+  sms_escalation_minutes: 15    # czas trwania incydentu po którym uruchamiamy SMS
+  warning_throttle_minutes: 5   # minimalny odstęp pomiędzy ostrzeżeniami dla tego samego symbolu
+```
+
+Domyślne progi bazują na dwukrotności długości interwału i są bezpieczne dla
+środowiska demo/paper. Kanały alertowe (Telegram/e-mail/SMS) konfigurowane są
+tak jak dla runtime – wymagają obecności sekretów w natywnym keychainie lub
+zaszyfrowanym magazynie.
+
+Każdy przebieg backfillu zapisuje ponadto wpisy audytowe luk do pliku
+`<data_cache_path>/audit/<environment>_ohlcv_gaps.jsonl`, gdzie utrwalane są
+ostatni znany znacznik czasu, liczba świec oraz status (`ok`, `warning`,
+`warning_suppressed`, `incident`, `sms_escalated`). Plik jest w formacie JSONL
+i można go trzymać w retencji ≥24 miesięcy na potrzeby audytu operacyjnego.
+
+### Raportowanie luk z pliku audytu
+
+Do szybkiej inspekcji bieżącego stanu luk służy skrypt
+`scripts/gap_audit_report.py`, który wczytuje plik JSONL i agreguje wpisy po
+symbolu/interwale. Podstawowe użycie:
+
+```bash
+python scripts/gap_audit_report.py \
+  data/cache/audit/binance_paper_ohlcv_gaps.jsonl \
+  --environment binance_paper \
+  --since-hours 24
+```
+
+Wynik zawiera tabelę z ostatnim statusem, wielkością luki (minuty), liczbą
+wierszy w cache oraz liczbą ostrzeżeń/incydentów/SMS w zadanym oknie
+czasowym (domyślnie 24 h). Parametr `--window-hours` pozwala zmienić szerokość
+tego okna do własnych potrzeb operacyjnych.
+
+### Raport zdrowia manifestu SQLite
+
+W sytuacjach, gdy potrzebna jest szybka inspekcja aktualnego stanu cache bez
+sięgania do logów audytowych, można użyć skryptu
+`scripts/manifest_gap_report.py`. Narzędzie odczytuje manifest SQLite,
+porównuje ostatnie stemple czasowe z bieżącą godziną i stosuje progi ostrzeżeń
+zdefiniowane w `ohlcv_gap_alerts.warning_gap_minutes` (a w razie braku –
+domyślnie dwukrotność interwału). Raport można otrzymać jako tabelę tekstową
+lub JSON, np.:
+
+```bash
+python scripts/manifest_gap_report.py \
+  --environment binance_paper \
+  --as-of 2024-05-20T12:00:00Z
+```
+
+Wynik pokazuje każdy symbol/interwał wraz z liczbą wierszy, ostatnim
+timestampem, długością luki oraz statusem (`ok`, `warning`, `missing_metadata`,
+`invalid_metadata`). Dzięki temu łatwo wychwycić instrumenty pominięte w
+backfillu lub manifesty z uszkodzonymi danymi, zanim pipeline trafi na
+środowisko paper/live.
+
+Jeżeli backfill uruchomiono z flagą `--enable-alerts`, raport manifestu jest
+generowany automatycznie po zakończeniu synchronizacji. Wszelkie wykryte
+nieprawidłowości trafiają na kanały Telegram/e-mail/SMS zgodnie z polityką
+alertów: braki metadanych i uszkodzone wpisy eskalują się jako krytyczne
+powiadomienia, a długotrwałe luki (`warning`) wysyłane są jako ostrzeżenia z
+pełnym kontekstem (ostatni timestamp, liczba świec, długość luki). Dzięki temu
+operacje otrzymują komplet informacji o stanie cache natychmiast po
+backfillu – jeszcze zanim harmonogram odświeżania rozpocznie kolejne cykle.

--- a/scripts/backfill.py
+++ b/scripts/backfill.py
@@ -3,22 +3,31 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
+from bot_core.alerts import AlertMessage, DefaultAlertRouter
 from bot_core.config.loader import load_core_config
 from bot_core.config.models import CoreConfig, EnvironmentConfig, InstrumentUniverseConfig
 from bot_core.data.ohlcv import (
+    BackfillSummary,
     CachedOHLCVSource,
+    DataGapIncidentTracker,
     DualCacheStorage,
+    JSONLGapAuditLogger,
+    GapAlertPolicy,
+    ManifestEntry,
     OHLCVBackfillService,
     OHLCVRefreshScheduler,
     ParquetCacheStorage,
     PublicAPIDataSource,
     SQLiteCacheStorage,
+    generate_manifest_report,
+    summarize_status,
 )
 from bot_core.exchanges.base import Environment, ExchangeCredentials
 from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
@@ -26,10 +35,19 @@ from bot_core.exchanges.binance.spot import BinanceSpotAdapter
 from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
 from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
 from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
+from bot_core.runtime.bootstrap import build_alert_channels
+from bot_core.security import SecretManager, SecretStorageError, create_default_secret_storage
 
 _LOGGER = logging.getLogger(__name__)
 
 _MILLISECONDS_IN_DAY = 86_400_000
+
+
+_DEFAULT_REFRESH_SECONDS: Mapping[str, int] = {
+    "1d": 24 * 60 * 60,
+    "1h": 15 * 60,
+    "15m": 5 * 60,
+}
 
 
 @dataclass(slots=True)
@@ -37,6 +55,7 @@ class _IntervalPlan:
     symbols: set[str]
     backfill_start_ms: int
     incremental_lookback_ms: int
+    refresh_seconds: int
 
 
 def _build_public_source(exchange: str, environment: Environment) -> PublicAPIDataSource:
@@ -92,10 +111,13 @@ def _build_interval_plans(
     universe: InstrumentUniverseConfig,
     exchange_name: str,
     incremental_lookback_days: int,
+    refresh_overrides: Mapping[str, int] | None = None,
 ) -> tuple[dict[str, _IntervalPlan], set[str]]:
     plans: dict[str, _IntervalPlan] = {}
     symbols: set[str] = set()
     now_ms = _utc_now_ms()
+
+    overrides = {key: int(value) for key, value in (refresh_overrides or {}).items() if int(value) > 0}
 
     for instrument in universe.instruments:
         symbol = instrument.exchange_symbols.get(exchange_name)
@@ -107,7 +129,15 @@ def _build_interval_plans(
             start = now_ms - window.lookback_days * _MILLISECONDS_IN_DAY
             plan = plans.get(window.interval)
             if plan is None:
-                plan = _IntervalPlan(symbols=set(), backfill_start_ms=start, incremental_lookback_ms=0)
+                refresh_seconds = overrides.get(
+                    window.interval, _DEFAULT_REFRESH_SECONDS.get(window.interval, 0)
+                )
+                plan = _IntervalPlan(
+                    symbols=set(),
+                    backfill_start_ms=start,
+                    incremental_lookback_ms=0,
+                    refresh_seconds=refresh_seconds,
+                )
                 plans[window.interval] = plan
             plan.symbols.add(symbol)
             plan.backfill_start_ms = min(plan.backfill_start_ms, start)
@@ -116,6 +146,187 @@ def _build_interval_plans(
 
     return plans, symbols
 
+
+def _extract_gap_policy(environment: EnvironmentConfig) -> GapAlertPolicy:
+    settings: Mapping[str, object] = {}
+    if isinstance(environment.adapter_settings, Mapping):
+        candidate = environment.adapter_settings.get("ohlcv_gap_alerts")
+        if isinstance(candidate, Mapping):
+            settings = candidate
+
+    warnings_cfg = {}
+    raw_warnings = settings.get("warning_gap_minutes") if settings else None
+    if isinstance(raw_warnings, Mapping):
+        warnings_cfg = {
+            str(interval): max(1, int(value))
+            for interval, value in raw_warnings.items()
+            if value is not None and int(value) > 0
+        }
+
+    def _safe_int(key: str, default: int) -> int:
+        value = settings.get(key) if settings else None
+        try:
+            return max(1, int(value))
+        except (TypeError, ValueError):
+            return default
+
+    return GapAlertPolicy(
+        warning_gap_minutes=warnings_cfg,
+        incident_threshold_count=_safe_int("incident_threshold_count", 5),
+        incident_window_minutes=_safe_int("incident_window_minutes", 10),
+        sms_escalation_minutes=_safe_int("sms_escalation_minutes", 15),
+        warning_throttle_minutes=_safe_int("warning_throttle_minutes", 5),
+    )
+
+
+def _build_gap_callback(
+    gap_tracker: DataGapIncidentTracker | None,
+) -> Callable[[str, Sequence[BackfillSummary], int], None] | None:
+    if gap_tracker is None:
+        return None
+
+    def _callback(interval: str, summaries: Sequence[BackfillSummary], as_of_ms: int) -> None:
+        gap_tracker.handle_summaries(interval=interval, summaries=summaries, as_of_ms=as_of_ms)
+
+    return _callback
+
+
+def _report_manifest_health(
+    *,
+    manifest_path: Path,
+    universe: InstrumentUniverseConfig,
+    exchange_name: str,
+    environment_name: str,
+    alert_router: DefaultAlertRouter | None,
+    as_of: datetime | None = None,
+) -> None:
+    """Loguje stan manifestu i wysyła alerty o wykrytych lukach."""
+
+    entries = generate_manifest_report(
+        manifest_path=manifest_path,
+        universe=universe,
+        exchange_name=exchange_name,
+        as_of=as_of,
+    )
+
+    if not entries:
+        _LOGGER.info(
+            "Manifest OHLCV nie zawiera wpisów dla exchange=%s – pomijam raport",
+            exchange_name,
+        )
+        return
+
+    summary = summarize_status(entries)
+    _LOGGER.info(
+        "Manifest OHLCV %s/%s – statusy: %s",
+        environment_name,
+        exchange_name,
+        summary,
+    )
+
+    issues: list[ManifestEntry] = [entry for entry in entries if entry.status != "ok"]
+    if not issues:
+        return
+
+    for entry in issues:
+        gap_display = "-" if entry.gap_minutes is None else f"{entry.gap_minutes:.1f} min"
+        _LOGGER.warning(
+            "Manifest alert: %s %s status=%s gap=%s rows=%s last=%s",
+            entry.symbol,
+            entry.interval,
+            entry.status,
+            gap_display,
+            entry.row_count if entry.row_count is not None else "-",
+            entry.last_timestamp_iso or "-",
+        )
+
+    if not alert_router:
+        return
+
+    critical_entries = [
+        entry
+        for entry in issues
+        if entry.status in {"missing_metadata", "invalid_metadata"}
+    ]
+    warning_entries = [entry for entry in issues if entry.status == "warning"]
+
+    def _build_body(entries: Sequence[ManifestEntry]) -> str:
+        lines = ["Problemy w manifeście OHLCV:"]
+        for entry in list(entries)[:10]:
+            gap_display = "-" if entry.gap_minutes is None else f"{entry.gap_minutes:.1f} min"
+            row_display = "-" if entry.row_count is None else str(entry.row_count)
+            last_display = entry.last_timestamp_iso or "-"
+            lines.append(
+                f"- {entry.symbol} {entry.interval} ({entry.status}) – ostatnia świeca: {last_display} UTC, "
+                f"luka: {gap_display}, wiersze: {row_display}"
+            )
+        if len(entries) > 10:
+            lines.append(f"… oraz {len(entries) - 10} kolejnych wpisów.")
+        lines.append("Szczegóły w logach backfillu oraz pliku manifestu.")
+        return "\n".join(lines)
+
+    context = {
+        "environment": environment_name,
+        "exchange": exchange_name,
+        "entries": str(len(entries)),
+        "issues": str(len(issues)),
+        "summary": json.dumps(summary, ensure_ascii=False),
+    }
+
+    if critical_entries:
+        alert_router.dispatch(
+            AlertMessage(
+                category="data.ohlcv",
+                title=f"Krytyczne braki w manifeście OHLCV ({environment_name})",
+                body=_build_body(critical_entries),
+                severity="critical",
+                context=context,
+            )
+        )
+
+    if warning_entries:
+        alert_router.dispatch(
+            AlertMessage(
+                category="data.ohlcv",
+                title=f"Ostrzeżenia w manifeście OHLCV ({environment_name})",
+                body=_build_body(warning_entries),
+                severity="warning",
+                context=context,
+            )
+        )
+
+
+def _initialize_alerting(
+    *,
+    args: argparse.Namespace,
+    config: CoreConfig,
+    environment: EnvironmentConfig,
+) -> tuple[DefaultAlertRouter | None, GapAlertPolicy | None, str]:
+    if not args.enable_alerts:
+        return None, None, "Alerty wyłączone flagą CLI"
+
+    try:
+        storage = create_default_secret_storage(
+            namespace=args.secret_namespace,
+            headless_passphrase=args.headless_passphrase,
+            headless_path=args.headless_secrets_path,
+        )
+    except SecretStorageError as exc:
+        return None, None, f"Nie udało się przygotować magazynu sekretów: {exc}"
+
+    secret_manager = SecretManager(storage, namespace=args.secret_namespace)
+
+    try:
+        _, router, _ = build_alert_channels(
+            core_config=config,
+            environment=environment,
+            secret_manager=secret_manager,
+        )
+    except SecretStorageError as exc:
+        return None, None, f"Nie udało się zbudować kanałów alertów: {exc}"
+
+    policy = _extract_gap_policy(environment)
+    return router, policy, "Kanały alertowe zainicjalizowane"
 
 def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Backfill danych OHLCV zgodnie z config/core.yaml")
@@ -144,6 +355,26 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         action="store_true",
         help="Wykonaj tylko pełny backfill i zakończ (bez harmonogramu)",
     )
+    parser.add_argument(
+        "--enable-alerts",
+        action="store_true",
+        help="Aktywuj wysyłkę alertów o lukach danych (wymaga skonfigurowanych sekretów)",
+    )
+    parser.add_argument(
+        "--secret-namespace",
+        default="dudzian.trading",
+        help="Namespace używany przy odczycie sekretów (keychain / plik szyfrowany)",
+    )
+    parser.add_argument(
+        "--headless-passphrase",
+        default=None,
+        help="Hasło do magazynu sekretów w środowiskach headless (Linux).",
+    )
+    parser.add_argument(
+        "--headless-secrets-path",
+        default=None,
+        help="Ścieżka do zaszyfrowanego magazynu sekretów w trybie headless.",
+    )
     return parser.parse_args(argv)
 
 
@@ -152,6 +383,7 @@ def _perform_backfill(
     service: OHLCVBackfillService,
     plans: Mapping[str, _IntervalPlan],
     end_timestamp: int,
+    gap_tracker: DataGapIncidentTracker | None = None,
 ) -> None:
     for interval, plan in plans.items():
         start = max(0, plan.backfill_start_ms)
@@ -168,6 +400,8 @@ def _perform_backfill(
             start=start,
             end=end_timestamp,
         )
+        if gap_tracker:
+            gap_tracker.handle_summaries(interval=interval, summaries=summaries, as_of_ms=end_timestamp)
         total = sum(summary.fetched_candles for summary in summaries)
         _LOGGER.info(
             "Zakończono backfill dla interval=%s – pobrano %s nowych świec",
@@ -183,15 +417,16 @@ async def _run_scheduler(
     refresh_seconds: int,
 ) -> None:
     for interval, plan in plans.items():
+        frequency = plan.refresh_seconds or refresh_seconds
         scheduler.add_job(
             symbols=tuple(sorted(plan.symbols)),
             interval=interval,
             lookback_ms=plan.incremental_lookback_ms or (_MILLISECONDS_IN_DAY * 1),
-            frequency_seconds=refresh_seconds,
+            frequency_seconds=frequency,
             name=f"{interval}:{len(plan.symbols)}",
         )
 
-    _LOGGER.info("Uruchamiam harmonogram odświeżania (co %s sekund)", refresh_seconds)
+    _LOGGER.info("Uruchamiam harmonogram odświeżania (domyślnie co %s sekund)", refresh_seconds)
     try:
         await scheduler.run_forever()
     finally:
@@ -210,10 +445,17 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     universe = _resolve_universe(config, environment)
 
+    refresh_overrides = {}
+    if isinstance(environment.adapter_settings, Mapping):
+        candidate = environment.adapter_settings.get("ohlcv_refresh_overrides")
+        if isinstance(candidate, Mapping):
+            refresh_overrides = candidate
+
     plans, symbols = _build_interval_plans(
         universe=universe,
         exchange_name=environment.exchange,
         incremental_lookback_days=max(1, args.incremental_lookback_days),
+        refresh_overrides=refresh_overrides,
     )
     if not plans:
         _LOGGER.warning("Brak instrumentów z zakresem backfill dla giełdy %s", environment.exchange)
@@ -221,8 +463,31 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     cache_root = Path(environment.data_cache_path)
     parquet_storage = ParquetCacheStorage(cache_root / "ohlcv_parquet", namespace=environment.exchange)
-    manifest_storage = SQLiteCacheStorage(cache_root / "ohlcv_manifest.sqlite", store_rows=False)
+    manifest_path = cache_root / "ohlcv_manifest.sqlite"
+    manifest_storage = SQLiteCacheStorage(manifest_path, store_rows=False)
     storage = DualCacheStorage(primary=parquet_storage, manifest=manifest_storage)
+    audit_logger = JSONLGapAuditLogger(cache_root / "audit" / f"{environment.name}_ohlcv_gaps.jsonl")
+
+    alert_router, gap_policy, alert_message = _initialize_alerting(
+        args=args,
+        config=config,
+        environment=environment,
+    )
+    gap_tracker: DataGapIncidentTracker | None = None
+    if alert_router and gap_policy:
+        gap_tracker = DataGapIncidentTracker(
+            router=alert_router,
+            metadata_provider=storage.metadata,
+            policy=gap_policy,
+            environment_name=environment.name,
+            exchange=environment.exchange,
+            audit_logger=audit_logger,
+        )
+        if alert_message:
+            _LOGGER.info(alert_message)
+    elif alert_message:
+        level = logging.INFO if not args.enable_alerts else logging.ERROR
+        _LOGGER.log(level, alert_message)
 
     upstream_source = _build_public_source(environment.exchange, environment.environment)
     upstream_source.exchange_adapter.configure_network(ip_allowlist=environment.ip_allowlist)
@@ -232,13 +497,30 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     backfill_service = OHLCVBackfillService(cached_source)
     now_ts = _utc_now_ms()
-    _perform_backfill(service=backfill_service, plans=plans, end_timestamp=now_ts)
+    _perform_backfill(
+        service=backfill_service,
+        plans=plans,
+        end_timestamp=now_ts,
+        gap_tracker=gap_tracker,
+    )
+
+    _report_manifest_health(
+        manifest_path=manifest_path,
+        universe=universe,
+        exchange_name=environment.exchange,
+        environment_name=environment.name,
+        alert_router=alert_router,
+        as_of=datetime.fromtimestamp(now_ts / 1000, tz=timezone.utc),
+    )
 
     if args.run_once:
         _LOGGER.info("Tryb run-once – kończę po pełnym backfillu")
         return 0
 
-    scheduler = OHLCVRefreshScheduler(backfill_service)
+    scheduler = OHLCVRefreshScheduler(
+        backfill_service,
+        on_job_complete=_build_gap_callback(gap_tracker),
+    )
     try:
         asyncio.run(
             _run_scheduler(

--- a/scripts/gap_audit_report.py
+++ b/scripts/gap_audit_report.py
@@ -1,0 +1,219 @@
+"""Raportuje stan luk danych na podstawie logów audytowych JSONL."""
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from bot_core.data.ohlcv import GapAuditRecord
+
+
+@dataclass(slots=True)
+class GapSummary:
+    exchange: str
+    symbol: str
+    interval: str
+    last_record: GapAuditRecord
+    warning_count: int
+    incident_count: int
+    sms_count: int
+
+    @property
+    def severity(self) -> int:
+        order = {
+            "sms_escalated": 0,
+            "incident": 1,
+            "missing_metadata": 1,
+            "invalid_metadata": 1,
+            "warning": 2,
+            "ok": 3,
+        }
+        return order.get(self.last_record.status, 4)
+
+
+def load_records(
+    path: str | Path,
+    *,
+    environment: str | None = None,
+    exchange: str | None = None,
+    since_hours: float | None = None,
+) -> list[GapAuditRecord]:
+    """Wczytuje wpisy audytowe filtrując środowisko, giełdę i zakres czasu."""
+
+    audit_path = Path(path)
+    if not audit_path.exists():
+        raise SystemExit(f"Plik audytu {audit_path} nie istnieje")
+
+    threshold: datetime | None = None
+    if since_hours is not None and since_hours > 0:
+        threshold = datetime.now(timezone.utc) - timedelta(hours=float(since_hours))
+
+    records: list[GapAuditRecord] = []
+    with audit_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = GapAuditRecord.from_json(line)
+            except ValueError:
+                continue
+            if environment and record.environment != environment:
+                continue
+            if exchange and record.exchange != exchange:
+                continue
+            if threshold and record.timestamp < threshold:
+                continue
+            records.append(record)
+
+    return records
+
+
+def summarize_records(
+    records: Sequence[GapAuditRecord],
+    *,
+    window_hours: float = 24.0,
+) -> list[GapSummary]:
+    """Buduje podsumowanie per symbol/interwał na podstawie wpisów."""
+
+    if not records:
+        return []
+
+    now = datetime.now(timezone.utc)
+    threshold = now - timedelta(hours=max(0.0, window_hours)) if window_hours > 0 else None
+
+    summaries: dict[tuple[str, str, str], GapSummary] = {}
+    for record in records:
+        key = (record.exchange, record.symbol, record.interval)
+        summary = summaries.get(key)
+        if summary is None:
+            summary = GapSummary(
+                exchange=record.exchange,
+                symbol=record.symbol,
+                interval=record.interval,
+                last_record=record,
+                warning_count=0,
+                incident_count=0,
+                sms_count=0,
+            )
+            summaries[key] = summary
+        else:
+            if record.timestamp >= summary.last_record.timestamp:
+                summary.last_record = record
+
+        if threshold is None or record.timestamp >= threshold:
+            if record.status == "warning":
+                summary.warning_count += 1
+            elif record.status in {"incident", "missing_metadata", "invalid_metadata"}:
+                summary.incident_count += 1
+            elif record.status == "sms_escalated":
+                summary.sms_count += 1
+
+    return sorted(
+        summaries.values(),
+        key=lambda item: (item.severity, -(item.last_record.gap_minutes or -1.0), item.symbol),
+    )
+
+
+def _format_value(value: object | None) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def format_summary_table(summaries: Sequence[GapSummary]) -> str:
+    """Formatuje listę podsumowań do tabeli tekstowej."""
+
+    headers = (
+        "Exchange",
+        "Symbol",
+        "Interval",
+        "Status",
+        "Gap[min]",
+        "Incident[min]",
+        "Rows",
+        "Last candle",
+        "Warn(24h)",
+        "Inc(24h)",
+        "SMS(24h)",
+        "Last event",
+    )
+
+    rows: list[tuple[str, ...]] = []
+    for summary in summaries:
+        record = summary.last_record
+        rows.append(
+            (
+                summary.exchange,
+                summary.symbol,
+                summary.interval,
+                record.status,
+                _format_value(record.gap_minutes),
+                _format_value(record.incident_minutes),
+                _format_value(record.row_count),
+                record.last_timestamp or "-",
+                str(summary.warning_count),
+                str(summary.incident_count),
+                str(summary.sms_count),
+                record.timestamp.isoformat(),
+            )
+        )
+
+    columns = list(zip(headers, *rows)) if rows else [(header,) for header in headers]
+    widths = [max(len(str(value)) for value in column) for column in columns]
+
+    def _format_row(values: Iterable[str]) -> str:
+        return "  ".join(value.ljust(width) for value, width in zip(values, widths))
+
+    lines = [_format_row(headers)]
+    lines.append("  ".join("-" * width for width in widths))
+    for row in rows:
+        lines.append(_format_row(row))
+    if not rows:
+        lines.append("(Brak wpisów spełniających kryteria)")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Raport luk danych OHLCV na podstawie pliku audytu JSONL")
+    parser.add_argument("audit_file", help="Ścieżka do pliku JSONL z logami audytu luk")
+    parser.add_argument("--environment", help="Filtruj wpisy po nazwie środowiska")
+    parser.add_argument("--exchange", help="Filtruj wpisy po nazwie giełdy")
+    parser.add_argument(
+        "--since-hours",
+        type=float,
+        default=None,
+        help="Weź pod uwagę tylko wpisy młodsze niż podana liczba godzin",
+    )
+    parser.add_argument(
+        "--window-hours",
+        type=float,
+        default=24.0,
+        help="Okno czasowe (w godzinach) do zliczania ostrzeżeń/incydentów",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    records = load_records(
+        args.audit_file,
+        environment=args.environment,
+        exchange=args.exchange,
+        since_hours=args.since_hours,
+    )
+
+    summaries = summarize_records(records, window_hours=args.window_hours)
+    table = format_summary_table(summaries)
+    print(table)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - punkt wejścia CLI
+    sys.exit(main())
+

--- a/scripts/manifest_gap_report.py
+++ b/scripts/manifest_gap_report.py
@@ -1,0 +1,179 @@
+"""CLI raportujący stan manifestu SQLite dla danych OHLCV."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import CoreConfig, EnvironmentConfig, InstrumentUniverseConfig
+from bot_core.data.ohlcv.manifest_report import generate_manifest_report, summarize_status
+
+
+def _resolve_environment(config: CoreConfig, environment_name: str) -> EnvironmentConfig:
+    try:
+        return config.environments[environment_name]
+    except KeyError as exc:
+        raise SystemExit(f"Nie znaleziono środowiska '{environment_name}' w konfiguracji") from exc
+
+
+def _resolve_universe(config: CoreConfig, environment: EnvironmentConfig) -> InstrumentUniverseConfig:
+    if not environment.instrument_universe:
+        raise SystemExit(
+            "Środowisko nie ma przypisanego instrument_universe – uzupełnij config/core.yaml."
+        )
+    try:
+        return config.instrument_universes[environment.instrument_universe]
+    except KeyError as exc:
+        raise SystemExit(
+            f"Uniwersum '{environment.instrument_universe}' nie istnieje w konfiguracji."
+        ) from exc
+
+
+def _parse_as_of(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise SystemExit(
+            "Parametr --as-of musi być w formacie ISO 8601, np. 2024-05-18T12:00:00Z"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _extract_threshold_overrides(environment: EnvironmentConfig) -> Mapping[str, int]:
+    settings = environment.adapter_settings or {}
+    raw_policy = settings.get("ohlcv_gap_alerts") if isinstance(settings, Mapping) else None
+    if not isinstance(raw_policy, Mapping):
+        return {}
+    warning_cfg = raw_policy.get("warning_gap_minutes")
+    if not isinstance(warning_cfg, Mapping):
+        return {}
+    result: dict[str, int] = {}
+    for key, value in warning_cfg.items():
+        try:
+            minutes = int(value)
+        except (TypeError, ValueError):
+            continue
+        if minutes > 0:
+            result[str(key)] = minutes
+    return result
+
+
+def _format_table(entries) -> str:
+    headers = [
+        "Symbol",
+        "Interwał",
+        "Wiersze",
+        "Ostatni timestamp (UTC)",
+        "Luka [min]",
+        "Próg [min]",
+        "Status",
+    ]
+    rows = []
+    for entry in entries:
+        rows.append(
+            [
+                entry.symbol,
+                entry.interval,
+                "-" if entry.row_count is None else str(entry.row_count),
+                entry.last_timestamp_iso or "-",
+                "-" if entry.gap_minutes is None else f"{entry.gap_minutes:.1f}",
+                "-" if entry.threshold_minutes is None else str(entry.threshold_minutes),
+                entry.status,
+            ]
+        )
+
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+
+    def _format_row(row: list[str]) -> str:
+        return " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+
+    parts = [
+        _format_row(headers),
+        "-+-".join("-" * width for width in widths),
+    ]
+    parts.extend(_format_row(row) for row in rows)
+    return "\n".join(parts)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Raport manifestu OHLCV z SQLite")
+    parser.add_argument("--config", default="config/core.yaml", help="Ścieżka do CoreConfig")
+    parser.add_argument("--environment", required=True, help="Środowisko do analizy")
+    parser.add_argument(
+        "--manifest-path",
+        help="Ścieżka do pliku manifestu. Domyślnie data_cache_path/ohlcv_manifest.sqlite",
+    )
+    parser.add_argument(
+        "--as-of",
+        help="Czas odniesienia w ISO 8601 (domyślnie teraz w UTC)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Zwróć wynik w formacie JSON zamiast tabeli tekstowej",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    config = load_core_config(args.config)
+    environment = _resolve_environment(config, args.environment)
+    universe = _resolve_universe(config, environment)
+
+    manifest_path = (
+        Path(args.manifest_path)
+        if args.manifest_path
+        else Path(environment.data_cache_path) / "ohlcv_manifest.sqlite"
+    )
+
+    if not manifest_path.exists():
+        raise SystemExit(f"Plik manifestu {manifest_path} nie istnieje")
+
+    overrides = _extract_threshold_overrides(environment)
+    as_of = _parse_as_of(args.as_of)
+    entries = generate_manifest_report(
+        manifest_path=manifest_path,
+        universe=universe,
+        exchange_name=environment.exchange,
+        as_of=as_of,
+        warning_thresholds=overrides,
+    )
+
+    if args.json:
+        payload = [entry.__dict__ for entry in entries]
+        print(json.dumps({"entries": payload, "summary": summarize_status(entries)}, indent=2, ensure_ascii=False))
+        return 0
+
+    if not entries:
+        print("Brak instrumentów do raportowania dla wybranego uniwersum")
+        return 0
+
+    table = _format_table(entries)
+    summary = summarize_status(entries)
+    print(table)
+    print()
+    print("Podsumowanie statusów:")
+    for status, count in sorted(summary.items()):
+        print(f"- {status}: {count}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_backfill_cli.py
+++ b/tests/test_backfill_cli.py
@@ -1,7 +1,17 @@
-"""Tests for the backfill CLI helpers."""
-from __future__ import annotations
+import asyncio
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from bot_core.config.loader import load_core_config
+from bot_core.config.models import (
+    InstrumentBackfillWindow,
+    InstrumentConfig,
+    InstrumentUniverseConfig,
+)
+from bot_core.data.ohlcv import SQLiteCacheStorage
 from bot_core.exchanges.base import Environment
 from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
 from bot_core.exchanges.binance.spot import BinanceSpotAdapter
@@ -9,20 +19,14 @@ from bot_core.exchanges.kraken.futures import KrakenFuturesAdapter
 from bot_core.exchanges.kraken.spot import KrakenSpotAdapter
 from bot_core.exchanges.zonda.spot import ZondaSpotAdapter
 
-from scripts.backfill import _build_public_source
+import scripts.backfill as backfill
 
 
-def test_build_public_source_supports_core_multi_exchange() -> None:
+def test_build_public_source_supports_all_exchanges_from_universe():
     config = load_core_config("config/core.yaml")
     universe = config.instrument_universes["core_multi_exchange"]
 
-    exchanges = {
-        exchange_name
-        for instrument in universe.instruments
-        for exchange_name in instrument.exchange_symbols
-    }
-
-    expected_types = {
+    expected_adapters = {
         "binance_spot": BinanceSpotAdapter,
         "binance_futures": BinanceFuturesAdapter,
         "kraken_spot": KrakenSpotAdapter,
@@ -30,7 +34,218 @@ def test_build_public_source_supports_core_multi_exchange() -> None:
         "zonda_spot": ZondaSpotAdapter,
     }
 
+    exchanges = {
+        exchange_name
+        for instrument in universe.instruments
+        for exchange_name in instrument.exchange_symbols.keys()
+    }
+
     for exchange in exchanges:
-        public_source = _build_public_source(exchange, Environment.PAPER)
-        adapter_type = expected_types[exchange]
-        assert isinstance(public_source.exchange_adapter, adapter_type)
+        source = backfill._build_public_source(exchange, Environment.PAPER)
+        assert isinstance(source.exchange_adapter, expected_adapters[exchange])
+        assert source.exchange_adapter.credentials.key_id == "public"
+        assert source.exchange_adapter.credentials.environment == Environment.PAPER
+
+
+def test_build_interval_plans_assigns_refresh_seconds_and_lookbacks():
+    universe = InstrumentUniverseConfig(
+        name="test",
+        description="test",
+        instruments=(
+            InstrumentConfig(
+                name="BTC_USDT",
+                base_asset="BTC",
+                quote_asset="USDT",
+                categories=("core",),
+                exchange_symbols={"binance_spot": "BTCUSDT"},
+                backfill_windows=(
+                    InstrumentBackfillWindow(interval="1d", lookback_days=365),
+                    InstrumentBackfillWindow(interval="1h", lookback_days=30),
+                ),
+            ),
+        ),
+    )
+
+    plans, symbols = backfill._build_interval_plans(
+        universe=universe,
+        exchange_name="binance_spot",
+        incremental_lookback_days=7,
+        refresh_overrides={"1h": 120},
+    )
+
+    assert symbols == {"BTCUSDT"}
+    assert plans["1d"].refresh_seconds == backfill._DEFAULT_REFRESH_SECONDS["1d"]
+    assert plans["1d"].incremental_lookback_ms == 7 * backfill._MILLISECONDS_IN_DAY
+
+    assert plans["1h"].refresh_seconds == 120
+    assert plans["1h"].incremental_lookback_ms == 7 * backfill._MILLISECONDS_IN_DAY
+
+
+class _DummyScheduler:
+    def __init__(self) -> None:
+        self.jobs: list[dict] = []
+        self.stopped = False
+
+    def add_job(self, **kwargs):
+        self.jobs.append(kwargs)
+
+    async def run_forever(self):
+        return
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_run_scheduler_uses_interval_specific_frequency():
+    scheduler = _DummyScheduler()
+    plans = {
+        "1d": backfill._IntervalPlan(
+            symbols={"BTCUSDT"},
+            backfill_start_ms=0,
+            incremental_lookback_ms=backfill._MILLISECONDS_IN_DAY,
+            refresh_seconds=backfill._DEFAULT_REFRESH_SECONDS["1d"],
+        ),
+        "1h": backfill._IntervalPlan(
+            symbols={"ETHUSDT"},
+            backfill_start_ms=0,
+            incremental_lookback_ms=3 * backfill._MILLISECONDS_IN_DAY,
+            refresh_seconds=900,
+        ),
+    }
+
+    asyncio.run(
+        backfill._run_scheduler(
+            scheduler=scheduler,
+            plans=plans,
+            refresh_seconds=600,
+        )
+    )
+
+    assert scheduler.stopped is True
+    assert len(scheduler.jobs) == 2
+
+    job_daily = next(job for job in scheduler.jobs if job["interval"] == "1d")
+    job_hourly = next(job for job in scheduler.jobs if job["interval"] == "1h")
+
+    assert job_daily["frequency_seconds"] == backfill._DEFAULT_REFRESH_SECONDS["1d"]
+    assert job_daily["lookback_ms"] == backfill._MILLISECONDS_IN_DAY
+
+    assert job_hourly["frequency_seconds"] == 900
+    assert job_hourly["lookback_ms"] == 3 * backfill._MILLISECONDS_IN_DAY
+
+
+class _CollectingRouter:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def dispatch(self, message):
+        self.messages.append(message)
+
+
+def _build_universe(symbol: str, interval: str) -> InstrumentUniverseConfig:
+    return InstrumentUniverseConfig(
+        name="test",
+        description="test",
+        instruments=(
+            InstrumentConfig(
+                name=symbol,
+                base_asset=symbol.split("_")[0],
+                quote_asset=symbol.split("_")[1],
+                categories=("core",),
+                exchange_symbols={"binance_spot": symbol.replace("_", "")},
+                backfill_windows=(
+                    InstrumentBackfillWindow(interval=interval, lookback_days=30),
+                ),
+            ),
+        ),
+    )
+
+
+def test_report_manifest_health_does_not_alert_when_everything_ok(tmp_path):
+    manifest = tmp_path / "manifest.sqlite"
+    storage = SQLiteCacheStorage(manifest, store_rows=False)
+    universe = _build_universe("BTC_USDT", "1h")
+    router = _CollectingRouter()
+    as_of = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    metadata = storage.metadata()
+    metadata["last_timestamp::BTCUSDT::1h"] = str(int((as_of - timedelta(minutes=30)).timestamp() * 1000))
+    metadata["row_count::BTCUSDT::1h"] = "120"
+
+    backfill._report_manifest_health(
+        manifest_path=manifest,
+        universe=universe,
+        exchange_name="binance_spot",
+        environment_name="binance_paper",
+        alert_router=router,
+        as_of=as_of,
+    )
+
+    assert router.messages == []
+
+
+def test_report_manifest_health_emits_warning_for_long_gap(tmp_path):
+    manifest = tmp_path / "manifest.sqlite"
+    storage = SQLiteCacheStorage(manifest, store_rows=False)
+    universe = InstrumentUniverseConfig(
+        name="test",
+        description="test",
+        instruments=(
+            InstrumentConfig(
+                name="BTC_USDT",
+                base_asset="BTC",
+                quote_asset="USDT",
+                categories=("core",),
+                exchange_symbols={"binance_spot": "BTCUSDT"},
+                backfill_windows=(
+                    InstrumentBackfillWindow(interval="1d", lookback_days=30),
+                    InstrumentBackfillWindow(interval="1h", lookback_days=30),
+                ),
+            ),
+        ),
+    )
+    router = _CollectingRouter()
+    as_of = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    metadata = storage.metadata()
+    metadata["last_timestamp::BTCUSDT::1d"] = str(int((as_of - timedelta(hours=12)).timestamp() * 1000))
+    metadata["row_count::BTCUSDT::1d"] = "365"
+    metadata["last_timestamp::BTCUSDT::1h"] = str(int((as_of - timedelta(hours=3)).timestamp() * 1000))
+    metadata["row_count::BTCUSDT::1h"] = "720"
+
+    backfill._report_manifest_health(
+        manifest_path=manifest,
+        universe=universe,
+        exchange_name="binance_spot",
+        environment_name="binance_paper",
+        alert_router=router,
+        as_of=as_of,
+    )
+
+    assert len(router.messages) == 1
+    message = router.messages[0]
+    assert message.severity == "warning"
+    assert "BTCUSDT" in message.body
+    assert message.context["environment"] == "binance_paper"
+
+
+def test_report_manifest_health_emits_critical_for_missing_metadata(tmp_path):
+    manifest = tmp_path / "manifest.sqlite"
+    SQLiteCacheStorage(manifest, store_rows=False)
+    universe = _build_universe("ETH_USDT", "1h")
+    router = _CollectingRouter()
+    as_of = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    backfill._report_manifest_health(
+        manifest_path=manifest,
+        universe=universe,
+        exchange_name="binance_spot",
+        environment_name="binance_paper",
+        alert_router=router,
+        as_of=as_of,
+    )
+
+    assert len(router.messages) == 1
+    message = router.messages[0]
+    assert message.severity == "critical"
+    assert "ETHUSDT" in message.body

--- a/tests/test_gap_audit.py
+++ b/tests/test_gap_audit.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from bot_core.data.ohlcv.audit import GapAuditRecord, JSONLGapAuditLogger
+
+
+def test_jsonl_gap_audit_logger_appends(tmp_path) -> None:
+    path = tmp_path / "audit.jsonl"
+    logger = JSONLGapAuditLogger(path)
+    record = GapAuditRecord(
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        environment="demo",
+        exchange="binance_spot",
+        symbol="BTCUSDT",
+        interval="1h",
+        status="warning",
+        gap_minutes=30.0,
+        row_count=1200,
+        last_timestamp="2024-01-01T00:00:00+00:00",
+        warnings_in_window=1,
+        incident_minutes=None,
+    )
+
+    logger.log(record)
+
+    content = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(content) == 1
+    payload = json.loads(content[0])
+    assert payload["status"] == "warning"
+    assert payload["symbol"] == "BTCUSDT"

--- a/tests/test_gap_audit_report.py
+++ b/tests/test_gap_audit_report.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from bot_core.data.ohlcv import GapAuditRecord
+
+import scripts.gap_audit_report as report
+
+
+def _record(**kwargs) -> GapAuditRecord:
+    defaults = {
+        "timestamp": datetime.now(timezone.utc),
+        "environment": "paper",
+        "exchange": "binance_spot",
+        "symbol": "BTCUSDT",
+        "interval": "1h",
+        "status": "ok",
+        "gap_minutes": 0.0,
+        "row_count": 100,
+        "last_timestamp": "1700000000000",
+        "warnings_in_window": 0,
+        "incident_minutes": None,
+    }
+    defaults.update(kwargs)
+    return GapAuditRecord(**defaults)
+
+
+def test_gap_audit_record_from_dict_roundtrip() -> None:
+    original = _record(
+        timestamp=datetime(2024, 5, 1, 12, 30, tzinfo=timezone.utc),
+        gap_minutes=12.3456,
+        row_count=123,
+        warnings_in_window=2,
+        incident_minutes=45.6,
+    )
+    payload = original.to_dict()
+    parsed = GapAuditRecord.from_dict(payload)
+    assert parsed.timestamp == original.timestamp
+    assert parsed.gap_minutes == round(original.gap_minutes, 3)
+    assert parsed.row_count == original.row_count
+    assert parsed.warnings_in_window == original.warnings_in_window
+    assert parsed.incident_minutes == round(original.incident_minutes, 3)
+
+
+def test_load_records_filters_environment_and_time(tmp_path: Path) -> None:
+    now = datetime.now(timezone.utc)
+    records = [
+        _record(timestamp=now - timedelta(hours=1), environment="paper", status="warning"),
+        _record(timestamp=now - timedelta(hours=3), environment="paper", status="incident"),
+        _record(timestamp=now - timedelta(hours=1), environment="prod", status="ok"),
+    ]
+
+    audit_path = tmp_path / "audit.jsonl"
+    with audit_path.open("w", encoding="utf-8") as handle:
+        for item in records:
+            handle.write(json.dumps(item.to_dict()) + "\n")
+
+    loaded = report.load_records(audit_path, environment="paper", since_hours=2)
+    assert len(loaded) == 1
+    assert loaded[0].status == "warning"
+
+
+def test_summarize_records_counts_events_within_window() -> None:
+    now = datetime.now(timezone.utc)
+    records = [
+        _record(status="warning", timestamp=now - timedelta(hours=1)),
+        _record(status="warning", timestamp=now - timedelta(hours=5)),
+        _record(status="incident", timestamp=now - timedelta(hours=2)),
+        _record(status="sms_escalated", timestamp=now - timedelta(hours=3)),
+    ]
+
+    summaries = report.summarize_records(records, window_hours=4)
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.warning_count == 1  # tylko ostrzeżenie z ostatnich 4h
+    assert summary.incident_count == 1
+    assert summary.sms_count == 1
+    assert summary.last_record.status == "warning"
+
+
+def test_format_summary_table_renders_rows() -> None:
+    record = _record(
+        status="incident",
+        gap_minutes=60.0,
+        incident_minutes=30.0,
+        row_count=500,
+        last_timestamp="1700012345000",
+        timestamp=datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    summary = report.GapSummary(
+        exchange=record.exchange,
+        symbol=record.symbol,
+        interval=record.interval,
+        last_record=record,
+        warning_count=2,
+        incident_count=1,
+        sms_count=0,
+    )
+
+    table = report.format_summary_table([summary])
+    assert "incident" in table
+    assert "60.00" in table
+    assert "1700012345000" in table
+    assert "2" in table
+    assert "1" in table
+

--- a/tests/test_gap_monitor.py
+++ b/tests/test_gap_monitor.py
@@ -1,0 +1,234 @@
+from datetime import datetime, timedelta, timezone
+
+from bot_core.alerts import AlertMessage
+from bot_core.data.ohlcv.audit import GapAuditRecord
+from bot_core.data.ohlcv.backfill import BackfillSummary
+from bot_core.data.ohlcv.gap_monitor import DataGapIncidentTracker, GapAlertPolicy
+
+
+class DummyRouter:
+    def __init__(self) -> None:
+        self.messages: list[AlertMessage] = []
+
+    def dispatch(self, message: AlertMessage) -> None:
+        self.messages.append(message)
+
+
+class DummyAuditLogger:
+    def __init__(self) -> None:
+        self.records: list[GapAuditRecord] = []
+
+    def log(self, record: GapAuditRecord) -> None:
+        self.records.append(record)
+
+
+def _summary(symbol: str, interval: str, end: int) -> BackfillSummary:
+    return BackfillSummary(
+        symbol=symbol,
+        interval=interval,
+        requested_start=end - 600_000,
+        requested_end=end,
+        fetched_candles=0,
+        skipped_candles=0,
+    )
+
+
+def test_gap_tracker_sends_warning_on_threshold_exceeded() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    now_ms = int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::BTCUSDT::1h": str(now_ms - 90 * 60_000),
+        "row_count::BTCUSDT::1h": "1200",
+    }
+    policy = GapAlertPolicy(warning_gap_minutes={"1h": 60})
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc),
+        audit_logger=audit,
+    )
+
+    tracker.handle_summaries(interval="1h", summaries=[_summary("BTCUSDT", "1h", now_ms)], as_of_ms=now_ms)
+
+    assert len(router.messages) == 1
+    message = router.messages[0]
+    assert message.severity == "warning"
+    assert message.context["symbol"] == "BTCUSDT"
+    assert message.context["interval"] == "1h"
+
+    assert len(audit.records) == 1
+    record = audit.records[0]
+    assert record.status == "warning"
+    assert record.symbol == "BTCUSDT"
+    assert record.interval == "1h"
+
+
+def test_gap_tracker_throttles_repeated_warnings() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    clock_times = [base_time, base_time + timedelta(minutes=2)]
+
+    def clock() -> datetime:
+        return clock_times.pop(0)
+
+    now_ms = int((base_time + timedelta(hours=2)).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::ETHUSDT::1h": str(now_ms - 180 * 60_000),
+        "row_count::ETHUSDT::1h": "900",
+    }
+    policy = GapAlertPolicy(warning_gap_minutes={"1h": 60}, warning_throttle_minutes=5)
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="paper",
+        exchange="binance_spot",
+        clock=clock,
+        audit_logger=audit,
+    )
+
+    tracker.handle_summaries(interval="1h", summaries=[_summary("ETHUSDT", "1h", now_ms)], as_of_ms=now_ms)
+    tracker.handle_summaries(interval="1h", summaries=[_summary("ETHUSDT", "1h", now_ms)], as_of_ms=now_ms)
+
+    assert len(router.messages) == 1
+    assert router.messages[0].severity == "warning"
+    assert [record.status for record in audit.records] == ["warning", "warning_suppressed"]
+
+
+def test_gap_tracker_opens_incident_after_repeated_warnings() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    times = [base_time + timedelta(minutes=idx) for idx in range(3)]
+
+    def clock() -> datetime:
+        return times.pop(0)
+
+    now_ms = int((base_time + timedelta(minutes=30)).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::ETHUSDT::1h": str(now_ms - 180 * 60_000),
+        "row_count::ETHUSDT::1h": "600",
+    }
+    policy = GapAlertPolicy(
+        warning_gap_minutes={"1h": 60},
+        incident_threshold_count=3,
+        incident_window_minutes=10,
+        sms_escalation_minutes=15,
+    )
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=clock,
+        audit_logger=audit,
+    )
+
+    for _ in range(3):
+        tracker.handle_summaries(
+            interval="1h",
+            summaries=[_summary("ETHUSDT", "1h", now_ms)],
+            as_of_ms=now_ms,
+        )
+
+    assert [message.severity for message in router.messages] == ["warning", "critical"]
+    assert "INCIDENT" in router.messages[-1].title
+
+    statuses = [record.status for record in audit.records]
+    assert statuses.count("warning") == 1
+    assert statuses.count("warning_suppressed") == 1
+    assert statuses[-1] == "incident"
+
+
+def test_gap_tracker_escalates_sms_and_recovers() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    clock_times = [
+        base_time,
+        base_time + timedelta(minutes=2),
+        base_time + timedelta(minutes=4),
+        base_time + timedelta(minutes=20),
+        base_time + timedelta(minutes=40),
+    ]
+
+    def clock() -> datetime:
+        return clock_times.pop(0)
+
+    now_ms = int((base_time + timedelta(minutes=30)).timestamp() * 1000)
+    metadata = {
+        "last_timestamp::SOLUSDT::15m": str(now_ms - 45 * 60_000),
+        "row_count::SOLUSDT::15m": "350",
+    }
+    policy = GapAlertPolicy(
+        warning_gap_minutes={"15m": 10},
+        incident_threshold_count=3,
+        incident_window_minutes=10,
+        sms_escalation_minutes=15,
+    )
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="test-env",
+        exchange="binance_spot",
+        clock=clock,
+        audit_logger=audit,
+    )
+
+    for _ in range(3):
+        tracker.handle_summaries(
+            interval="15m",
+            summaries=[_summary("SOLUSDT", "15m", now_ms)],
+            as_of_ms=now_ms,
+        )
+
+    tracker.handle_summaries(
+        interval="15m",
+        summaries=[_summary("SOLUSDT", "15m", now_ms)],
+        as_of_ms=now_ms,
+    )
+
+    metadata["last_timestamp::SOLUSDT::15m"] = str(now_ms)
+    tracker.handle_summaries(
+        interval="15m",
+        summaries=[_summary("SOLUSDT", "15m", now_ms)],
+        as_of_ms=now_ms,
+    )
+
+    assert any("Eskalacja SMS" in msg.title for msg in router.messages)
+    assert router.messages[-1].severity == "info"
+    assert "Incydent zamknięty" in router.messages[-1].title
+
+    statuses = [record.status for record in audit.records]
+    assert "sms_escalated" in statuses
+    assert statuses[-1] == "ok"
+
+
+def test_gap_tracker_audit_records_missing_metadata() -> None:
+    router = DummyRouter()
+    audit = DummyAuditLogger()
+    now_ms = int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    metadata: dict[str, str] = {"row_count::BTCPLN::1h": "42"}
+    policy = GapAlertPolicy(warning_gap_minutes={})
+    tracker = DataGapIncidentTracker(
+        router=router,
+        metadata_provider=lambda: metadata,
+        policy=policy,
+        environment_name="paper",
+        exchange="zonda_spot",
+        clock=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc),
+        audit_logger=audit,
+    )
+
+    tracker.handle_summaries(interval="1h", summaries=[_summary("BTCPLN", "1h", now_ms)], as_of_ms=now_ms)
+
+    assert router.messages[-1].severity == "critical"
+    assert audit.records[-1].status == "missing_metadata"
+

--- a/tests/test_manifest_report.py
+++ b/tests/test_manifest_report.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from bot_core.config.models import InstrumentBackfillWindow, InstrumentConfig, InstrumentUniverseConfig
+from bot_core.data.ohlcv.manifest_report import generate_manifest_report, summarize_status
+from bot_core.data.ohlcv.sqlite_storage import SQLiteCacheStorage
+
+
+@pytest.fixture()
+def sample_universe() -> InstrumentUniverseConfig:
+    return InstrumentUniverseConfig(
+        name="test",
+        description="",
+        instruments=(
+            InstrumentConfig(
+                name="BTC/USDT",
+                base_asset="BTC",
+                quote_asset="USDT",
+                categories=("core",),
+                exchange_symbols={"binance_spot": "BTCUSDT"},
+                backfill_windows=(
+                    InstrumentBackfillWindow(interval="1d", lookback_days=365),
+                    InstrumentBackfillWindow(interval="1h", lookback_days=30),
+                ),
+            ),
+            InstrumentConfig(
+                name="ETH/USDT",
+                base_asset="ETH",
+                quote_asset="USDT",
+                categories=("core",),
+                exchange_symbols={"binance_spot": "ETHUSDT"},
+                backfill_windows=(
+                    InstrumentBackfillWindow(interval="1d", lookback_days=365),
+                ),
+            ),
+        ),
+    )
+
+
+def test_report_marks_missing_metadata(tmp_path: Path, sample_universe: InstrumentUniverseConfig) -> None:
+    manifest = tmp_path / "manifest.sqlite"
+    storage = SQLiteCacheStorage(manifest, store_rows=False)
+    metadata = storage.metadata()
+    metadata["last_timestamp::BTCUSDT::1d"] = str(int(datetime(2024, 5, 1, tzinfo=timezone.utc).timestamp() * 1000))
+    metadata["row_count::BTCUSDT::1d"] = "200"
+
+    entries = generate_manifest_report(
+        manifest_path=manifest,
+        universe=sample_universe,
+        exchange_name="binance_spot",
+        as_of=datetime(2024, 5, 10, tzinfo=timezone.utc),
+        warning_thresholds={"1d": 1440},
+    )
+
+    btc_daily = next(e for e in entries if e.symbol == "BTCUSDT" and e.interval == "1d")
+    assert btc_daily.status == "warning"
+    assert pytest.approx(btc_daily.gap_minutes or 0.0, rel=1e-3) == 12960.0  # 9 dni
+
+    btc_hourly = next(e for e in entries if e.symbol == "BTCUSDT" and e.interval == "1h")
+    assert btc_hourly.status == "missing_metadata"
+    assert btc_hourly.last_timestamp_iso is None
+
+    eth_daily = next(e for e in entries if e.symbol == "ETHUSDT" and e.interval == "1d")
+    assert eth_daily.status == "missing_metadata"
+
+
+def test_report_handles_invalid_timestamp(tmp_path: Path, sample_universe: InstrumentUniverseConfig) -> None:
+    manifest = tmp_path / "manifest.sqlite"
+    storage = SQLiteCacheStorage(manifest, store_rows=False)
+    metadata = storage.metadata()
+    metadata["last_timestamp::BTCUSDT::1d"] = "not-a-number"
+    metadata["row_count::BTCUSDT::1d"] = "50"
+
+    entries = generate_manifest_report(
+        manifest_path=manifest,
+        universe=sample_universe,
+        exchange_name="binance_spot",
+    )
+
+    entry = next(e for e in entries if e.symbol == "BTCUSDT" and e.interval == "1d")
+    assert entry.status == "invalid_metadata"
+    assert entry.last_timestamp_iso == "not-a-number"
+
+
+def test_summarize_status_counts_entries(sample_universe: InstrumentUniverseConfig, tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.sqlite"
+    storage = SQLiteCacheStorage(manifest, store_rows=False)
+    metadata = storage.metadata()
+    now_ms = int(datetime(2024, 5, 10, tzinfo=timezone.utc).timestamp() * 1000)
+    metadata["last_timestamp::BTCUSDT::1d"] = str(now_ms)
+    metadata["row_count::BTCUSDT::1d"] = "10"
+
+    entries = generate_manifest_report(
+        manifest_path=manifest,
+        universe=sample_universe,
+        exchange_name="binance_spot",
+        as_of=datetime(2024, 5, 10, tzinfo=timezone.utc),
+    )
+
+    summary = summarize_status(entries)
+    assert summary["ok"] == 1

--- a/tests/test_pipeline_paper.py
+++ b/tests/test_pipeline_paper.py
@@ -243,6 +243,12 @@ def test_paper_pipeline_executes_and_alerts(tmp_path: Path) -> None:
         quantity=quantity,
         order_type="market",
         price=price,
+        metadata={
+            "atr": atr,
+            "stop_price": float(signal.metadata["stop_price"]),
+            "quantity": quantity,
+            "price": price,
+        },
     )
 
     check = risk_engine.apply_pre_trade_checks(order, account=account, profile_name=profile.name)

--- a/tests/test_risk_profiles.py
+++ b/tests/test_risk_profiles.py
@@ -87,7 +87,20 @@ def test_risk_engine_accepts_atr_informed_order(btc_daily_atr_series: list[float
     )
 
     quantity = _recommended_quantity(profile=profile, atr=atr, equity=equity, price=price, risk_pct=0.012)
-    order = OrderRequest(symbol="BTCUSDT", side="buy", quantity=quantity, order_type="market", price=price)
+    stop_price = price - atr * profile.stop_loss_atr_multiple()
+    order = OrderRequest(
+        symbol="BTCUSDT",
+        side="buy",
+        quantity=quantity,
+        order_type="market",
+        price=price,
+        metadata={
+            "atr": atr,
+            "stop_price": stop_price,
+            "quantity": quantity,
+            "price": price,
+        },
+    )
 
     check = engine.apply_pre_trade_checks(order, account=account, profile_name=profile.name)
     assert check.allowed, check.reason
@@ -99,6 +112,12 @@ def test_risk_engine_accepts_atr_informed_order(btc_daily_atr_series: list[float
         quantity=oversized_quantity,
         order_type="market",
         price=price,
+        metadata={
+            "atr": atr,
+            "stop_price": stop_price,
+            "quantity": oversized_quantity,
+            "price": price,
+        },
     )
 
     denial = engine.apply_pre_trade_checks(oversized_order, account=account, profile_name=profile.name)

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -147,7 +147,19 @@ def test_bootstrap_environment_initialises_components(tmp_path: Path) -> None:
     assert isinstance(context.risk_engine, ThresholdRiskEngine)
     assert isinstance(context.risk_repository, FileRiskRepository)
     result = context.risk_engine.apply_pre_trade_checks(
-        OrderRequest(symbol="BTCUSDT", side="buy", quantity=0.2, order_type="limit", price=100.0),
+        OrderRequest(
+            symbol="BTCUSDT",
+            side="buy",
+            quantity=0.2,
+            order_type="limit",
+            price=100.0,
+            metadata={
+                "atr": 5.0,
+                "stop_price": 90.0,
+                "quantity": 0.2,
+                "price": 100.0,
+            },
+        ),
         account=AccountSnapshot(
             balances={"USDT": 1000.0},
             total_equity=1000.0,


### PR DESCRIPTION
## Summary
- log manifest status after each backfill run and push grouped alerts for manifest warnings or critical metadata gaps
- cover the new manifest reporter with unit tests for nominal, warning, and critical cases
- document automatic manifest alerting in the backfill runbook

## Testing
- pytest --override-ini=addopts= tests/test_backfill_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a4edd8c4832a833101767f0e67e6