### PR TITLE
Odblokuj offline smoke test paper tradingu

### DIFF
--- a/docs/audit/paper_trading_log.md
+++ b/docs/audit/paper_trading_log.md
@@ -16,7 +16,8 @@ Dokument stanowi append-only rejestr zdarzeń operacyjnych związanych z trybem 
 | ID | Data (UTC) | Operator | Środowisko | Zakres dat | Raport (`summary.json`) | Hash SHA-256 | Status alertów | Uwagi |
 |----|------------|----------|------------|------------|-------------------------|--------------|----------------|-------|
 | S-TEST-0001 | YYYY-MM-DDThh:mm:ssZ | imię nazwisko | binance_paper | 2024-01-01 → 2024-02-15 | `/tmp/daily_trend_smoke_xxx/summary.json` | `<hash>` | OK | „Smoke test sanity” |
-
+ | S-0001 | 2025-09-30T16:53:03Z | CI Agent | binance_paper | 2024-01-01 → 2024-02-15 | `n/a` | `n/a` | ERROR (403 Binance API) | Smoke test przerwany – brak dostępu do API Binance (403 Forbidden) |
+| S-0002 | 2025-09-30T17:19:30Z | CI Agent | binance_paper | 2024-01-01 → 2024-02-15 | `/tmp/daily_trend_smoke_jk_rha7g/summary.json` | `c694ac951e24fb214fe8b454b4abb9582d94f59e25ed05f697035d2bff713f87` | WARN (alert channels) | Smoke test ukończony na cache offline; wysyłka alertów nieudana (403 Telegram, DNS e-mail). |
 ## Sekcja C – Incydenty i alerty krytyczne
 | ID | Data (UTC) | Operator | Kod alertu | Opis | Działanie naprawcze | Status |
 |----|------------|----------|------------|------|---------------------|--------|

--- a/scripts/seed_paper_cache.py
+++ b/scripts/seed_paper_cache.py
@@ -1,0 +1,319 @@
+"""Narzędzie do przygotowania lokalnego cache'u OHLCV dla smoke testów paper tradingu."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Sequence
+
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import CoreConfig, EnvironmentConfig, InstrumentConfig
+from bot_core.data.ohlcv import ParquetCacheStorage, SQLiteCacheStorage
+from bot_core.exchanges.base import Environment as ExchangeEnvironment
+
+_LOGGER = logging.getLogger(__name__)
+
+_COLUMNS = ("open_time", "open", "high", "low", "close", "volume")
+
+_BASE_PRICE_BY_ASSET = {
+    "BTC": 45_000.0,
+    "ETH": 2_500.0,
+    "SOL": 95.0,
+    "BNB": 320.0,
+    "XRP": 0.6,
+    "ADA": 0.45,
+    "LTC": 78.0,
+    "MATIC": 0.85,
+}
+
+_BASE_VOLUME_BY_ASSET = {
+    "BTC": 1_500.0,
+    "ETH": 3_000.0,
+    "SOL": 45_000.0,
+    "BNB": 25_000.0,
+    "XRP": 8_000_000.0,
+    "ADA": 9_500_000.0,
+    "LTC": 120_000.0,
+    "MATIC": 6_000_000.0,
+}
+
+
+@dataclass(slots=True)
+class GeneratedSeries:
+    symbol: str
+    interval: str
+    candles: int
+    start_timestamp: int
+    end_timestamp: int
+
+
+def _parse_start_date(value: str | None, *, days: int) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc) - timedelta(days=days)
+    text = value.strip()
+    if not text:
+        raise ValueError("start-date nie może być pusty")
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def _base_price(symbol: str, base_asset: str) -> float:
+    asset = base_asset.upper()
+    if asset in _BASE_PRICE_BY_ASSET:
+        return _BASE_PRICE_BY_ASSET[asset]
+    digest = hashlib.sha256(f"{symbol}:{asset}".encode("utf-8")).digest()
+    anchor = int.from_bytes(digest[:4], "big")
+    return 10.0 + (anchor % 10_000) / 100.0
+
+
+def _base_volume(symbol: str, base_asset: str) -> float:
+    asset = base_asset.upper()
+    if asset in _BASE_VOLUME_BY_ASSET:
+        return _BASE_VOLUME_BY_ASSET[asset]
+    digest = hashlib.sha256(f"vol:{symbol}:{asset}".encode("utf-8")).digest()
+    anchor = int.from_bytes(digest[4:8], "big")
+    return 1_000.0 + (anchor % 200_000)
+
+
+def _generate_rows(
+    *,
+    symbol: str,
+    base_asset: str,
+    days: int,
+    start: datetime,
+    interval: str,
+    seed: int | None,
+) -> list[list[float]]:
+    if interval != "1d":
+        raise ValueError("Skrypt obsługuje wyłącznie interwał 1d na potrzeby smoke testu")
+    step = timedelta(days=1)
+    price = _base_price(symbol, base_asset)
+    volume_anchor = _base_volume(symbol, base_asset)
+    if seed is not None:
+        digest = hashlib.sha256(f"{symbol}:{seed}".encode("utf-8")).digest()
+        rng_state = int.from_bytes(digest[:8], "big")
+    else:
+        rng_state = hash((symbol, days, start.toordinal())) & 0xFFFFFFFF
+
+    def _rand() -> float:
+        nonlocal rng_state
+        rng_state = (1103515245 * rng_state + 12345) % (2 ** 31)
+        return rng_state / float(2 ** 31)
+
+    rows: list[list[float]] = []
+    current = start
+    for _ in range(days):
+        open_price = price
+        drift = 0.0025 + (_rand() - 0.5) * 0.004
+        shock = (_rand() - 0.5) * 0.015
+        close_price = max(0.0001, open_price * (1.0 + drift + shock))
+        high_price = max(open_price, close_price) * (1.0 + abs((_rand() - 0.5) * 0.01))
+        low_price = min(open_price, close_price) * (1.0 - abs((_rand() - 0.5) * 0.01))
+        volume = volume_anchor * (0.75 + _rand() * 0.5)
+        timestamp = int(current.replace(hour=0, minute=0, second=0, microsecond=0).timestamp() * 1000)
+        rows.append([
+            float(timestamp),
+            float(round(open_price, 6)),
+            float(round(high_price, 6)),
+            float(round(low_price, 6)),
+            float(round(close_price, 6)),
+            float(round(volume, 6)),
+        ])
+        price = close_price
+        current += step
+    return rows
+
+
+def _resolve_symbols(
+    *,
+    config: CoreConfig,
+    environment: EnvironmentConfig,
+) -> list[tuple[str, InstrumentConfig]]:
+    if not environment.instrument_universe:
+        raise ValueError(
+            f"Środowisko {environment.name} nie ma przypisanego instrument_universe w konfiguracji"
+        )
+    try:
+        universe = config.instrument_universes[environment.instrument_universe]
+    except KeyError as exc:
+        raise KeyError(
+            f"Brak uniwersum instrumentów '{environment.instrument_universe}' w konfiguracji"
+        ) from exc
+
+    raw_settings = getattr(environment, "adapter_settings", {}) or {}
+    paper_settings = raw_settings.get("paper_trading", {}) or {}
+    quote_assets = paper_settings.get("quote_assets")
+    if quote_assets:
+        allowed_quotes = {str(asset).upper() for asset in quote_assets}
+    else:
+        valuation = str(paper_settings.get("valuation_asset", "USDT")).upper()
+        allowed_quotes = {valuation}
+
+    symbols: list[tuple[str, InstrumentConfig]] = []
+    for instrument in universe.instruments:
+        exchange_symbol = instrument.exchange_symbols.get(environment.exchange)
+        if not exchange_symbol:
+            continue
+        if instrument.quote_asset.upper() not in allowed_quotes:
+            continue
+        symbols.append((exchange_symbol, instrument))
+    return symbols
+
+
+def generate_smoke_cache(
+    *,
+    config_path: Path,
+    environment_name: str,
+    interval: str,
+    days: int,
+    start_date: datetime,
+    seed: int | None = None,
+) -> list[GeneratedSeries]:
+    if days <= 0:
+        raise ValueError("Liczba dni musi być dodatnia")
+
+    config = load_core_config(config_path)
+    try:
+        environment = config.environments[environment_name]
+    except KeyError as exc:
+        raise KeyError(f"Brak środowiska '{environment_name}' w konfiguracji") from exc
+
+    if environment.environment not in {ExchangeEnvironment.PAPER, ExchangeEnvironment.TESTNET}:
+        raise ValueError("Cache smoke obsługuje wyłącznie środowiska paper/testnet")
+
+    symbols = _resolve_symbols(config=config, environment=environment)
+    if not symbols:
+        raise ValueError(
+            f"Uniwersum {environment.instrument_universe} nie posiada instrumentów dla giełdy {environment.exchange}"
+        )
+
+    cache_root = Path(environment.data_cache_path)
+    parquet_storage = ParquetCacheStorage(cache_root / "ohlcv_parquet", namespace=environment.exchange)
+    manifest_storage = SQLiteCacheStorage(cache_root / "ohlcv_manifest.sqlite", store_rows=False)
+    metadata = parquet_storage.metadata()
+
+    generated: list[GeneratedSeries] = []
+    for symbol, instrument in symbols:
+        rows = _generate_rows(
+            symbol=symbol,
+            base_asset=instrument.base_asset,
+            days=days,
+            start=start_date,
+            interval=interval,
+            seed=seed,
+        )
+        payload = {"columns": _COLUMNS, "rows": rows}
+        key = f"{symbol}::{interval}"
+        parquet_storage.write(key, payload)
+        manifest_storage.write(key, payload)
+        metadata[f"row_count::{symbol}::{interval}"] = str(len(rows))
+        metadata[f"last_timestamp::{symbol}::{interval}"] = str(int(rows[-1][0]))
+        generated.append(
+            GeneratedSeries(
+                symbol=symbol,
+                interval=interval,
+                candles=len(rows),
+                start_timestamp=int(rows[0][0]),
+                end_timestamp=int(rows[-1][0]),
+            )
+        )
+        _LOGGER.info(
+            "Zapisano %s świec dla %s (%s) w %s",
+            len(rows),
+            symbol,
+            interval,
+            cache_root,
+        )
+
+    return generated
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generuje deterministyczne dane OHLCV 1d dla środowiska paper/testnet, "
+            "aby umożliwić offline smoke test strategii Daily Trend."
+        )
+    )
+    parser.add_argument("--config", default="config/core.yaml", help="Ścieżka do pliku konfiguracyjnego core")
+    parser.add_argument(
+        "--environment",
+        default="binance_paper",
+        help="Nazwa środowiska paper/testnet, dla którego generujemy cache",
+    )
+    parser.add_argument(
+        "--interval",
+        default="1d",
+        help="Interwał OHLCV (obecnie obsługiwany 1d)",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=60,
+        help="Liczba kolejnych dni do wygenerowania",
+    )
+    parser.add_argument(
+        "--start-date",
+        default="2024-01-01",
+        help="Data początkowa (ISO 8601, UTC) pierwszej świecy",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Opcjonalne ziarno generatora szumu (dla powtarzalności)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Ogranicz logowanie do ostrzeżeń/błędów",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING if args.quiet else logging.INFO)
+
+    try:
+        start_date = _parse_start_date(args.start_date, days=args.days)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+    try:
+        results = generate_smoke_cache(
+            config_path=Path(args.config),
+            environment_name=args.environment,
+            interval=args.interval,
+            days=args.days,
+            start_date=start_date,
+            seed=args.seed,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.error("Nie udało się zbudować cache'u smoke: %s", exc)
+        return 1
+
+    total = sum(entry.candles for entry in results)
+    earliest = min(entry.start_timestamp for entry in results)
+    latest = max(entry.end_timestamp for entry in results)
+    _LOGGER.info(
+        "Cache smoke gotowy: %s świec, zakres %s – %s (UTC)",
+        total,
+        datetime.fromtimestamp(earliest / 1000, tz=timezone.utc).isoformat(),
+        datetime.fromtimestamp(latest / 1000, tz=timezone.utc).isoformat(),
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/tests/test_run_daily_trend_script.py
+++ b/tests/test_run_daily_trend_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Iterable
@@ -51,10 +52,18 @@ def test_run_once_executes_single_iteration(monkeypatch: pytest.MonkeyPatch) -> 
     calls: list[str] = []
 
     class DummyRunner:
-        def __init__(self, *, controller: Any, trading_controller: Any, history_bars: int) -> None:
+        def __init__(
+            self,
+            *,
+            controller: Any,
+            trading_controller: Any,
+            history_bars: int,
+            clock=None,
+        ) -> None:
             assert controller is pipeline.controller
             assert trading_controller is trading_controller_obj
             captured_args["history_bars"] = history_bars
+            captured_args["clock"] = clock
             calls.append("init")
 
         def run_once(self) -> Iterable[OrderResult]:
@@ -102,3 +111,142 @@ def test_dry_run_returns_success(monkeypatch: pytest.MonkeyPatch) -> None:
     exit_code = run_daily_trend.main(["--config", "config/core.yaml", "--dry-run"])
 
     assert exit_code == 0
+
+
+def test_paper_smoke_uses_date_window(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from scripts import run_daily_trend
+
+    dispatch_calls: list[Any] = []
+    sync_calls: list[dict[str, Any]] = []
+    collected_calls: list[dict[str, int]] = []
+
+    class DummyController:
+        symbols = ("BTCUSDT",)
+        interval = "1d"
+        tick_seconds = 86400.0
+
+        def collect_signals(self, *, start: int, end: int) -> list[Any]:
+            collected_calls.append({"start": start, "end": end})
+            return []
+
+    class DummyBackfill:
+        def synchronize(self, **kwargs: Any) -> None:
+            sync_calls.append(kwargs)
+
+    class DummyExecutionService:
+        def ledger(self) -> list[dict[str, Any]]:
+            return []
+
+    class DummyAlertRouter:
+        def dispatch(self, message: Any) -> None:
+            dispatch_calls.append(message)
+
+        def health_snapshot(self) -> dict[str, Any]:
+            return {}
+
+    environment_cfg = SimpleNamespace(environment=Environment.PAPER, risk_profile="balanced")
+
+    pipeline = SimpleNamespace(
+        controller=DummyController(),
+        backfill_service=DummyBackfill(),
+        execution_service=DummyExecutionService(),
+        bootstrap=SimpleNamespace(environment=environment_cfg, alert_router=DummyAlertRouter()),
+    )
+
+    captured_args: dict[str, Any] = {}
+
+    def fake_build_pipeline(**kwargs: Any) -> SimpleNamespace:
+        captured_args.update(kwargs)
+        return pipeline
+
+    monkeypatch.setattr(run_daily_trend, "build_daily_trend_pipeline", fake_build_pipeline)
+
+    trading_controller = SimpleNamespace(
+        maybe_report_health=lambda: None,
+        process_signals=lambda signals: [],
+    )
+
+    monkeypatch.setattr(
+        run_daily_trend,
+        "create_trading_controller",
+        lambda pipeline_arg, alert_router, **kwargs: trading_controller,
+    )
+
+    captured_runner: dict[str, Any] = {}
+
+    class DummyRunner:
+        def __init__(
+            self,
+            *,
+            controller: Any,
+            trading_controller: Any,
+            history_bars: int,
+            clock=None,
+            ) -> None:
+            captured_runner.update(
+                {
+                    "controller": controller,
+                    "trading_controller": trading_controller,
+                    "history_bars": history_bars,
+                    "clock": clock,
+                }
+            )
+
+        def run_once(self) -> list[OrderResult]:
+            now = captured_runner["clock"]()
+            captured_runner["now"] = now
+            controller = captured_runner["controller"]
+            tick_ms = int(getattr(controller, "tick_seconds", 86400.0) * 1000)
+            history = int(captured_runner["history_bars"])
+            end_ms = int(now.timestamp() * 1000)
+            start_ms = max(0, end_ms - history * tick_ms)
+            controller.collect_signals(start=start_ms, end=end_ms)
+            return []
+
+    monkeypatch.setattr(run_daily_trend, "DailyTrendRealtimeRunner", DummyRunner)
+
+    def fake_export_smoke_report(**kwargs: Any) -> Path:
+        summary_path = tmp_path / "summary.json"
+        summary_path.write_text("{}", encoding="utf-8")
+        return summary_path
+
+    monkeypatch.setattr(run_daily_trend, "_export_smoke_report", fake_export_smoke_report)
+
+    exit_code = run_daily_trend.main(
+        [
+            "--config",
+            "config/core.yaml",
+            "--environment",
+            "binance_paper",
+            "--paper-smoke",
+            "--date-window",
+            "2024-01-01:2024-02-15",
+        ]
+    )
+
+    assert exit_code == 0
+    assert "adapter_factories" in captured_args
+    assert "binance_spot" in captured_args["adapter_factories"]
+
+    end_dt = datetime.fromisoformat("2024-02-15T23:59:59.999000+00:00")
+    start_dt = datetime.fromisoformat("2024-01-01T00:00:00+00:00")
+    start_ms = int(start_dt.timestamp() * 1000)
+    end_ms = int(end_dt.timestamp() * 1000)
+    tick_ms = int(pipeline.controller.tick_seconds * 1000)
+    window_duration_ms = max(0, end_ms - start_ms)
+    approx_bars = max(1, int(window_duration_ms / tick_ms) + 1)
+    expected_history = max(1, min(180, approx_bars))
+    expected_runner_start = max(0, end_ms - expected_history * tick_ms)
+
+    assert captured_runner["history_bars"] == expected_history
+    assert captured_runner["now"] == end_dt
+
+    assert sync_calls
+    assert sync_calls[0]["start"] == min(start_ms, expected_runner_start)
+    assert sync_calls[0]["end"] == end_ms
+
+    assert collected_calls
+    assert collected_calls[0]["start"] == expected_runner_start
+    assert collected_calls[0]["end"] >= end_ms
+
+    assert dispatch_calls, "Kanał alertów powinien otrzymać powiadomienie smoke"

--- a/tests/test_seed_paper_cache.py
+++ b/tests/test_seed_paper_cache.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.data.ohlcv import ParquetCacheStorage, SQLiteCacheStorage
+
+from scripts.seed_paper_cache import GeneratedSeries, generate_smoke_cache
+
+
+def _write_config(path: Path, data_path: Path) -> None:
+    path.write_text(
+        f"""
+risk_profiles:
+  balanced:
+    max_daily_loss_pct: 0.01
+    max_position_pct: 0.05
+    target_volatility: 0.1
+    max_leverage: 2.0
+    stop_loss_atr_multiple: 1.5
+    max_open_positions: 5
+    hard_drawdown_pct: 0.1
+
+instrument_universes:
+  test_universe:
+    description: smoke
+    instruments:
+      AAA_USDT:
+        base_asset: AAA
+        quote_asset: USDT
+        categories: []
+        exchanges:
+          binance_spot: AAAUSDT
+        backfill:
+          - interval: "1d"
+            lookback_days: 30
+      BBB_USDT:
+        base_asset: BBB
+        quote_asset: USDT
+        categories: []
+        exchanges:
+          binance_spot: BBBUSDT
+        backfill:
+          - interval: "1d"
+            lookback_days: 30
+
+environments:
+  test_env:
+    exchange: binance_spot
+    environment: paper
+    keychain_key: test
+    credential_purpose: trading
+    data_cache_path: {data_path!s}
+    risk_profile: balanced
+    alert_channels: []
+    ip_allowlist: []
+    required_permissions: [trade]
+    forbidden_permissions: []
+    instrument_universe: test_universe
+    adapter_settings:
+      paper_trading:
+        valuation_asset: USDT
+        position_size: 0.1
+        initial_balances:
+          USDT: 1000.0
+""",
+        encoding="utf-8",
+    )
+
+
+def test_generate_smoke_cache_writes_parquet_and_manifest(tmp_path):
+    data_path = tmp_path / "cache"
+    config_path = tmp_path / "core.yaml"
+    _write_config(config_path, data_path)
+
+    start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    results = generate_smoke_cache(
+        config_path=config_path,
+        environment_name="test_env",
+        interval="1d",
+        days=5,
+        start_date=start_date,
+        seed=42,
+    )
+
+    assert results
+    assert all(isinstance(entry, GeneratedSeries) for entry in results)
+    symbols = {entry.symbol for entry in results}
+    assert symbols == {"AAAUSDT", "BBBUSDT"}
+
+    parquet_storage = ParquetCacheStorage(data_path / "ohlcv_parquet", namespace="binance_spot")
+    manifest_storage = SQLiteCacheStorage(data_path / "ohlcv_manifest.sqlite", store_rows=False)
+
+    for entry in results:
+        payload = parquet_storage.read(f"{entry.symbol}::{entry.interval}")
+        rows = payload["rows"]
+        assert len(rows) == entry.candles
+        assert rows[0][0] == entry.start_timestamp
+        assert rows[-1][0] == entry.end_timestamp
+        key = f"row_count::{entry.symbol}::{entry.interval}"
+        metadata = manifest_storage.metadata()
+        assert metadata[key] == str(entry.candles)
+        last_key = f"last_timestamp::{entry.symbol}::{entry.interval}"
+        assert metadata[last_key] == str(entry.end_timestamp)


### PR DESCRIPTION
## Summary
- dodano offline'owy adapter giełdowy w `run_daily_trend.py`, aby tryb `--paper-smoke` korzystał wyłącznie z lokalnego cache i wyliczał zakres lookback na podstawie okna dat
- rozszerzono testy skryptu CLI o scenariusz smoke, weryfikując konfigurację adapterów, zakres backfillu i zegar offline
- zaktualizowano runbook oraz log audytu o instrukcje/artefakt pierwszego udanego smoke testu offline

## Testing
- pytest --override-ini=addopts= tests/test_run_daily_trend_script.py tests/test_pipeline_smoke_binance.py

------
https://chatgpt.com/codex/tasks/task_e_68daff44fa8c832a9c7049b9af610f1d