### PR TITLE
Dodaj raport pokrycia danych do smoke testu

### DIFF
--- a/bot_core/config/__init__.py
+++ b/bot_core/config/__init__.py
@@ -1,6 +1,12 @@
 """Warstwa konfiguracji aplikacji."""
 
 from bot_core.config.loader import load_core_config
+from bot_core.config.validation import (
+    ConfigValidationError,
+    ConfigValidationResult,
+    assert_core_config_valid,
+    validate_core_config,
+)
 from bot_core.config.models import (
     AlertAuditConfig,
     CoreConfig,
@@ -29,5 +35,9 @@ __all__ = [
     "TelegramChannelSettings",
     "WhatsAppChannelSettings",
     "AlertAuditConfig",
+    "ConfigValidationError",
+    "ConfigValidationResult",
+    "assert_core_config_valid",
+    "validate_core_config",
     "load_core_config",
 ]

--- a/bot_core/config/models.py
+++ b/bot_core/config/models.py
@@ -61,6 +61,8 @@ class EnvironmentConfig:
     alert_throttle: AlertThrottleConfig | None = None
     alert_audit: AlertAuditConfig | None = None
     decision_journal: DecisionJournalConfig | None = None
+    default_strategy: str | None = None
+    default_controller: str | None = None
 
 
 @dataclass(slots=True)
@@ -199,19 +201,61 @@ class ControllerRuntimeConfig:
 
 
 @dataclass(slots=True)
+class SmokeArchiveLocalConfig:
+    """Konfiguracja lokalnego magazynu archiwów smoke testów."""
+
+    directory: str
+    filename_pattern: str = "{environment}_{date}_{hash}.zip"
+    fsync: bool = False
+
+
+@dataclass(slots=True)
+class SmokeArchiveS3Config:
+    """Konfiguracja wysyłki archiwów smoke testu do S3/MinIO."""
+
+    bucket: str
+    object_prefix: str | None = None
+    endpoint_url: str | None = None
+    region: str | None = None
+    use_ssl: bool = True
+    extra_args: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class SmokeArchiveUploadConfig:
+    """Parametry wysyłki archiwum smoke testu po udanym przebiegu."""
+
+    backend: str
+    credential_secret: str | None = None
+    local: SmokeArchiveLocalConfig | None = None
+    s3: SmokeArchiveS3Config | None = None
+
+
+@dataclass(slots=True)
+class CoreReportingConfig:
+    """Konfiguracja sekcji reportingowej CoreConfig."""
+
+    daily_report_time_utc: str | None = None
+    weekly_report_day: str | None = None
+    retention_months: str | None = None
+    smoke_archive_upload: SmokeArchiveUploadConfig | None = None
+
+
+@dataclass(slots=True)
 class CoreConfig:
     """Najwyższego poziomu konfiguracja aplikacji."""
+
     environments: Mapping[str, EnvironmentConfig]
     risk_profiles: Mapping[str, RiskProfileConfig]
-    instrument_universes: Mapping[str, InstrumentUniverseConfig]
-    strategies: Mapping[str, DailyTrendMomentumStrategyConfig]
-    reporting: Mapping[str, str]
-    sms_providers: Mapping[str, SMSProviderSettings]
-    telegram_channels: Mapping[str, TelegramChannelSettings]
-    email_channels: Mapping[str, EmailChannelSettings]
-    signal_channels: Mapping[str, SignalChannelSettings]
-    whatsapp_channels: Mapping[str, WhatsAppChannelSettings]
-    messenger_channels: Mapping[str, MessengerChannelSettings]
+    instrument_universes: Mapping[str, InstrumentUniverseConfig] = field(default_factory=dict)
+    strategies: Mapping[str, DailyTrendMomentumStrategyConfig] = field(default_factory=dict)
+    reporting: CoreReportingConfig | None = None
+    sms_providers: Mapping[str, SMSProviderSettings] = field(default_factory=dict)
+    telegram_channels: Mapping[str, TelegramChannelSettings] = field(default_factory=dict)
+    email_channels: Mapping[str, EmailChannelSettings] = field(default_factory=dict)
+    signal_channels: Mapping[str, SignalChannelSettings] = field(default_factory=dict)
+    whatsapp_channels: Mapping[str, WhatsAppChannelSettings] = field(default_factory=dict)
+    messenger_channels: Mapping[str, MessengerChannelSettings] = field(default_factory=dict)
     runtime_controllers: Mapping[str, ControllerRuntimeConfig] = field(default_factory=dict)
 
 
@@ -229,7 +273,12 @@ __all__ = [
     "WhatsAppChannelSettings",
     "MessengerChannelSettings",
     "ControllerRuntimeConfig",
+    "SmokeArchiveLocalConfig",
+    "SmokeArchiveS3Config",
+    "SmokeArchiveUploadConfig",
+    "CoreReportingConfig",
     "CoreConfig",
     "AlertThrottleConfig",
     "AlertAuditConfig",
+    "DecisionJournalConfig",
 ]

--- a/bot_core/config/validation.py
+++ b/bot_core/config/validation.py
@@ -1,0 +1,423 @@
+"""Walidacja spójności konfiguracji CoreConfig."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+_INTERVAL_SUFFIX_TO_SECONDS: Mapping[str, int] = {
+    "m": 60,
+    "h": 60 * 60,
+    "d": 24 * 60 * 60,
+    "w": 7 * 24 * 60 * 60,
+    "M": 30 * 24 * 60 * 60,
+}
+
+
+def _interval_seconds(interval: str) -> int:
+    """Zwraca długość interwału w sekundach.
+
+    Akceptuje wartości w formacie ``<liczba><jednostka>``, gdzie jednostka należy do
+    zestawu {m, h, d, w, M}. Wielkość liter jest znacząca jedynie dla miesięcy
+    (``1M``). Przy błędnym formacie zgłaszamy :class:`ValueError`.
+    """
+
+    text = interval.strip()
+    if not text:
+        raise ValueError("interwał nie może być pusty")
+
+    number_part = []
+    suffix = None
+    for char in text:
+        if char.isdigit():
+            if suffix is not None:
+                raise ValueError(f"niepoprawny format interwału '{interval}'")
+            number_part.append(char)
+        else:
+            if suffix is not None:
+                raise ValueError(f"niepoprawny format interwału '{interval}'")
+            suffix = char
+
+    if not number_part or suffix is None:
+        raise ValueError(f"niepoprawny format interwału '{interval}'")
+
+    seconds_per_unit = _INTERVAL_SUFFIX_TO_SECONDS.get(suffix)
+    if seconds_per_unit is None:
+        raise ValueError(f"nieobsługiwany sufiks interwału '{suffix}'")
+
+    value = int("".join(number_part))
+    if value <= 0:
+        raise ValueError("interwał musi być dodatni")
+
+    return value * seconds_per_unit
+
+from bot_core.config.models import CoreConfig
+
+
+@dataclass(slots=True)
+class ConfigValidationResult:
+    """Wynik walidacji konfiguracji."""
+
+    errors: list[str]
+    warnings: list[str]
+
+    def is_valid(self) -> bool:
+        """Zwraca True, jeśli nie znaleziono błędów."""
+
+        return not self.errors
+
+
+class ConfigValidationError(RuntimeError):
+    """Wyjątek rzucany przy krytycznych błędach konfiguracji."""
+
+    def __init__(self, result: ConfigValidationResult):
+        self.result = result
+        message = "\n".join(result.errors)
+        super().__init__(message or "Nieznany błąd walidacji konfiguracji")
+
+
+def validate_core_config(config: CoreConfig) -> ConfigValidationResult:
+    """Waliduje spójność konfiguracji i zwraca listę błędów/ostrzeżeń."""
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    _validate_risk_profiles(config, errors, warnings)
+    _validate_strategies(config, errors, warnings)
+    _validate_runtime_controllers(config, errors, warnings)
+    _validate_instrument_universes(config, errors, warnings)
+    _validate_environments(config, errors, warnings)
+
+    return ConfigValidationResult(errors=errors, warnings=warnings)
+
+
+def assert_core_config_valid(config: CoreConfig) -> ConfigValidationResult:
+    """Waliduje konfigurację i rzuca wyjątek przy błędach."""
+
+    result = validate_core_config(config)
+    if result.errors:
+        raise ConfigValidationError(result)
+    return result
+
+
+def _validate_risk_profiles(
+    config: CoreConfig, errors: list[str], warnings: list[str]
+) -> None:
+    for name, profile in config.risk_profiles.items():
+        context = f"profil ryzyka '{name}'"
+        if profile.max_daily_loss_pct < 0:
+            errors.append(f"{context}: max_daily_loss_pct nie może być ujemne")
+        if profile.max_position_pct < 0:
+            errors.append(f"{context}: max_position_pct nie może być ujemne")
+        if profile.target_volatility < 0:
+            errors.append(f"{context}: target_volatility nie może być ujemne")
+        if profile.max_leverage < 0:
+            errors.append(f"{context}: max_leverage nie może być ujemne")
+        if profile.stop_loss_atr_multiple < 0:
+            errors.append(f"{context}: stop_loss_atr_multiple nie może być ujemne")
+        if profile.max_open_positions < 0:
+            errors.append(f"{context}: max_open_positions nie może być ujemne")
+        if profile.hard_drawdown_pct < 0:
+            errors.append(f"{context}: hard_drawdown_pct nie może być ujemne")
+
+        if name.lower() != profile.name.lower():
+            warnings.append(
+                f"profil ryzyka '{name}' ma nazwę '{profile.name}' – zalecana spójność"
+            )
+
+
+def _validate_strategies(
+    config: CoreConfig, errors: list[str], warnings: list[str]
+) -> None:
+    for name, strategy in config.strategies.items():
+        context = f"strategia '{name}'"
+        if strategy.fast_ma <= 0:
+            errors.append(f"{context}: fast_ma musi być dodatnie")
+        if strategy.slow_ma <= 0:
+            errors.append(f"{context}: slow_ma musi być dodatnie")
+        if strategy.fast_ma >= strategy.slow_ma:
+            errors.append(
+                f"{context}: fast_ma musi być mniejsze od slow_ma, otrzymano {strategy.fast_ma} >= {strategy.slow_ma}"
+            )
+        if strategy.breakout_lookback <= 0:
+            errors.append(f"{context}: breakout_lookback musi być dodatnie")
+        if strategy.momentum_window <= 0:
+            errors.append(f"{context}: momentum_window musi być dodatnie")
+        if strategy.atr_window <= 0:
+            errors.append(f"{context}: atr_window musi być dodatnie")
+        if strategy.atr_multiplier <= 0:
+            errors.append(f"{context}: atr_multiplier musi być dodatnie")
+        if strategy.min_trend_strength < 0:
+            warnings.append(
+                f"{context}: min_trend_strength ma wartość ujemną ({strategy.min_trend_strength})"
+            )
+        if strategy.min_momentum < 0:
+            warnings.append(
+                f"{context}: min_momentum ma wartość ujemną ({strategy.min_momentum})"
+            )
+
+
+def _validate_runtime_controllers(
+    config: CoreConfig, errors: list[str], warnings: list[str]
+) -> None:
+    for name, controller in config.runtime_controllers.items():
+        context = f"kontroler runtime '{name}'"
+        if controller.tick_seconds <= 0:
+            errors.append(f"{context}: tick_seconds musi być dodatnie")
+        interval = controller.interval.strip()
+        if not interval:
+            errors.append(f"{context}: interval nie może być pusty")
+            continue
+        try:
+            expected_seconds = _interval_seconds(interval)
+        except ValueError as exc:
+            errors.append(f"{context}: {exc}")
+            continue
+
+        delta = abs(controller.tick_seconds - expected_seconds)
+        tolerance = max(1.0, expected_seconds * 0.1)
+        if delta > tolerance:
+            warnings.append(
+                f"{context}: tick_seconds={controller.tick_seconds} znacząco różni się od interwału {interval} (~{expected_seconds}s)"
+            )
+
+
+def _validate_environments(
+    config: CoreConfig, errors: list[str], warnings: list[str]
+) -> None:
+    risk_profiles = set(config.risk_profiles)
+    universes = set(config.instrument_universes)
+    strategies = set(config.strategies)
+    controllers = set(config.runtime_controllers)
+
+    for name, environment in config.environments.items():
+        context = f"środowisko '{name}'"
+        if environment.risk_profile not in risk_profiles:
+            errors.append(
+                f"{context}: profil ryzyka '{environment.risk_profile}' nie istnieje w konfiguracji"
+            )
+
+        if environment.instrument_universe and environment.instrument_universe not in universes:
+            errors.append(
+                f"{context}: uniwersum instrumentów '{environment.instrument_universe}' nie istnieje"
+            )
+            continue
+
+        intervals_available: set[str] = set()
+        if environment.instrument_universe:
+            universe = config.instrument_universes[environment.instrument_universe]
+            exchange = environment.exchange
+            matching_instruments = [
+                instrument
+                for instrument in universe.instruments
+                if exchange in instrument.exchange_symbols
+            ]
+            if not matching_instruments:
+                errors.append(
+                    f"{context}: uniwersum instrumentów '{environment.instrument_universe}' nie zawiera powiązań dla giełdy '{exchange}'"
+                )
+            else:
+                intervals_available = {
+                    window.interval.strip().lower()
+                    for instrument in matching_instruments
+                    for window in instrument.backfill_windows
+                    if window.interval.strip()
+                }
+                if intervals_available and config.runtime_controllers:
+                    controller_intervals = {
+                        controller.interval.strip().lower()
+                        for controller in config.runtime_controllers.values()
+                        if controller.interval.strip()
+                    }
+                    if controller_intervals and not (
+                        intervals_available & controller_intervals
+                    ):
+                        warnings.append(
+                            f"{context}: brak wspólnego interwału między oknami backfill ({', '.join(sorted(intervals_available)) or 'brak'}) a kontrolerami runtime ({', '.join(sorted(controller_intervals))})"
+                        )
+
+        default_strategy = getattr(environment, "default_strategy", None)
+        if strategies:
+            if not default_strategy:
+                errors.append(
+                    f"{context}: default_strategy nie jest ustawione mimo zdefiniowanych strategii"
+                )
+            elif default_strategy not in strategies:
+                errors.append(
+                    f"{context}: domyślna strategia '{default_strategy}' nie istnieje w sekcji strategies"
+                )
+        elif default_strategy:
+            errors.append(
+                f"{context}: domyślna strategia '{default_strategy}' wskazana bez dostępnych strategii"
+            )
+
+        default_controller = getattr(environment, "default_controller", None)
+        default_controller_interval: str | None = None
+        if controllers:
+            if not default_controller:
+                errors.append(
+                    f"{context}: default_controller nie jest ustawione mimo zdefiniowanych kontrolerów runtime"
+                )
+            elif default_controller not in controllers:
+                errors.append(
+                    f"{context}: domyślny kontroler '{default_controller}' nie istnieje w sekcji runtime.controllers"
+                )
+            else:
+                controller_cfg = config.runtime_controllers[default_controller]
+                interval_text = controller_cfg.interval.strip()
+                if interval_text:
+                    default_controller_interval = interval_text.lower()
+        elif default_controller:
+            errors.append(
+                f"{context}: domyślny kontroler '{default_controller}' wskazany bez dostępnych kontrolerów runtime"
+            )
+
+        _validate_alert_channels(config, environment.alert_channels, context, errors)
+        _validate_permissions(environment.required_permissions, environment.forbidden_permissions, context, errors)
+
+        if (
+            default_controller
+            and default_controller_interval
+            and environment.instrument_universe
+            and intervals_available
+            and default_controller_interval not in intervals_available
+        ):
+            controller_cfg = config.runtime_controllers[default_controller]
+            errors.append(
+                f"{context}: domyślny kontroler '{default_controller}' używa interwału '{controller_cfg.interval}'"
+                f" niedostępnego w oknach backfill uniwersum '{environment.instrument_universe}' dla giełdy '{environment.exchange}'"
+            )
+
+
+def _validate_permissions(
+    required: Mapping | tuple | list | set,
+    forbidden: Mapping | tuple | list | set,
+    context: str,
+    errors: list[str],
+) -> None:
+    required_set = {str(value).lower() for value in required}
+    forbidden_set = {str(value).lower() for value in forbidden}
+    overlap = required_set & forbidden_set
+    if overlap:
+        overlap_list = ", ".join(sorted(overlap))
+        errors.append(
+            f"{context}: uprawnienia {overlap_list} nie mogą jednocześnie znajdować się w required i forbidden"
+        )
+
+
+def _validate_alert_channels(
+    config: CoreConfig, alert_channels: tuple[str, ...], context: str, errors: list[str]
+) -> None:
+    registry: Mapping[str, Mapping[str, object]] = {
+        "telegram": config.telegram_channels,
+        "email": config.email_channels,
+        "sms": config.sms_providers,
+        "signal": config.signal_channels,
+        "whatsapp": config.whatsapp_channels,
+        "messenger": config.messenger_channels,
+    }
+
+    for channel in alert_channels:
+        if ":" not in channel:
+            errors.append(f"{context}: kanał alertowy '{channel}' ma nieprawidłowy format")
+            continue
+        backend, key = channel.split(":", 1)
+        backend = backend.strip().lower()
+        key = key.strip()
+        if not backend or not key:
+            errors.append(f"{context}: kanał alertowy '{channel}' ma nieprawidłowy format")
+            continue
+        if backend not in registry:
+            errors.append(
+                f"{context}: kanał alertowy '{channel}' wskazuje nieobsługiwany typ '{backend}'"
+            )
+            continue
+        mapping = registry[backend]
+        if key not in mapping:
+            errors.append(
+                f"{context}: kanał alertowy '{channel}' nie istnieje w sekcji alerts"
+            )
+
+
+def _validate_instrument_universes(
+    config: CoreConfig, errors: list[str], warnings: list[str]
+) -> None:
+    known_exchanges = {env.exchange for env in config.environments.values()}
+
+    for name, universe in config.instrument_universes.items():
+        context = f"uniwersum instrumentów '{name}'"
+        if not universe.instruments:
+            errors.append(f"{context}: musi zawierać co najmniej jeden instrument")
+            continue
+
+        seen_instruments: set[str] = set()
+        for instrument in universe.instruments:
+            inst_context = f"{context}: instrument '{instrument.name}'"
+            if instrument.name in seen_instruments:
+                errors.append(
+                    f"{context}: instrument '{instrument.name}' został zdefiniowany wielokrotnie"
+                )
+            else:
+                seen_instruments.add(instrument.name)
+
+            if not instrument.base_asset or not instrument.quote_asset:
+                errors.append(
+                    f"{inst_context}: base_asset i quote_asset muszą być ustawione"
+                )
+
+            if not instrument.categories:
+                errors.append(
+                    f"{inst_context}: lista kategorii nie może być pusta"
+                )
+            elif len(set(cat.lower() for cat in instrument.categories)) != len(
+                instrument.categories
+            ):
+                warnings.append(
+                    f"{inst_context}: wykryto zduplikowane kategorie"
+                )
+
+            if not instrument.exchange_symbols:
+                errors.append(
+                    f"{inst_context}: musi mieć przypisane co najmniej jedno powiązanie giełdowe"
+                )
+            else:
+                for exchange, symbol in instrument.exchange_symbols.items():
+                    if not symbol:
+                        errors.append(
+                            f"{inst_context}: symbol dla giełdy '{exchange}' nie może być pusty"
+                        )
+                    if exchange not in known_exchanges:
+                        warnings.append(
+                            f"{inst_context}: giełda '{exchange}' nie jest zdefiniowana w sekcji environments"
+                        )
+
+            if not instrument.backfill_windows:
+                warnings.append(
+                    f"{inst_context}: brak zdefiniowanych okien backfill – pipeline nie pobierze danych"
+                )
+                continue
+
+            intervals_seen: set[str] = set()
+            for window in instrument.backfill_windows:
+                interval = window.interval.strip()
+                if not interval:
+                    errors.append(
+                        f"{inst_context}: interwał w sekcji backfill nie może być pusty"
+                    )
+                    continue
+                try:
+                    _interval_seconds(interval)
+                except ValueError as exc:
+                    errors.append(f"{inst_context}: {exc}")
+                    continue
+                if window.lookback_days <= 0:
+                    errors.append(
+                        f"{inst_context}: lookback_days dla interwału '{window.interval}' musi być dodatni"
+                    )
+                interval_key = interval.lower()
+                if interval_key in intervals_seen:
+                    warnings.append(
+                        f"{inst_context}: interwał '{window.interval}' zdefiniowano wielokrotnie"
+                    )
+                else:
+                    intervals_seen.add(interval_key)
+

--- a/bot_core/data/ohlcv/__init__.py
+++ b/bot_core/data/ohlcv/__init__.py
@@ -3,6 +3,11 @@
 from bot_core.data.ohlcv.audit import GapAuditLogger, GapAuditRecord, JSONLGapAuditLogger
 from bot_core.data.ohlcv.backfill import BackfillSummary, OHLCVBackfillService
 from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
+from bot_core.data.ohlcv.coverage_check import (
+    CoverageStatus,
+    evaluate_coverage,
+    summarize_issues,
+)
 from bot_core.data.ohlcv.gap_monitor import DataGapIncidentTracker, GapAlertPolicy
 from bot_core.data.ohlcv.manifest_report import (
     ManifestEntry,
@@ -20,6 +25,7 @@ __all__ = [
     "GapAuditRecord",
     "JSONLGapAuditLogger",
     "CachedOHLCVSource",
+    "CoverageStatus",
     "DataGapIncidentTracker",
     "GapAlertPolicy",
     "ManifestEntry",
@@ -27,8 +33,10 @@ __all__ = [
     "OHLCVRefreshScheduler",
     "ParquetCacheStorage",
     "PublicAPIDataSource",
+    "evaluate_coverage",
     "generate_manifest_report",
     "summarize_status",
+    "summarize_issues",
     "SQLiteCacheStorage",
     "DualCacheStorage",
 ]

--- a/bot_core/data/ohlcv/coverage_check.py
+++ b/bot_core/data/ohlcv/coverage_check.py
@@ -1,0 +1,135 @@
+"""Kontrola pokrycia danych OHLCV względem wymagań backfillu."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from math import ceil
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from bot_core.config.models import InstrumentBackfillWindow, InstrumentUniverseConfig
+from bot_core.data.ohlcv.manifest_report import ManifestEntry, generate_manifest_report
+
+
+@dataclass(slots=True)
+class CoverageStatus:
+    """Rezultat walidacji pojedynczego symbolu/interwału."""
+
+    symbol: str
+    interval: str
+    manifest_entry: ManifestEntry
+    required_rows: int | None
+    issues: Sequence[str]
+
+    @property
+    def status(self) -> str:
+        return "ok" if not self.issues else "error"
+
+
+def _interval_minutes(interval: str) -> int:
+    mapping = {
+        "1m": 1,
+        "3m": 3,
+        "5m": 5,
+        "15m": 15,
+        "30m": 30,
+        "1h": 60,
+        "2h": 120,
+        "4h": 240,
+        "6h": 360,
+        "8h": 480,
+        "12h": 720,
+        "1d": 1440,
+        "3d": 4320,
+        "1w": 10_080,
+        "1M": 43_200,
+    }
+    try:
+        return mapping[interval]
+    except KeyError as exc:  # pragma: no cover - format wejściowy waliduje konfiguracja
+        raise ValueError(f"Nieobsługiwany interwał: {interval}") from exc
+
+
+def _build_requirements(
+    universe: InstrumentUniverseConfig,
+    exchange_name: str,
+) -> Mapping[tuple[str, str], InstrumentBackfillWindow]:
+    requirements: dict[tuple[str, str], InstrumentBackfillWindow] = {}
+    for instrument in universe.instruments:
+        symbol = instrument.exchange_symbols.get(exchange_name)
+        if not symbol:
+            continue
+        for window in instrument.backfill_windows:
+            key = (symbol, window.interval)
+            existing = requirements.get(key)
+            if existing is None or window.lookback_days > existing.lookback_days:
+                requirements[key] = window
+    return requirements
+
+
+def evaluate_coverage(
+    *,
+    manifest_path: str | Path,
+    universe: InstrumentUniverseConfig,
+    exchange_name: str,
+    as_of: datetime | None = None,
+) -> Sequence[CoverageStatus]:
+    """Zwraca status pokrycia danych względem manifestu."""
+
+    as_of_dt = (as_of or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    manifest_entries = generate_manifest_report(
+        manifest_path=manifest_path,
+        universe=universe,
+        exchange_name=exchange_name,
+        as_of=as_of_dt,
+    )
+    requirements = _build_requirements(universe, exchange_name)
+
+    statuses: list[CoverageStatus] = []
+    for entry in manifest_entries:
+        window = requirements.get((entry.symbol, entry.interval))
+        required_rows: int | None = None
+        issues: list[str] = []
+
+        if entry.status != "ok":
+            issues.append(f"manifest_status:{entry.status}")
+
+        if window is not None:
+            try:
+                interval_minutes = _interval_minutes(entry.interval)
+                required_rows = ceil(window.lookback_days * 24 * 60 / interval_minutes)
+            except ValueError as exc:
+                issues.append(str(exc))
+            else:
+                row_count = entry.row_count
+                if row_count is None:
+                    issues.append("missing_row_count")
+                elif row_count < required_rows:
+                    issues.append(
+                        f"insufficient_rows:{row_count}<{required_rows}"
+                    )
+        statuses.append(
+            CoverageStatus(
+                symbol=entry.symbol,
+                interval=entry.interval,
+                manifest_entry=entry,
+                required_rows=required_rows,
+                issues=tuple(issues),
+            )
+        )
+    return statuses
+
+
+def summarize_issues(statuses: Iterable[CoverageStatus]) -> list[str]:
+    """Agreguje komunikaty o problemach w listę opisową."""
+
+    issues: list[str] = []
+    for status in statuses:
+        if not status.issues:
+            continue
+        for issue in status.issues:
+            issues.append(f"{status.symbol}/{status.interval}: {issue}")
+    return issues
+
+
+__all__ = ["CoverageStatus", "evaluate_coverage", "summarize_issues"]

--- a/bot_core/reporting/upload.py
+++ b/bot_core/reporting/upload.py
@@ -1,0 +1,205 @@
+"""Obsługa wysyłki archiwów smoke testu do bezpiecznego magazynu."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+from bot_core.config.models import (
+    CoreReportingConfig,
+    SmokeArchiveLocalConfig,
+    SmokeArchiveS3Config,
+    SmokeArchiveUploadConfig,
+)
+from bot_core.security import SecretManager, SecretStorageError
+
+
+@dataclass(slots=True)
+class SmokeArchiveUploadResult:
+    """Szczegóły udanego przesłania archiwum smoke testu."""
+
+    backend: str
+    location: str
+    metadata: Mapping[str, str]
+
+
+class SmokeArchiveUploader:
+    """Realizuje wysyłkę artefaktów smoke testu zgodnie z konfiguracją."""
+
+    def __init__(
+        self,
+        config: SmokeArchiveUploadConfig,
+        *,
+        secret_manager: SecretManager | None = None,
+    ) -> None:
+        self._config = config
+        self._secret_manager = secret_manager
+
+    def upload(
+        self,
+        archive_path: Path,
+        *,
+        environment: str,
+        summary_sha256: str,
+        window: Mapping[str, str],
+    ) -> SmokeArchiveUploadResult:
+        if not archive_path.exists():
+            raise FileNotFoundError(archive_path)
+
+        backend = self._config.backend.lower()
+        timestamp = datetime.now(timezone.utc)
+        placeholders = self._build_placeholders(
+            environment=environment,
+            summary_sha256=summary_sha256,
+            window=window,
+            timestamp=timestamp,
+        )
+
+        if backend == "local":
+            if self._config.local is None:
+                raise ValueError("Brak konfiguracji local dla backendu 'local'")
+            destination = self._upload_local(
+                archive_path,
+                local_cfg=self._config.local,
+                placeholders=placeholders,
+            )
+            return SmokeArchiveUploadResult(
+                backend="local",
+                location=str(destination),
+                metadata={"timestamp": timestamp.isoformat()},
+            )
+
+        if backend == "s3":
+            if self._config.s3 is None:
+                raise ValueError("Brak konfiguracji s3 dla backendu 's3'")
+            location = self._upload_s3(
+                archive_path,
+                s3_cfg=self._config.s3,
+                placeholders=placeholders,
+            )
+            return SmokeArchiveUploadResult(
+                backend="s3",
+                location=location,
+                metadata={"timestamp": timestamp.isoformat()},
+            )
+
+        raise ValueError(f"Nieobsługiwany backend wysyłki archiwum: {self._config.backend}")
+
+    @staticmethod
+    def resolve_config(reporting: CoreReportingConfig | object | None) -> SmokeArchiveUploadConfig | None:
+        """Zwraca konfigurację uploadu, jeśli została zdefiniowana w configu."""
+
+        if reporting is None:
+            return None
+        return getattr(reporting, "smoke_archive_upload", None)
+
+    @staticmethod
+    def _build_placeholders(
+        *,
+        environment: str,
+        summary_sha256: str,
+        window: Mapping[str, str],
+        timestamp: datetime,
+    ) -> MutableMapping[str, str]:
+        values: MutableMapping[str, str] = {
+            "environment": environment,
+            "hash": summary_sha256,
+            "timestamp": timestamp.strftime("%Y%m%dT%H%M%SZ"),
+            "date": timestamp.strftime("%Y-%m-%d"),
+            "start": str(window.get("start", "")),
+            "end": str(window.get("end", "")),
+        }
+        return values
+
+    @staticmethod
+    def _upload_local(
+        archive_path: Path,
+        *,
+        local_cfg: SmokeArchiveLocalConfig,
+        placeholders: Mapping[str, str],
+    ) -> Path:
+        destination_dir = Path(local_cfg.directory)
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        filename = local_cfg.filename_pattern.format(**placeholders)
+        target_path = destination_dir / filename
+        shutil.copy2(archive_path, target_path)
+        if local_cfg.fsync:
+            with target_path.open("rb+") as handle:  # pragma: no cover - zależne od platformy
+                handle.flush()
+                os.fsync(handle.fileno())
+        return target_path
+
+    def _upload_s3(
+        self,
+        archive_path: Path,
+        *,
+        s3_cfg: SmokeArchiveS3Config,
+        placeholders: Mapping[str, str],
+    ) -> str:
+        credentials = self._load_s3_credentials()
+
+        try:
+            import boto3
+        except ModuleNotFoundError as exc:  # pragma: no cover - zależne od środowiska
+            raise RuntimeError("Backend 's3' wymaga zainstalowanego pakietu boto3") from exc
+
+        object_key = self._build_object_key(s3_cfg, placeholders)
+        session = boto3.session.Session(
+            aws_access_key_id=credentials.get("access_key_id"),
+            aws_secret_access_key=credentials.get("secret_access_key"),
+            aws_session_token=credentials.get("session_token"),
+            region_name=s3_cfg.region,
+        )
+        client = session.client(
+            "s3",
+            endpoint_url=s3_cfg.endpoint_url,
+            use_ssl=s3_cfg.use_ssl,
+        )
+        extra_args = dict(s3_cfg.extra_args)
+        client.upload_file(str(archive_path), s3_cfg.bucket, object_key, ExtraArgs=extra_args)
+        location = f"s3://{s3_cfg.bucket}/{object_key}"
+        return location
+
+    def _load_s3_credentials(self) -> Mapping[str, str]:
+        if not self._config.credential_secret:
+            raise SecretStorageError(
+                "Konfiguracja backendu 's3' wymaga podania credential_secret z kluczami dostępowymi"
+            )
+        if self._secret_manager is None:
+            raise SecretStorageError("Brak dostępu do SecretManager przy backendzie 's3'")
+
+        raw_value = self._secret_manager.load_secret_value(self._config.credential_secret)
+        try:
+            payload = json.loads(raw_value)
+        except json.JSONDecodeError as exc:
+            raise SecretStorageError("Sekret S3 ma nieprawidłowy format JSON") from exc
+
+        expected_keys = {"access_key_id", "secret_access_key"}
+        missing = sorted(key for key in expected_keys if key not in payload)
+        if missing:
+            raise SecretStorageError(
+                "Sekret S3 nie zawiera wymaganych pól: " + ", ".join(missing)
+            )
+        return {str(key): str(value) for key, value in payload.items()}
+
+    @staticmethod
+    def _build_object_key(
+        config: SmokeArchiveS3Config,
+        placeholders: Mapping[str, str],
+    ) -> str:
+        filename = "{environment}_{timestamp}_{hash}.zip".format(**placeholders)
+        if config.object_prefix:
+            prefix = config.object_prefix.rstrip("/")
+            return f"{prefix}/{filename}"
+        return filename
+
+
+__all__ = [
+    "SmokeArchiveUploader",
+    "SmokeArchiveUploadResult",
+]
+

--- a/bot_core/risk/base.py
+++ b/bot_core/risk/base.py
@@ -86,6 +86,16 @@ class RiskEngine(abc.ABC):
     def should_liquidate(self, *, profile_name: str) -> bool:
         ...
 
+    def snapshot_state(self, profile_name: str) -> Mapping[str, object] | None:
+        """Zwraca bieżący stan profilu ryzyka do celów raportowych.
+
+        Domyślna implementacja pozostawia metodę niezaimplementowaną –
+        konkretne silniki powinny ją nadpisać, jeśli udostępniają możliwość
+        inspekcji stanu w trybie tylko do odczytu.
+        """
+
+        raise NotImplementedError
+
 
 class RiskRepository(Protocol):
     """Kontrakt dla repozytoriów stanu ryzyka (np. SQLite, Parquet)."""

--- a/bot_core/runtime/bootstrap.py
+++ b/bot_core/runtime/bootstrap.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
@@ -35,6 +36,7 @@ from bot_core.config.models import (
     TelegramChannelSettings,
     WhatsAppChannelSettings,
 )
+from bot_core.config.validation import assert_core_config_valid
 from bot_core.exchanges.base import (
     Environment,
     ExchangeAdapter,
@@ -73,6 +75,9 @@ _PROFILE_CLASS_BY_NAME: Mapping[str, type[RiskProfile]] = {
 }
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 @dataclass(slots=True)
 class BootstrapContext:
     """Zawiera wszystkie komponenty zainicjalizowane dla danego środowiska."""
@@ -99,6 +104,9 @@ def bootstrap_environment(
 ) -> BootstrapContext:
     """Tworzy kompletny kontekst uruchomieniowy dla wskazanego środowiska."""
     core_config = load_core_config(config_path)
+    validation = assert_core_config_valid(core_config)
+    for warning in validation.warnings:
+        _LOGGER.warning("Walidacja konfiguracji: %s", warning)
     if environment_name not in core_config.environments:
         raise KeyError(f"Środowisko '{environment_name}' nie istnieje w konfiguracji")
 

--- a/config/core.yaml
+++ b/config/core.yaml
@@ -250,6 +250,8 @@ environments:
     credential_purpose: trading
     data_cache_path: ./var/data/binance_paper
     risk_profile: balanced
+    default_strategy: core_daily_trend
+    default_controller: daily_trend_core
     alert_channels: ["telegram:primary", "email:ops"]
     ip_allowlist: []
     required_permissions: [read, trade]
@@ -291,6 +293,8 @@ environments:
     keychain_key: binance_live_trading
     data_cache_path: ./var/data/binance_live
     risk_profile: conservative
+    default_strategy: core_daily_trend
+    default_controller: daily_trend_core
     alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
     ip_allowlist: []
     required_permissions: [read, trade]
@@ -320,6 +324,8 @@ environments:
     keychain_key: binance_futures_paper_trading
     data_cache_path: ./var/data/binance_futures_paper
     risk_profile: balanced
+    default_strategy: core_daily_trend
+    default_controller: daily_trend_core
     alert_channels: ["telegram:primary", "email:ops"]
     ip_allowlist: []
     required_permissions: [read, trade]
@@ -349,6 +355,8 @@ environments:
     keychain_key: binance_futures_live_trading
     data_cache_path: ./var/data/binance_futures_live
     risk_profile: conservative
+    default_strategy: core_daily_trend
+    default_controller: daily_trend_core
     alert_channels: ["telegram:primary", "sms:orange_local", "email:ops"]
     ip_allowlist: []
     required_permissions: [read, trade]
@@ -560,6 +568,12 @@ reporting:
   daily_report_time_utc: "21:00"
   weekly_report_day: "sunday"
   retention_months: "24"
+  smoke_archive_upload:
+    backend: local
+    local:
+      directory: audit/smoke_archives
+      filename_pattern: "{environment}_{timestamp}_{hash}.zip"
+      fsync: true
 
 alerts:
   telegram_channels:

--- a/docs/audit/paper_trading_log.md
+++ b/docs/audit/paper_trading_log.md
@@ -16,7 +16,8 @@ Dokument stanowi append-only rejestr zdarzeń operacyjnych związanych z trybem 
 | ID | Data (UTC) | Operator | Środowisko | Zakres dat | Raport (`summary.json`) | Hash SHA-256 | Status alertów | Uwagi |
 |----|------------|----------|------------|------------|-------------------------|--------------|----------------|-------|
 | S-TEST-0001 | YYYY-MM-DDThh:mm:ssZ | imię nazwisko | binance_paper | 2024-01-01 → 2024-02-15 | `/tmp/daily_trend_smoke_xxx/summary.json` | `<hash>` | OK | „Smoke test sanity” |
-
+ | S-0001 | 2025-09-30T16:53:03Z | CI Agent | binance_paper | 2024-01-01 → 2024-02-15 | `n/a` | `n/a` | ERROR (403 Binance API) | Smoke test przerwany – brak dostępu do API Binance (403 Forbidden) |
+| S-0002 | 2025-09-30T17:19:30Z | CI Agent | binance_paper | 2024-01-01 → 2024-02-15 | `/tmp/daily_trend_smoke_jk_rha7g/summary.json` | `c694ac951e24fb214fe8b454b4abb9582d94f59e25ed05f697035d2bff713f87` | WARN (alert channels) | Smoke test ukończony na cache offline; wysyłka alertów nieudana (403 Telegram, DNS e-mail). |
 ## Sekcja C – Incydenty i alerty krytyczne
 | ID | Data (UTC) | Operator | Kod alertu | Opis | Działanie naprawcze | Status |
 |----|------------|----------|------------|------|---------------------|--------|
@@ -33,3 +34,5 @@ Dokument stanowi append-only rejestr zdarzeń operacyjnych związanych z trybem 
 | C-0001 | YYYY-MM-DDThh:mm:ssZ | imię nazwisko | `strategies.daily_trend.momentum.window_fast` | 20 | 30 | „Optymalizacja walk-forward” |
 
 > **Instrukcja aktualizacji:** dodawaj nowe wiersze na końcu każdej sekcji, zachowując rosnącą numerację ID. Nie modyfikuj historycznych wpisów – w razie pomyłki dodaj nowy wiersz korygujący z referencją do oryginalnego ID.
+> Dla smoke testów kopiuj zarówno hash `summary.json`, jak i treść pliku `summary.txt` (skrót można dodać w kolumnie „Uwagi”). Jeśli skrypt utworzył archiwum ZIP (`--archive-smoke`), dopisz ścieżkę pliku w kolumnie „Uwagi” i zabezpiecz archiwum w sejfie audytu. W razie wykonywania weryfikacji `scripts/check_data_coverage.py` dopisz status (`ok` / `error`) do kolumny „Uwagi”.
+> Gdy konfiguracja `reporting.smoke_archive_upload` wykona dodatkowy upload (np. do `audit/smoke_archives/` lub koszyka S3), dopisz docelową lokalizację z pola alertu `archive_upload_location` – ułatwi to odtworzenie pakietu podczas audytu.

--- a/docs/runbooks/paper_trading.md
+++ b/docs/runbooks/paper_trading.md
@@ -8,6 +8,7 @@ Ten runbook opisuje, jak uruchomić, monitorować i bezpiecznie zatrzymać tryb 
 - System operacyjny: Windows 10/11 (primary) lub macOS 13+ (fallback). W obu przypadkach wymagany jest Python 3.11 oraz dostęp do Windows Credential Manager / macOS Keychain.
 - Repozytorium `Dudzian` w wersji zgodnej z `phase1_foundation` (aktualne testy `pytest` przechodzą bez błędów).
 - Pliki konfiguracyjne `config/core.yaml` oraz `config/credentials/` dopasowane do środowiska `paper`.
+- Każde środowisko w `config/core.yaml` ma ustawione pola `default_strategy` i `default_controller`, aby CLI automatycznie wybierało właściwą strategię i kontroler runtime.
 - Katalog roboczy danych: `data/ohlcv` (Parquet + manifest SQLite) oraz `data/reports` na raporty dzienne.
 
 ### Klucze API i bezpieczeństwo
@@ -20,15 +21,18 @@ Ten runbook opisuje, jak uruchomić, monitorować i bezpiecznie zatrzymać tryb 
 - Wykonany backfill OHLCV (D1 + 1h) dla koszyka: BTC/USDT, ETH/USDT, SOL/USDT, BNB/USDT, XRP/USDT, ADA/USDT, LTC/USDT, MATIC/USDT.
 - Dane zapisane w strukturze partycjonowanej Parquet: `exchange/symbol/granularity/year=YYYY/month=MM/`.
 - Manifest SQLite (`ohlcv_manifest.sqlite`) zawiera zaktualizowane liczniki świec i ostatnie znaczniki czasu.
+- **Tryb offline (brak dostępu do API):** uruchom `PYTHONPATH=. python scripts/seed_paper_cache.py --environment binance_paper --days 60 --start-date 2024-01-01`, aby wygenerować deterministyczny cache D1 w katalogu `var/data/binance_paper`.
 
 ## 2. Checklista przed startem sesji
 1. **Weryfikacja kodu i konfiguracji**
    - `git status` – brak lokalnych, niezatwierdzonych zmian.
+   - `python scripts/validate_config.py --config config/core.yaml` – potwierdzenie spójności sekcji środowisk, profili ryzyka i kanałów alertowych.
    - `pytest --override-ini=addopts= tests/test_runtime_pipeline.py` – potwierdzenie, że pipeline przechodzi testy integracyjne.
    - `scripts/check_key_rotation.py --dry-run` – upewnij się, że rotacja kluczy nie jest przeterminowana.
 2. **Aktualizacja danych**
    - Uruchom `scripts/backfill.py --environment paper --granularity 1d --since 2016-01-01`.
    - Sprawdź logi (`logs/backfill.log`) pod kątem błędów; w razie limitów API powtórz z większym interwałem throttlingu.
+   - Zweryfikuj pokrycie cache: `PYTHONPATH=. python scripts/check_data_coverage.py --config config/core.yaml --environment binance_paper --json`. Status `ok` oznacza komplet danych wymaganych przez backfill.
 3. **Konfiguracja środowiska**
    - Plik `config/core.yaml` ma aktywne środowisko `paper_binance` i profil ryzyka `balanced` (domyślny).
    - `config/alerts.yaml` (jeśli używany) zawiera aktywne kanały Telegram + e-mail + SMS (Orange jako operator referencyjny).
@@ -42,17 +46,23 @@ Ten runbook opisuje, jak uruchomić, monitorować i bezpiecznie zatrzymać tryb 
 ## 3. Uruchomienie pipeline’u paper trading
 1. Aktywuj wirtualne środowisko Pythona: `py -3.11 -m venv .venv && .venv\Scripts\activate` (Windows) lub `python3 -m venv .venv && source .venv/bin/activate` (macOS).
 2. Zainstaluj zależności: `pip install -e .[dev]` (pierwsze uruchomienie) lub `pip install -e .` dla aktualizacji.
-3. Wykonaj smoke test środowiska paper (sprawdzenie backfillu + egzekucji na krótkim oknie):
+3. Jeśli łączność z API Binance jest ograniczona, w pierwszej kolejności odtwórz cache poleceniem `PYTHONPATH=. python scripts/seed_paper_cache.py --environment binance_paper --days 60 --start-date 2024-01-01`. Następnie wykonaj smoke test środowiska paper (sprawdzenie backfillu + egzekucji na krótkim oknie):
    ```bash
    PYTHONPATH=. python scripts/run_daily_trend.py \
        --config config/core.yaml \
        --environment binance_paper \
        --paper-smoke \
+       --archive-smoke \
        --date-window 2024-01-01:2024-02-15 \
        --run-once
    ```
-   - Narzędzie wykona backfill ograniczony do podanego zakresu, uruchomi pojedynczą iterację i zapisze raport tymczasowy (`ledger.jsonl` + `summary.json`).
-   - Ścieżka katalogu raportu pojawi się w logu – zanotuj hash `summary.json` w logu audytu (sekcja „Smoke test”).
+   - Narzędzie wykona backfill ograniczony do podanego zakresu, uruchomi pojedynczą iterację i zapisze raport tymczasowy (`ledger.jsonl`, `summary.json`, `summary.txt`, `README.txt`).
+    - `summary.txt` zawiera gotowe podsumowanie dla zespołu ryzyka (środowisko, okno dat, liczba zleceń, status kanałów alertowych, hash `summary.json`).
+    - `README.txt` zawiera skróconą instrukcję audytu (co przepisać do logu, gdzie przechowywać ledger, jak długo archiwizować paczkę).
+    - W trybie `--paper-smoke` skrypt podmienia adapter giełdowy na tryb offline i korzysta wyłącznie z lokalnego cache Parquet/SQLite, dlatego przed uruchomieniem wymagany jest kompletny seed danych z kroku wcześniejszego oraz pozytywna weryfikacja `scripts/check_data_coverage.py`.
+    - Jeżeli w keychainie znajdują się placeholderowe tokeny kanałów alertowych, komunikaty o błędach (403/DNS) zostaną zarejestrowane w logu, ale nie przerywają smoke testu; status kanałów należy odnotować w audycie.
+   - Użycie flagi `--archive-smoke` tworzy dodatkowo archiwum ZIP z kompletem plików i instrukcją audytu. Ścieżka katalogu raportu i hash `summary.json` pojawią się w logu. Skopiuj hash, treść `summary.txt` oraz status kanałów alertowych do `docs/audit/paper_trading_log.md`. Archiwum ZIP przechowuj w sejfie audytu (retencja ≥ 24 miesiące).
+   - Jeśli w `config/core.yaml` skonfigurowano sekcję `reporting.smoke_archive_upload`, CLI automatycznie wykona kopię archiwum (domyślnie do `audit/smoke_archives/`) oraz – w przypadku backendu S3/MinIO – prześle plik do zdefiniowanego koszyka. Ścieżka docelowa trafia do logu oraz kontekstu alertu w polach `archive_upload_backend` i `archive_upload_location`. Zweryfikuj obecność pliku w magazynie i odnotuj lokalizację w audycie.
 4. Uruchom tryb jednorazowy (dry-run) w celu sanity check konfiguracji:
    ```bash
    PYTHONPATH=. python scripts/run_daily_trend.py --config config/core.yaml --environment binance_paper --dry-run

--- a/scripts/check_data_coverage.py
+++ b/scripts/check_data_coverage.py
@@ -1,0 +1,128 @@
+"""CLI do weryfikacji pokrycia danych OHLCV względem wymagań backfillu."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+from bot_core.config import load_core_config
+from bot_core.data.ohlcv import CoverageStatus, evaluate_coverage, summarize_issues
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sprawdza manifest danych OHLCV dla środowiska paper/testnet.",
+    )
+    parser.add_argument("--config", default="config/core.yaml", help="Ścieżka do CoreConfig")
+    parser.add_argument(
+        "--environment",
+        required=True,
+        help="Nazwa środowiska z sekcji environments",
+    )
+    parser.add_argument(
+        "--as-of",
+        default=None,
+        help="Znacznik czasu ISO8601 używany do oceny opóźnień danych (domyślnie teraz, UTC)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Zwróć wynik w formacie JSON (łatwy do integracji z CI)",
+    )
+    return parser.parse_args(argv)
+
+
+def _parse_as_of(arg: str | None) -> datetime:
+    if not arg:
+        return datetime.now(timezone.utc)
+    dt = datetime.fromisoformat(arg)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _format_status(status: CoverageStatus) -> dict[str, object]:
+    entry = status.manifest_entry
+    return {
+        "symbol": status.symbol,
+        "interval": status.interval,
+        "status": status.status,
+        "manifest_status": entry.status,
+        "row_count": entry.row_count,
+        "required_rows": status.required_rows,
+        "last_timestamp_iso": entry.last_timestamp_iso,
+        "gap_minutes": entry.gap_minutes,
+        "issues": list(status.issues),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    config = load_core_config(Path(args.config))
+
+    environment = config.environments.get(args.environment)
+    if environment is None:
+        print(f"Nie znaleziono środowiska: {args.environment}", file=sys.stderr)
+        return 2
+
+    if not environment.instrument_universe:
+        print(
+            f"Środowisko {environment.name} nie ma przypisanego instrument_universe", file=sys.stderr
+        )
+        return 2
+
+    universe = config.instrument_universes.get(environment.instrument_universe)
+    if universe is None:
+        print(
+            f"Brak definicji uniwersum instrumentów: {environment.instrument_universe}",
+            file=sys.stderr,
+        )
+        return 2
+
+    as_of = _parse_as_of(args.as_of)
+    manifest_path = Path(environment.data_cache_path) / "ohlcv_manifest.sqlite"
+    statuses = evaluate_coverage(
+        manifest_path=manifest_path,
+        universe=universe,
+        exchange_name=environment.exchange,
+        as_of=as_of,
+    )
+
+    issues = summarize_issues(statuses)
+    payload = {
+        "environment": environment.name,
+        "exchange": environment.exchange,
+        "manifest_path": str(manifest_path),
+        "as_of": as_of.isoformat(),
+        "entries": [_format_status(status) for status in statuses],
+        "issues": issues,
+        "status": "ok" if not issues else "error",
+    }
+
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(f"Manifest: {payload['manifest_path']}")
+        print(f"Środowisko: {payload['environment']} ({payload['exchange']})")
+        print(f"Ocena na: {payload['as_of']}")
+        for entry in payload["entries"]:
+            print(
+                " - {symbol} {interval}: status={status} row_count={row_count} required={required_rows} gap={gap_minutes}".format(
+                    **entry
+                )
+            )
+        if issues:
+            print("Problemy:")
+            for issue in issues:
+                print(f" * {issue}")
+        else:
+            print("Brak problemów z pokryciem danych")
+
+    return 0 if not issues else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - wejście CLI
+    raise SystemExit(main())

--- a/scripts/run_daily_trend.py
+++ b/scripts/run_daily_trend.py
@@ -3,17 +3,29 @@ from __future__ import annotations
 
 import argparse
 import json
+import hashlib
+import os
 import logging
 import signal
 import sys
+import shutil
 import tempfile
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
 from bot_core.alerts import AlertMessage
-from bot_core.exchanges.base import Environment, OrderResult
+from bot_core.exchanges.base import (
+    AccountSnapshot,
+    Environment,
+    ExchangeAdapter,
+    ExchangeAdapterFactory,
+    ExchangeCredentials,
+    OrderResult,
+)
+from bot_core.reporting.upload import SmokeArchiveUploader
+from bot_core.data.ohlcv import evaluate_coverage
 from bot_core.runtime.pipeline import build_daily_trend_pipeline, create_trading_controller
 from bot_core.runtime.realtime import DailyTrendRealtimeRunner
 from bot_core.security import SecretManager, SecretStorageError, create_default_secret_storage
@@ -33,13 +45,13 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--strategy",
-        default="core_daily_trend",
-        help="Nazwa strategii z sekcji strategies w configu",
+        default=None,
+        help="Nazwa strategii z sekcji strategies (domyślnie pobierana z konfiguracji środowiska)",
     )
     parser.add_argument(
         "--controller",
-        default="daily_trend_core",
-        help="Nazwa kontrolera runtime z sekcji runtime.controllers",
+        default=None,
+        help="Nazwa kontrolera runtime (domyślnie pobierana z konfiguracji środowiska)",
     )
     parser.add_argument(
         "--history-bars",
@@ -89,6 +101,11 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         "--paper-smoke",
         action="store_true",
         help="Uruchom test dymny strategii paper trading (backfill + pojedyncza iteracja)",
+    )
+    parser.add_argument(
+        "--archive-smoke",
+        action="store_true",
+        help="Po zakończeniu smoke testu spakuj raport do archiwum ZIP z instrukcją audytu",
     )
     parser.add_argument(
         "--date-window",
@@ -167,6 +184,113 @@ def _resolve_date_window(arg: str | None, *, default_days: int = 30) -> tuple[in
     }
 
 
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _as_float(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_int(value: object) -> int | None:
+    float_value = _as_float(value)
+    if float_value is None:
+        return None
+    try:
+        return int(float_value)
+    except (TypeError, ValueError):  # pragma: no cover - ostrożność przy dziwnych typach
+        return None
+
+
+def _format_money(value: float, *, decimals: int = 2) -> str:
+    formatted = f"{value:,.{decimals}f}"
+    return formatted.replace(",", " ")
+
+
+def _format_percentage(value: float | None, *, decimals: int = 2) -> str:
+    if value is None:
+        return "n/d"
+    return f"{value * 100:.{decimals}f}%"
+
+
+def _compute_ledger_metrics(ledger_entries: Sequence[Mapping[str, object]]) -> Mapping[str, object]:
+    counts: MutableMapping[str, int] = {"buy": 0, "sell": 0}
+    other_counts: MutableMapping[str, int] = {}
+    notionals: MutableMapping[str, float] = {"buy": 0.0, "sell": 0.0}
+    other_notionals: MutableMapping[str, float] = {}
+    total_fees = 0.0
+    last_position_value: float | None = None
+
+    for entry in ledger_entries:
+        if not isinstance(entry, Mapping):
+            continue
+
+        side = str(entry.get("side", "")).lower()
+        quantity = _as_float(entry.get("quantity")) or 0.0
+        price = _as_float(entry.get("price")) or 0.0
+        notional_value = abs(quantity) * max(price, 0.0)
+
+        if side in ("buy", "sell"):
+            counts[side] += 1
+            notionals[side] += notional_value
+        else:
+            side_key = side or "unknown"
+            other_counts[side_key] = other_counts.get(side_key, 0) + 1
+            other_notionals[side_key] = other_notionals.get(side_key, 0.0) + notional_value
+
+        fee_value = _as_float(entry.get("fee"))
+        if fee_value is not None:
+            total_fees += fee_value
+
+        position_value = _as_float(entry.get("position_value"))
+        if position_value is not None:
+            last_position_value = position_value
+
+    total_notional = sum(notionals.values()) + sum(other_notionals.values())
+
+    side_counts: MutableMapping[str, int] = {
+        "buy": counts.get("buy", 0),
+        "sell": counts.get("sell", 0),
+    }
+    for key, value in other_counts.items():
+        if value:
+            side_counts[key] = value
+
+    notional_payload: MutableMapping[str, float] = {
+        "buy": notionals.get("buy", 0.0),
+        "sell": notionals.get("sell", 0.0),
+    }
+    for key, value in other_notionals.items():
+        if value:
+            notional_payload[key] = value
+    notional_payload["total"] = total_notional
+
+    metrics: dict[str, object] = {
+        "side_counts": dict(side_counts),
+        "notional": dict(notional_payload),
+        "total_fees": total_fees,
+    }
+    if last_position_value is not None:
+        metrics["last_position_value"] = last_position_value
+    return metrics
+
+
 def _export_smoke_report(
     *,
     report_dir: Path,
@@ -175,6 +299,8 @@ def _export_smoke_report(
     window: Mapping[str, str],
     environment: str,
     alert_snapshot: Mapping[str, Mapping[str, str]],
+    risk_state: Mapping[str, object] | None,
+    data_checks: Mapping[str, object] | None = None,
 ) -> Path:
     report_dir.mkdir(parents=True, exist_ok=True)
     ledger_entries = list(ledger)
@@ -184,7 +310,9 @@ def _export_smoke_report(
             json.dump(entry, handle, ensure_ascii=False)
             handle.write("\n")
 
-    summary = {
+    metrics = _compute_ledger_metrics(ledger_entries)
+
+    summary: dict[str, object] = {
         "environment": environment,
         "window": dict(window),
         "orders": [
@@ -197,12 +325,578 @@ def _export_smoke_report(
             for result in results
         ],
         "ledger_entries": len(ledger_entries),
+        "metrics": metrics,
         "alert_snapshot": {channel: dict(data) for channel, data in alert_snapshot.items()},
     }
+
+    if risk_state:
+        summary["risk_state"] = dict(risk_state)
+
+    if data_checks:
+        summary["data_checks"] = json.loads(json.dumps(data_checks))
 
     summary_path = report_dir / "summary.json"
     summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return summary_path
+
+
+def _write_smoke_readme(report_dir: Path) -> Path:
+    readme_path = report_dir / "README.txt"
+    readme_text = (
+        "Daily Trend – smoke test paper trading\n"
+        "======================================\n\n"
+        "Ten katalog zawiera artefakty pojedynczego uruchomienia trybu --paper-smoke.\n"
+        "Na potrzeby audytu:"
+    )
+    readme_text += (
+        "\n\n"
+        "1. Zweryfikuj hash SHA-256 pliku summary.json zapisany w logu CLI oraz w alertach.\n"
+        "2. Przepisz treść summary.txt do dziennika audytowego (docs/audit/paper_trading_log.md).\n"
+        "3. Zabezpiecz ledger.jsonl (pełna historia decyzji) w repozytorium operacyjnym.\n"
+        "4. Zarchiwizowany plik ZIP można przechowywać w sejfie audytu przez min. 24 miesiące.\n"
+    )
+    readme_path.write_text(readme_text + "\n", encoding="utf-8")
+    return readme_path
+
+
+def _archive_smoke_report(report_dir: Path) -> Path:
+    archive_path_str = shutil.make_archive(str(report_dir), "zip", root_dir=report_dir)
+    return Path(archive_path_str)
+
+
+def _render_smoke_summary(*, summary: Mapping[str, object], summary_sha256: str) -> str:
+    environment = str(summary.get("environment", "unknown"))
+    window = summary.get("window", {})
+    if isinstance(window, Mapping):
+        start = str(window.get("start", "?"))
+        end = str(window.get("end", "?"))
+    else:  # pragma: no cover - obrona przed błędną strukturą
+        start = end = "?"
+
+    orders = summary.get("orders", [])
+    orders_count = len(orders) if isinstance(orders, Sequence) else 0
+    ledger_entries = summary.get("ledger_entries", 0)
+    try:
+        ledger_entries = int(ledger_entries)
+    except Exception:  # noqa: BLE001, pragma: no cover - fallback
+        ledger_entries = 0
+
+    alert_snapshot = summary.get("alert_snapshot", {})
+    alert_lines: list[str] = []
+    if isinstance(alert_snapshot, Mapping):
+        for channel, data in alert_snapshot.items():
+            status = "unknown"
+            detail: str | None = None
+            if isinstance(data, Mapping):
+                raw_status = data.get("status")
+                if raw_status is not None:
+                    status = str(raw_status).upper()
+                raw_detail = data.get("detail")
+                if raw_detail:
+                    detail = str(raw_detail)
+            channel_name = str(channel)
+            if detail:
+                alert_lines.append(f"{channel_name}: {status} ({detail})")
+            else:
+                alert_lines.append(f"{channel_name}: {status}")
+
+    if not alert_lines:
+        alert_lines.append("brak danych o kanałach alertów")
+
+    metrics_lines: list[str] = []
+    metrics = summary.get("metrics")
+    if isinstance(metrics, Mapping):
+        side_counts = metrics.get("side_counts")
+        if isinstance(side_counts, Mapping):
+            buy_count = _as_int(side_counts.get("buy")) or 0
+            sell_count = _as_int(side_counts.get("sell")) or 0
+            if buy_count or sell_count:
+                metrics_lines.append(f"Zlecenia BUY/SELL: {buy_count}/{sell_count}")
+            other_sides = [
+                f"{str(name).upper()}: {_as_int(value) or 0}"
+                for name, value in side_counts.items()
+                if str(name).lower() not in {"buy", "sell"}
+            ]
+            if other_sides:
+                metrics_lines.append("Inne strony: " + ", ".join(other_sides))
+
+        notionals = metrics.get("notional")
+        if isinstance(notionals, Mapping) and notionals:
+            buy_notional = _as_float(notionals.get("buy")) or 0.0
+            sell_notional = _as_float(notionals.get("sell")) or 0.0
+            total_notional = _as_float(notionals.get("total")) or (buy_notional + sell_notional)
+            metrics_lines.append(
+                "Wolumen BUY: {buy} | SELL: {sell} | Razem: {total}".format(
+                    buy=_format_money(buy_notional),
+                    sell=_format_money(sell_notional),
+                    total=_format_money(total_notional),
+                )
+            )
+            other_notional_lines = [
+                f"{str(name).upper()}: {_format_money(_as_float(value) or 0.0)}"
+                for name, value in notionals.items()
+                if str(name).lower() not in {"buy", "sell", "total"}
+            ]
+            if other_notional_lines:
+                metrics_lines.append("Wolumen inne: " + "; ".join(other_notional_lines))
+
+        total_fees = _as_float(metrics.get("total_fees"))
+        if total_fees is not None:
+            metrics_lines.append(f"Łączne opłaty: {_format_money(total_fees, decimals=4)}")
+
+        last_position = _as_float(metrics.get("last_position_value"))
+        if last_position is not None:
+            metrics_lines.append(
+                f"Ostatnia wartość pozycji: {_format_money(last_position)}"
+            )
+
+    risk_lines: list[str] = []
+    risk_state = summary.get("risk_state")
+    if isinstance(risk_state, Mapping) and risk_state:
+        profile_name = str(risk_state.get("profile", "unknown"))
+        risk_lines.append(f"Profil ryzyka: {profile_name}")
+
+        active_positions = _as_int(risk_state.get("active_positions")) or 0
+        gross_notional = _as_float(risk_state.get("gross_notional"))
+        exposure_line = f"Aktywne pozycje: {active_positions}"
+        if gross_notional is not None:
+            exposure_line += f" | Ekspozycja brutto: {_format_money(gross_notional)}"
+        risk_lines.append(exposure_line)
+
+        daily_loss_pct = _as_float(risk_state.get("daily_loss_pct"))
+        drawdown_pct = _as_float(risk_state.get("drawdown_pct"))
+        risk_lines.append(
+            "Dzienna strata: {loss} | Obsunięcie: {dd}".format(
+                loss=_format_percentage(daily_loss_pct),
+                dd=_format_percentage(drawdown_pct),
+            )
+        )
+
+        liquidation = bool(risk_state.get("force_liquidation"))
+        risk_lines.append("Force liquidation: TAK" if liquidation else "Force liquidation: NIE")
+
+        limits = risk_state.get("limits")
+        if isinstance(limits, Mapping):
+            limit_parts: list[str] = []
+            max_positions = _as_int(limits.get("max_positions"))
+            if max_positions is not None:
+                limit_parts.append(f"max pozycje {max_positions}")
+            max_exposure = _as_float(limits.get("max_position_pct"))
+            if max_exposure is not None:
+                limit_parts.append(f"max ekspozycja {_format_percentage(max_exposure)}")
+            max_leverage = _as_float(limits.get("max_leverage"))
+            if max_leverage is not None:
+                limit_parts.append(f"max dźwignia {max_leverage:.2f}x")
+            daily_limit = _as_float(limits.get("daily_loss_limit"))
+            if daily_limit is not None:
+                limit_parts.append(f"dzienna strata {_format_percentage(daily_limit)}")
+            drawdown_limit = _as_float(limits.get("drawdown_limit"))
+            if drawdown_limit is not None:
+                limit_parts.append(f"obsunięcie {_format_percentage(drawdown_limit)}")
+            target_vol = _as_float(limits.get("target_volatility"))
+            if target_vol is not None:
+                limit_parts.append(f"target vol {_format_percentage(target_vol)}")
+            stop_loss_atr = _as_float(limits.get("stop_loss_atr_multiple"))
+            if stop_loss_atr is not None:
+                limit_parts.append(f"stop loss ATR× {stop_loss_atr:.2f}")
+            if limit_parts:
+                risk_lines.append("Limity: " + ", ".join(limit_parts))
+
+    data_lines: list[str] = []
+    data_checks = summary.get("data_checks")
+    if isinstance(data_checks, Mapping):
+        manifest_info = data_checks.get("manifest")
+        if isinstance(manifest_info, Mapping):
+            entries = manifest_info.get("entries") or []
+            if isinstance(entries, list):
+                total_entries = len(entries)
+                issues_count = 0
+                for entry in entries:
+                    issues = entry.get("issues")
+                    if isinstance(issues, list) and any(issues):
+                        issues_count += 1
+                status_text = str(manifest_info.get("status", "n/a")).upper()
+                if total_entries:
+                    data_lines.append(
+                        f"Manifest OHLCV: {status_text} ({total_entries} wpisów, problemy: {issues_count})"
+                    )
+                else:
+                    data_lines.append(f"Manifest OHLCV: {status_text} (brak wpisów)")
+        cache_info = data_checks.get("cache")
+        if isinstance(cache_info, Mapping) and cache_info:
+            fragments: list[str] = []
+            for symbol, payload in sorted(cache_info.items()):
+                fragment = str(symbol)
+                coverage = payload.get("coverage_bars")
+                required = payload.get("required_bars")
+                row_count = payload.get("row_count")
+                try:
+                    coverage_int = int(coverage) if coverage is not None else None
+                except (TypeError, ValueError):
+                    coverage_int = None
+                try:
+                    required_int = int(required) if required is not None else None
+                except (TypeError, ValueError):
+                    required_int = None
+                try:
+                    row_count_int = int(row_count) if row_count is not None else None
+                except (TypeError, ValueError):
+                    row_count_int = None
+                if coverage_int is not None and required_int is not None:
+                    fragment += f": pokrycie {coverage_int}/{required_int}"
+                if row_count_int is not None:
+                    fragment += f", wiersze {row_count_int}"
+                fragments.append(fragment)
+            if fragments:
+                data_lines.append("Cache offline: " + "; ".join(fragments))
+
+    lines = [
+        f"Środowisko: {environment}",
+        f"Zakres dat: {start} → {end}",
+        f"Liczba zleceń: {orders_count}",
+        f"Liczba wpisów w ledgerze: {ledger_entries}",
+    ]
+    if metrics_lines:
+        lines.extend(metrics_lines)
+    if risk_lines:
+        lines.extend(risk_lines)
+    if data_lines:
+        lines.extend(data_lines)
+    lines.append("Alerty: " + "; ".join(alert_lines))
+    lines.append(f"SHA-256 summary.json: {summary_sha256}")
+    return "\n".join(lines)
+
+
+def _ensure_smoke_cache(
+    *,
+    pipeline,
+    symbols: Sequence[str],
+    interval: str,
+    start_ms: int,
+    end_ms: int,
+    required_bars: int,
+    tick_ms: int,
+) -> Mapping[str, object] | None:
+    """Sprawdza, czy lokalny cache zawiera dane potrzebne do smoke testu."""
+
+    manifest_report = _verify_manifest_coverage(
+        pipeline=pipeline,
+        symbols=symbols,
+        interval=interval,
+        end_ms=end_ms,
+        required_bars=required_bars,
+    )
+
+    data_source = getattr(pipeline, "data_source", None)
+    storage = getattr(data_source, "storage", None)
+    if storage is None:
+        _LOGGER.warning(
+            "Nie mogę zweryfikować cache – pipeline nie udostępnia storage'u. Pomijam kontrolę.",
+        )
+        cache_reports: dict[str, dict[str, object]] = {}
+    else:
+        try:
+            metadata: MutableMapping[str, str] = storage.metadata()
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("Nie udało się odczytać metadanych cache: %s", exc)
+            metadata = {}
+
+        issues: list[tuple[str, str]] = []
+        cache_reports = {}
+
+        for symbol in symbols:
+            key = f"{symbol}::{interval}"
+            row_count: int | None = None
+            last_timestamp: int | None = None
+
+            if metadata:
+                raw_rows = metadata.get(f"row_count::{symbol}::{interval}")
+                if raw_rows is not None:
+                    try:
+                        row_count = int(raw_rows)
+                    except (TypeError, ValueError):
+                        _LOGGER.warning(
+                            "Nieprawidłowa wartość row_count dla %s (%s): %s",
+                            symbol,
+                            interval,
+                            raw_rows,
+                        )
+                raw_last = metadata.get(f"last_timestamp::{symbol}::{interval}")
+                if raw_last is not None:
+                    try:
+                        last_timestamp = int(float(raw_last))
+                    except (TypeError, ValueError):
+                        _LOGGER.warning(
+                            "Nieprawidłowa wartość last_timestamp dla %s (%s): %s",
+                            symbol,
+                            interval,
+                            raw_last,
+                        )
+
+            try:
+                payload = storage.read(key)
+            except KeyError:
+                issues.append((symbol, "brak wpisu w cache"))
+                continue
+
+            rows = list(payload.get("rows", []))
+            if not rows:
+                issues.append((symbol, "puste dane w cache"))
+                continue
+
+            if row_count is None:
+                row_count = len(rows)
+            if last_timestamp is None:
+                last_timestamp = int(float(rows[-1][0]))
+
+            first_timestamp = int(float(rows[0][0]))
+
+            if row_count < required_bars:
+                issues.append((symbol, f"za mało świec ({row_count} < {required_bars})"))
+                continue
+
+            if last_timestamp < end_ms:
+                issues.append((symbol, f"ostatnia świeca {last_timestamp} < wymaganego końca {end_ms}"))
+                continue
+
+            if first_timestamp > start_ms:
+                issues.append((symbol, f"pierwsza świeca {first_timestamp} > wymaganego startu {start_ms}"))
+                continue
+
+            coverage = ((last_timestamp - first_timestamp) // max(1, tick_ms)) + 1
+            if coverage < required_bars:
+                issues.append((symbol, f"pokrycie obejmuje {coverage} świec (wymagane {required_bars})"))
+                continue
+
+            cache_reports[str(symbol)] = {
+                "row_count": int(row_count),
+                "first_timestamp_ms": first_timestamp,
+                "last_timestamp_ms": last_timestamp,
+                "coverage_bars": int(coverage),
+                "required_bars": int(required_bars),
+            }
+
+        if issues:
+            for symbol, reason in issues:
+                _LOGGER.error(
+                    "Cache offline dla symbolu %s (%s) nie spełnia wymagań smoke testu: %s",
+                    symbol,
+                    interval,
+                    reason,
+                )
+            raise RuntimeError(
+                "Cache offline nie obejmuje wymaganego zakresu danych. Uruchom scripts/seed_paper_cache.py, "
+                "aby zbudować deterministyczny seed przed smoke testem.",
+            )
+
+    result: dict[str, object] = {
+        "interval": interval,
+        "symbols": [str(symbol) for symbol in symbols],
+        "required_bars": int(required_bars),
+        "tick_ms": int(max(1, tick_ms)),
+        "window_ms": {"start": int(start_ms), "end": int(end_ms)},
+    }
+    if manifest_report:
+        result["manifest"] = manifest_report
+    if cache_reports:
+        result["cache"] = cache_reports
+    return result
+
+
+def _verify_manifest_coverage(
+    *,
+    pipeline,
+    symbols: Sequence[str],
+    interval: str,
+    end_ms: int,
+    required_bars: int,
+) -> Mapping[str, object] | None:
+    """Waliduje metadane manifestu przed uruchomieniem smoke testu."""
+
+    bootstrap = getattr(pipeline, "bootstrap", None)
+    if bootstrap is None:
+        return None
+
+    environment_cfg = getattr(bootstrap, "environment", None)
+    core_config = getattr(bootstrap, "core_config", None)
+    if environment_cfg is None or core_config is None:
+        return None
+
+    if not hasattr(core_config, "instrument_universes"):
+        return None
+
+    universe_name = getattr(environment_cfg, "instrument_universe", None)
+    cache_root = getattr(environment_cfg, "data_cache_path", None)
+    exchange_name = getattr(environment_cfg, "exchange", None)
+    if not universe_name or not cache_root or not exchange_name:
+        return None
+
+    manifest_path = Path(cache_root) / "ohlcv_manifest.sqlite"
+    if not manifest_path.exists():
+        _LOGGER.warning(
+            "Manifest %s nie istnieje – pomijam kontrolę metadanych i sprawdzam wyłącznie surowe pliki.",
+            manifest_path,
+        )
+        return None
+
+    try:
+        universe = core_config.instrument_universes[universe_name]
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning(
+            "Nie udało się pobrać uniwersum instrumentów '%s' z konfiguracji: %s – pomijam kontrolę manifestu.",
+            universe_name,
+            exc,
+        )
+        return None
+
+    as_of = datetime.fromtimestamp(end_ms / 1000, tz=timezone.utc)
+    try:
+        statuses = evaluate_coverage(
+            manifest_path=manifest_path,
+            universe=universe,
+            exchange_name=exchange_name,
+            as_of=as_of,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("Nie udało się ocenić pokrycia manifestu: %s", exc)
+        return None
+
+    tracked_symbols = {str(symbol).lower() for symbol in symbols}
+    interval_key = interval.lower()
+    relevant = [
+        status
+        for status in statuses
+        if status.symbol.lower() in tracked_symbols and status.interval.lower() == interval_key
+    ]
+
+    issues: list[str] = []
+    if not relevant:
+        issues.append(
+            "Manifest nie zawiera wpisów dla wymaganych symboli/interwałów – uruchom ponownie scripts/seed_paper_cache.py."
+        )
+    else:
+        for status in relevant:
+            entry = status.manifest_entry
+            if status.issues:
+                issues.extend(
+                    _render_manifest_issue(status.symbol, interval, issue)
+                    for issue in status.issues
+                )
+
+            row_count = entry.row_count
+            if row_count is None:
+                issues.append(
+                    f"{status.symbol}/{interval}: manifest nie zawiera licznika świec (row_count)"
+                )
+            elif row_count < required_bars:
+                issues.append(
+                    f"{status.symbol}/{interval}: manifest raportuje jedynie {row_count} świec (< {required_bars})"
+                )
+
+            last_ts = entry.last_timestamp_ms
+            if last_ts is None:
+                issues.append(
+                    f"{status.symbol}/{interval}: manifest nie zawiera ostatniego stempla czasowego"
+                )
+            elif last_ts < end_ms:
+                issues.append(
+                    f"{status.symbol}/{interval}: ostatnia świeca w manifescie ({last_ts}) < wymaganego końca ({end_ms})"
+                )
+
+    if issues:
+        for detail in issues:
+            _LOGGER.error("Manifest OHLCV: %s", detail)
+        raise RuntimeError(
+            "Manifest danych OHLCV jest niekompletny dla smoke testu. Uruchom scripts/seed_paper_cache.py lub pełny backfill, "
+            "aby zaktualizować manifest."
+        )
+
+    entries_payload: list[dict[str, object]] = []
+    for status in relevant:
+        entry = status.manifest_entry
+        entries_payload.append(
+            {
+                "symbol": status.symbol,
+                "interval": status.interval,
+                "status": status.status,
+                "issues": list(status.issues),
+                "row_count": entry.row_count,
+                "required_rows": status.required_rows,
+                "gap_minutes": entry.gap_minutes,
+                "last_timestamp_ms": entry.last_timestamp_ms,
+                "last_timestamp_iso": entry.last_timestamp_iso,
+            }
+        )
+
+    return {
+        "status": "ok",
+        "as_of": as_of.isoformat(),
+        "interval": interval,
+        "required_rows": int(required_bars),
+        "symbols": sorted(str(symbol) for symbol in symbols),
+        "entries": entries_payload,
+    }
+
+
+def _render_manifest_issue(symbol: str, interval: str, issue: str) -> str:
+    if issue.startswith("manifest_status:"):
+        status = issue.split(":", 1)[1]
+        return f"{symbol}/{interval}: status manifestu = {status}"
+    if issue == "missing_row_count":
+        return f"{symbol}/{interval}: manifest nie zawiera informacji o liczbie świec"
+    if issue.startswith("insufficient_rows:"):
+        payload = issue.split(":", 1)[1]
+        return f"{symbol}/{interval}: manifest raportuje zbyt mało świec ({payload})"
+    return f"{symbol}/{interval}: {issue}"
+
+
+class _OfflineExchangeAdapter(ExchangeAdapter):
+    """Minimalny adapter giełdowy działający offline dla trybu paper-smoke."""
+
+    name = "offline"
+
+    def __init__(self, credentials: ExchangeCredentials, **_: object) -> None:
+        super().__init__(credentials)
+
+    def configure_network(self, *, ip_allowlist: tuple[str, ...] | None = None) -> None:  # noqa: D401, ARG002
+        return None
+
+    def fetch_account_snapshot(self) -> AccountSnapshot:
+        return AccountSnapshot(
+            balances={"USDT": 100_000.0},
+            total_equity=100_000.0,
+            available_margin=100_000.0,
+            maintenance_margin=0.0,
+        )
+
+    def fetch_symbols(self):  # pragma: no cover - nieużywane w trybie smoke
+        return ()
+
+    def fetch_ohlcv(  # noqa: D401, ARG002
+        self,
+        symbol: str,
+        interval: str,
+        start: int | None = None,
+        end: int | None = None,
+        limit: int | None = None,
+    ):
+        return []
+
+    def place_order(self, request):  # pragma: no cover - paper trading korzysta z symulatora
+        raise NotImplementedError
+
+    def cancel_order(self, order_id: str, *, symbol: str | None = None) -> None:  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+    def stream_public_data(self, *, channels):  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+    def stream_private_data(self, *, channels):  # pragma: no cover - nieużywane
+        raise NotImplementedError
+
+
+def _offline_adapter_factory(credentials: ExchangeCredentials, **kwargs: object) -> ExchangeAdapter:
+    return _OfflineExchangeAdapter(credentials, **kwargs)
 
 
 def _run_loop(runner: DailyTrendRealtimeRunner, poll_seconds: float) -> int:
@@ -249,6 +943,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         _LOGGER.error("Plik konfiguracyjny %s nie istnieje", config_path)
         return 1
 
+    adapter_factories: Mapping[str, ExchangeAdapterFactory] | None = None
+    if args.paper_smoke:
+        adapter_factories = {
+            "binance_spot": _offline_adapter_factory,
+            "binance_futures": _offline_adapter_factory,
+            "kraken_spot": _offline_adapter_factory,
+            "kraken_futures": _offline_adapter_factory,
+            "zonda_spot": _offline_adapter_factory,
+        }
+
     try:
         pipeline = build_daily_trend_pipeline(
             environment_name=args.environment,
@@ -256,10 +960,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             controller_name=args.controller,
             config_path=config_path,
             secret_manager=secret_manager,
+            adapter_factories=adapter_factories,
         )
     except Exception as exc:  # noqa: BLE001
         _LOGGER.exception("Nie udało się zbudować pipeline'u daily trend: %s", exc)
         return 1
+
+    _LOGGER.info(
+        "Pipeline gotowy: środowisko=%s, strategia=%s, kontroler=%s",
+        args.environment,
+        pipeline.strategy_name,
+        pipeline.controller_name,
+    )
 
     environment = pipeline.bootstrap.environment.environment
     if environment is Environment.LIVE and not args.allow_live:
@@ -280,6 +992,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             _LOGGER.error("Niepoprawny zakres dat: %s", exc)
             return 1
 
+        end_dt = datetime.fromisoformat(window_meta["end"])
+        tick_seconds = float(getattr(pipeline.controller, "tick_seconds", 86400.0) or 86400.0)
+        tick_ms = max(1, int(tick_seconds * 1000))
+        window_duration_ms = max(0, end_ms - start_ms)
+        approx_bars = max(1, int(window_duration_ms / tick_ms) + 1)
+        history_bars = max(1, min(int(args.history_bars), approx_bars))
+        runner_start_ms = max(0, end_ms - history_bars * tick_ms)
+        sync_start = min(start_ms, runner_start_ms)
+
         _LOGGER.info(
             "Startuję smoke test paper trading dla %s w zakresie %s – %s.",
             args.environment,
@@ -287,10 +1008,29 @@ def main(argv: Sequence[str] | None = None) -> int:
             window_meta["end"],
         )
 
+        required_bars = max(
+            history_bars,
+            max(1, int((end_ms - sync_start) / tick_ms) + 1),
+        )
+        data_checks: Mapping[str, object] | None = None
+        try:
+            data_checks = _ensure_smoke_cache(
+                pipeline=pipeline,
+                symbols=pipeline.controller.symbols,
+                interval=pipeline.controller.interval,
+                start_ms=sync_start,
+                end_ms=end_ms,
+                required_bars=required_bars,
+                tick_ms=tick_ms,
+            )
+        except RuntimeError as exc:
+            _LOGGER.error("%s", exc)
+            return 1
+
         pipeline.backfill_service.synchronize(
             symbols=pipeline.controller.symbols,
             interval=pipeline.controller.interval,
-            start=start_ms,
+            start=sync_start,
             end=end_ms,
         )
 
@@ -303,7 +1043,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         runner = DailyTrendRealtimeRunner(
             controller=pipeline.controller,
             trading_controller=trading_controller,
-            history_bars=max(1, args.history_bars),
+            history_bars=history_bars,
+            clock=lambda end=end_dt: end,
         )
 
         results = runner.run_once()
@@ -314,6 +1055,22 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         report_dir = Path(tempfile.mkdtemp(prefix="daily_trend_smoke_"))
         alert_snapshot = pipeline.bootstrap.alert_router.health_snapshot()
+        core_config = getattr(pipeline.bootstrap, "core_config", None)
+        reporting_source = core_config
+        if reporting_source is not None and hasattr(reporting_source, "reporting"):
+            reporting_source = getattr(reporting_source, "reporting", None)
+        upload_cfg = SmokeArchiveUploader.resolve_config(reporting_source)
+        risk_snapshot: Mapping[str, object] | None = None
+        try:
+            risk_snapshot = pipeline.bootstrap.risk_engine.snapshot_state(
+                pipeline.bootstrap.environment.risk_profile
+            )
+        except NotImplementedError:
+            _LOGGER.warning(
+                "Silnik ryzyka nie udostępnia metody snapshot_state – pomijam stan ryzyka"
+            )
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning("Nie udało się pobrać stanu ryzyka: %s", exc)
         summary_path = _export_smoke_report(
             report_dir=report_dir,
             results=results,
@@ -321,21 +1078,92 @@ def main(argv: Sequence[str] | None = None) -> int:
             window=window_meta,
             environment=args.environment,
             alert_snapshot=alert_snapshot,
+            risk_state=risk_snapshot,
+            data_checks=data_checks,
         )
-        _LOGGER.info("Raport smoke testu zapisany w %s", report_dir)
+        summary_hash = _hash_file(summary_path)
+        try:
+            summary_payload = json.loads(summary_path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error("Nie udało się odczytać summary.json: %s", exc)
+            summary_payload = {
+                "environment": args.environment,
+                "window": dict(window_meta),
+                "orders": [],
+                "ledger_entries": 0,
+                "alert_snapshot": alert_snapshot,
+                "risk_state": risk_snapshot or {},
+            }
+
+        summary_text = _render_smoke_summary(
+            summary=summary_payload,
+            summary_sha256=summary_hash,
+        )
+        summary_txt_path = summary_path.with_suffix(".txt")
+        summary_txt_path.write_text(summary_text + "\n", encoding="utf-8")
+        readme_path = _write_smoke_readme(report_dir)
+        _LOGGER.info(
+            "Raport smoke testu zapisany w %s (summary sha256=%s)",
+            report_dir,
+            summary_hash,
+        )
+        _LOGGER.info("Podsumowanie smoke testu:%s%s", os.linesep, summary_text)
+
+        archive_path: Path | None = None
+        archive_required = bool(args.archive_smoke or upload_cfg)
+        if archive_required:
+            archive_path = _archive_smoke_report(report_dir)
+            if args.archive_smoke:
+                _LOGGER.info("Utworzono archiwum smoke testu: %s", archive_path)
+            else:
+                _LOGGER.info(
+                    "Archiwum smoke testu wygenerowane automatycznie na potrzeby uploadu: %s",
+                    archive_path,
+                )
+
+        upload_result = None
+        if upload_cfg and archive_path:
+            try:
+                uploader = SmokeArchiveUploader(upload_cfg, secret_manager=secret_manager)
+                upload_result = uploader.upload(
+                    archive_path,
+                    environment=args.environment,
+                    summary_sha256=summary_hash,
+                    window=window_meta,
+                )
+                _LOGGER.info(
+                    "Przesłano archiwum smoke testu (%s) do %s",
+                    upload_result.backend,
+                    upload_result.location,
+                )
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.error("Nie udało się przesłać archiwum smoke testu: %s", exc)
 
         message = AlertMessage(
             category="paper_smoke",
             title=f"Smoke test paper trading ({args.environment})",
             body=(
                 "Zakończono smoke test paper trading."
-                f" Zamówienia: {len(results)}, raport: {summary_path}"
+                f" Zamówienia: {len(results)}, raport: {summary_path},"
+                f" sha256: {summary_hash}"
             ),
             severity="info",
             context={
                 "environment": args.environment,
                 "report_dir": str(report_dir),
                 "orders": str(len(results)),
+                "summary_sha256": summary_hash,
+                "summary_text_path": str(summary_txt_path),
+                "readme_path": str(readme_path),
+                **({"archive_path": str(archive_path)} if archive_path else {}),
+                **(
+                    {
+                        "archive_upload_backend": upload_result.backend,
+                        "archive_upload_location": upload_result.location,
+                    }
+                    if upload_result
+                    else {}
+                ),
             },
         )
         pipeline.bootstrap.alert_router.dispatch(message)

--- a/scripts/seed_paper_cache.py
+++ b/scripts/seed_paper_cache.py
@@ -1,0 +1,319 @@
+"""Narzędzie do przygotowania lokalnego cache'u OHLCV dla smoke testów paper tradingu."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Sequence
+
+from bot_core.config.loader import load_core_config
+from bot_core.config.models import CoreConfig, EnvironmentConfig, InstrumentConfig
+from bot_core.data.ohlcv import ParquetCacheStorage, SQLiteCacheStorage
+from bot_core.exchanges.base import Environment as ExchangeEnvironment
+
+_LOGGER = logging.getLogger(__name__)
+
+_COLUMNS = ("open_time", "open", "high", "low", "close", "volume")
+
+_BASE_PRICE_BY_ASSET = {
+    "BTC": 45_000.0,
+    "ETH": 2_500.0,
+    "SOL": 95.0,
+    "BNB": 320.0,
+    "XRP": 0.6,
+    "ADA": 0.45,
+    "LTC": 78.0,
+    "MATIC": 0.85,
+}
+
+_BASE_VOLUME_BY_ASSET = {
+    "BTC": 1_500.0,
+    "ETH": 3_000.0,
+    "SOL": 45_000.0,
+    "BNB": 25_000.0,
+    "XRP": 8_000_000.0,
+    "ADA": 9_500_000.0,
+    "LTC": 120_000.0,
+    "MATIC": 6_000_000.0,
+}
+
+
+@dataclass(slots=True)
+class GeneratedSeries:
+    symbol: str
+    interval: str
+    candles: int
+    start_timestamp: int
+    end_timestamp: int
+
+
+def _parse_start_date(value: str | None, *, days: int) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc) - timedelta(days=days)
+    text = value.strip()
+    if not text:
+        raise ValueError("start-date nie może być pusty")
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def _base_price(symbol: str, base_asset: str) -> float:
+    asset = base_asset.upper()
+    if asset in _BASE_PRICE_BY_ASSET:
+        return _BASE_PRICE_BY_ASSET[asset]
+    digest = hashlib.sha256(f"{symbol}:{asset}".encode("utf-8")).digest()
+    anchor = int.from_bytes(digest[:4], "big")
+    return 10.0 + (anchor % 10_000) / 100.0
+
+
+def _base_volume(symbol: str, base_asset: str) -> float:
+    asset = base_asset.upper()
+    if asset in _BASE_VOLUME_BY_ASSET:
+        return _BASE_VOLUME_BY_ASSET[asset]
+    digest = hashlib.sha256(f"vol:{symbol}:{asset}".encode("utf-8")).digest()
+    anchor = int.from_bytes(digest[4:8], "big")
+    return 1_000.0 + (anchor % 200_000)
+
+
+def _generate_rows(
+    *,
+    symbol: str,
+    base_asset: str,
+    days: int,
+    start: datetime,
+    interval: str,
+    seed: int | None,
+) -> list[list[float]]:
+    if interval != "1d":
+        raise ValueError("Skrypt obsługuje wyłącznie interwał 1d na potrzeby smoke testu")
+    step = timedelta(days=1)
+    price = _base_price(symbol, base_asset)
+    volume_anchor = _base_volume(symbol, base_asset)
+    if seed is not None:
+        digest = hashlib.sha256(f"{symbol}:{seed}".encode("utf-8")).digest()
+        rng_state = int.from_bytes(digest[:8], "big")
+    else:
+        rng_state = hash((symbol, days, start.toordinal())) & 0xFFFFFFFF
+
+    def _rand() -> float:
+        nonlocal rng_state
+        rng_state = (1103515245 * rng_state + 12345) % (2 ** 31)
+        return rng_state / float(2 ** 31)
+
+    rows: list[list[float]] = []
+    current = start
+    for _ in range(days):
+        open_price = price
+        drift = 0.0025 + (_rand() - 0.5) * 0.004
+        shock = (_rand() - 0.5) * 0.015
+        close_price = max(0.0001, open_price * (1.0 + drift + shock))
+        high_price = max(open_price, close_price) * (1.0 + abs((_rand() - 0.5) * 0.01))
+        low_price = min(open_price, close_price) * (1.0 - abs((_rand() - 0.5) * 0.01))
+        volume = volume_anchor * (0.75 + _rand() * 0.5)
+        timestamp = int(current.replace(hour=0, minute=0, second=0, microsecond=0).timestamp() * 1000)
+        rows.append([
+            float(timestamp),
+            float(round(open_price, 6)),
+            float(round(high_price, 6)),
+            float(round(low_price, 6)),
+            float(round(close_price, 6)),
+            float(round(volume, 6)),
+        ])
+        price = close_price
+        current += step
+    return rows
+
+
+def _resolve_symbols(
+    *,
+    config: CoreConfig,
+    environment: EnvironmentConfig,
+) -> list[tuple[str, InstrumentConfig]]:
+    if not environment.instrument_universe:
+        raise ValueError(
+            f"Środowisko {environment.name} nie ma przypisanego instrument_universe w konfiguracji"
+        )
+    try:
+        universe = config.instrument_universes[environment.instrument_universe]
+    except KeyError as exc:
+        raise KeyError(
+            f"Brak uniwersum instrumentów '{environment.instrument_universe}' w konfiguracji"
+        ) from exc
+
+    raw_settings = getattr(environment, "adapter_settings", {}) or {}
+    paper_settings = raw_settings.get("paper_trading", {}) or {}
+    quote_assets = paper_settings.get("quote_assets")
+    if quote_assets:
+        allowed_quotes = {str(asset).upper() for asset in quote_assets}
+    else:
+        valuation = str(paper_settings.get("valuation_asset", "USDT")).upper()
+        allowed_quotes = {valuation}
+
+    symbols: list[tuple[str, InstrumentConfig]] = []
+    for instrument in universe.instruments:
+        exchange_symbol = instrument.exchange_symbols.get(environment.exchange)
+        if not exchange_symbol:
+            continue
+        if instrument.quote_asset.upper() not in allowed_quotes:
+            continue
+        symbols.append((exchange_symbol, instrument))
+    return symbols
+
+
+def generate_smoke_cache(
+    *,
+    config_path: Path,
+    environment_name: str,
+    interval: str,
+    days: int,
+    start_date: datetime,
+    seed: int | None = None,
+) -> list[GeneratedSeries]:
+    if days <= 0:
+        raise ValueError("Liczba dni musi być dodatnia")
+
+    config = load_core_config(config_path)
+    try:
+        environment = config.environments[environment_name]
+    except KeyError as exc:
+        raise KeyError(f"Brak środowiska '{environment_name}' w konfiguracji") from exc
+
+    if environment.environment not in {ExchangeEnvironment.PAPER, ExchangeEnvironment.TESTNET}:
+        raise ValueError("Cache smoke obsługuje wyłącznie środowiska paper/testnet")
+
+    symbols = _resolve_symbols(config=config, environment=environment)
+    if not symbols:
+        raise ValueError(
+            f"Uniwersum {environment.instrument_universe} nie posiada instrumentów dla giełdy {environment.exchange}"
+        )
+
+    cache_root = Path(environment.data_cache_path)
+    parquet_storage = ParquetCacheStorage(cache_root / "ohlcv_parquet", namespace=environment.exchange)
+    manifest_storage = SQLiteCacheStorage(cache_root / "ohlcv_manifest.sqlite", store_rows=False)
+    metadata = parquet_storage.metadata()
+
+    generated: list[GeneratedSeries] = []
+    for symbol, instrument in symbols:
+        rows = _generate_rows(
+            symbol=symbol,
+            base_asset=instrument.base_asset,
+            days=days,
+            start=start_date,
+            interval=interval,
+            seed=seed,
+        )
+        payload = {"columns": _COLUMNS, "rows": rows}
+        key = f"{symbol}::{interval}"
+        parquet_storage.write(key, payload)
+        manifest_storage.write(key, payload)
+        metadata[f"row_count::{symbol}::{interval}"] = str(len(rows))
+        metadata[f"last_timestamp::{symbol}::{interval}"] = str(int(rows[-1][0]))
+        generated.append(
+            GeneratedSeries(
+                symbol=symbol,
+                interval=interval,
+                candles=len(rows),
+                start_timestamp=int(rows[0][0]),
+                end_timestamp=int(rows[-1][0]),
+            )
+        )
+        _LOGGER.info(
+            "Zapisano %s świec dla %s (%s) w %s",
+            len(rows),
+            symbol,
+            interval,
+            cache_root,
+        )
+
+    return generated
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generuje deterministyczne dane OHLCV 1d dla środowiska paper/testnet, "
+            "aby umożliwić offline smoke test strategii Daily Trend."
+        )
+    )
+    parser.add_argument("--config", default="config/core.yaml", help="Ścieżka do pliku konfiguracyjnego core")
+    parser.add_argument(
+        "--environment",
+        default="binance_paper",
+        help="Nazwa środowiska paper/testnet, dla którego generujemy cache",
+    )
+    parser.add_argument(
+        "--interval",
+        default="1d",
+        help="Interwał OHLCV (obecnie obsługiwany 1d)",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=60,
+        help="Liczba kolejnych dni do wygenerowania",
+    )
+    parser.add_argument(
+        "--start-date",
+        default="2024-01-01",
+        help="Data początkowa (ISO 8601, UTC) pierwszej świecy",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Opcjonalne ziarno generatora szumu (dla powtarzalności)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Ogranicz logowanie do ostrzeżeń/błędów",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING if args.quiet else logging.INFO)
+
+    try:
+        start_date = _parse_start_date(args.start_date, days=args.days)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 2
+
+    try:
+        results = generate_smoke_cache(
+            config_path=Path(args.config),
+            environment_name=args.environment,
+            interval=args.interval,
+            days=args.days,
+            start_date=start_date,
+            seed=args.seed,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.error("Nie udało się zbudować cache'u smoke: %s", exc)
+        return 1
+
+    total = sum(entry.candles for entry in results)
+    earliest = min(entry.start_timestamp for entry in results)
+    latest = max(entry.end_timestamp for entry in results)
+    _LOGGER.info(
+        "Cache smoke gotowy: %s świec, zakres %s – %s (UTC)",
+        total,
+        datetime.fromtimestamp(earliest / 1000, tz=timezone.utc).isoformat(),
+        datetime.fromtimestamp(latest / 1000, tz=timezone.utc).isoformat(),
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -1,0 +1,62 @@
+"""Walidacja spójności konfiguracji CoreConfig."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from bot_core.config.loader import load_core_config
+from bot_core.config.validation import validate_core_config
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Waliduje config/core.yaml i zależności środowisk.")
+    parser.add_argument(
+        "--config",
+        default="config/core.yaml",
+        help="Ścieżka do pliku konfiguracyjnego CoreConfig",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Zwróć wynik w formacie JSON (łatwiejszy do użycia w CI)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    config = load_core_config(args.config)
+    result = validate_core_config(config)
+
+    if args.json:
+        payload = {
+            "valid": result.is_valid(),
+            "errors": result.errors,
+            "warnings": result.warnings,
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        if result.errors:
+            print("✖ Błędy konfiguracji:", file=sys.stderr)
+            for entry in result.errors:
+                print(f"  - {entry}", file=sys.stderr)
+        else:
+            print("✓ Konfiguracja jest spójna")
+
+        if result.warnings:
+            print("⚠ Ostrzeżenia:")
+            for entry in result.warnings:
+                print(f"  - {entry}")
+
+    return 0 if result.is_valid() else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - punkt wejścia CLI
+    sys.exit(main())

--- a/tests/test_check_data_coverage_script.py
+++ b/tests/test_check_data_coverage_script.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.data.ohlcv import ParquetCacheStorage, SQLiteCacheStorage
+from scripts import check_data_coverage
+
+
+_COLUMNS = ("open_time", "open", "high", "low", "close", "volume")
+
+
+def _generate_rows(start: datetime, count: int) -> list[list[float]]:
+    base_ts = int(start.timestamp() * 1000)
+    day_ms = 24 * 60 * 60 * 1000
+    rows: list[list[float]] = []
+    price = 40_000.0
+    for index in range(count):
+        timestamp = base_ts + index * day_ms
+        rows.append([
+            float(timestamp),
+            price + index * 10,
+            price + index * 15,
+            price + index * 5,
+            price + index * 12,
+            100 + index,
+        ])
+    return rows
+
+
+def _write_cache(cache_dir: Path, rows: list[list[float]]) -> None:
+    payload = {"columns": _COLUMNS, "rows": rows}
+    parquet = ParquetCacheStorage(cache_dir / "ohlcv_parquet", namespace="binance_spot")
+    parquet.write("BTCUSDT::1d", payload)
+    manifest = SQLiteCacheStorage(cache_dir / "ohlcv_manifest.sqlite", store_rows=False)
+    manifest.write("BTCUSDT::1d", payload)
+
+
+def _write_config(tmp_path: Path, cache_dir: Path) -> Path:
+    content = f"""
+risk_profiles:
+  test_profile:
+    max_daily_loss_pct: 0.5
+    max_position_pct: 1.0
+    target_volatility: 0.5
+    max_leverage: 2.0
+    stop_loss_atr_multiple: 1.5
+    max_open_positions: 10
+    hard_drawdown_pct: 0.8
+
+instrument_universes:
+  test_universe:
+    description: smoke
+    instruments:
+      BTC_USDT:
+        base_asset: BTC
+        quote_asset: USDT
+        categories: [smoke]
+        exchanges:
+          binance_spot: BTCUSDT
+        backfill:
+          - interval: 1d
+            lookback_days: 30
+
+environments:
+  binance_smoke:
+    exchange: binance_spot
+    environment: paper
+    keychain_key: smoke_key
+    data_cache_path: {cache_dir}
+    risk_profile: test_profile
+    alert_channels: []
+    instrument_universe: test_universe
+    required_permissions: [read]
+    forbidden_permissions: []
+"""
+    path = tmp_path / "config.yaml"
+    path.write_text(content)
+    return path
+
+
+def test_check_data_coverage_success(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cache_dir = tmp_path / "cache_success"
+    rows = _generate_rows(datetime(2024, 1, 1, tzinfo=timezone.utc), 40)
+    _write_cache(cache_dir, rows)
+    config_path = _write_config(tmp_path, cache_dir)
+
+    as_of = datetime.fromtimestamp(rows[-1][0] / 1000, tz=timezone.utc).isoformat()
+    exit_code = check_data_coverage.main(
+        [
+            "--config",
+            str(config_path),
+            "--environment",
+            "binance_smoke",
+            "--as-of",
+            as_of,
+            "--json",
+        ]
+    )
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "ok"
+    assert output["entries"][0]["required_rows"] >= 30
+
+
+def test_check_data_coverage_detects_insufficient_rows(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cache_dir = tmp_path / "cache_failure"
+    rows = _generate_rows(datetime(2024, 1, 1, tzinfo=timezone.utc), 5)
+    _write_cache(cache_dir, rows)
+    config_path = _write_config(tmp_path, cache_dir)
+
+    as_of = datetime.fromtimestamp(rows[-1][0] / 1000, tz=timezone.utc).isoformat()
+    exit_code = check_data_coverage.main(
+        [
+            "--config",
+            str(config_path),
+            "--environment",
+            "binance_smoke",
+            "--as-of",
+            as_of,
+            "--json",
+        ]
+    )
+    assert exit_code == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "error"
+    assert any("insufficient_rows" in issue for issue in output["issues"])

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from bot_core.config.models import (
+    ControllerRuntimeConfig,
+    CoreConfig,
+    EnvironmentConfig,
+    InstrumentBackfillWindow,
+    InstrumentConfig,
+    InstrumentUniverseConfig,
+    DailyTrendMomentumStrategyConfig,
+    RiskProfileConfig,
+    TelegramChannelSettings,
+)
+from bot_core.config.validation import (
+    ConfigValidationError,
+    assert_core_config_valid,
+    validate_core_config,
+)
+from bot_core.exchanges.base import Environment
+
+
+@pytest.fixture()
+def base_config() -> CoreConfig:
+    risk = RiskProfileConfig(
+        name="balanced",
+        max_daily_loss_pct=0.01,
+        max_position_pct=0.03,
+        target_volatility=0.07,
+        max_leverage=2.0,
+        stop_loss_atr_multiple=1.0,
+        max_open_positions=3,
+        hard_drawdown_pct=0.05,
+    )
+    strategy = DailyTrendMomentumStrategyConfig(
+        name="core_daily_trend",
+        fast_ma=25,
+        slow_ma=100,
+        breakout_lookback=55,
+        momentum_window=20,
+        atr_window=14,
+        atr_multiplier=2.0,
+        min_trend_strength=0.0,
+        min_momentum=0.0,
+    )
+    controller = ControllerRuntimeConfig(tick_seconds=86400, interval="1d")
+    environment = EnvironmentConfig(
+        name="paper",
+        exchange="binance_spot",
+        environment=Environment.PAPER,
+        keychain_key="binance_paper",
+        data_cache_path="/tmp/cache",
+        risk_profile="balanced",
+        alert_channels=("telegram:primary",),
+        ip_allowlist=(),
+        credential_purpose="trading",
+        instrument_universe=None,
+        adapter_settings={},
+        required_permissions=("read", "trade"),
+        forbidden_permissions=("withdraw",),
+        default_strategy="core_daily_trend",
+        default_controller="daily_trend_core",
+    )
+    telegram = TelegramChannelSettings(
+        name="primary",
+        chat_id="123",
+        token_secret="telegram_primary_token",
+        parse_mode="MarkdownV2",
+    )
+    return CoreConfig(
+        environments={"paper": environment},
+        risk_profiles={"balanced": risk},
+        instrument_universes={},
+        strategies={"core_daily_trend": strategy},
+        reporting=None,
+        sms_providers={},
+        telegram_channels={"primary": telegram},
+        email_channels={},
+        signal_channels={},
+        whatsapp_channels={},
+        messenger_channels={},
+        runtime_controllers={"daily_trend_core": controller},
+    )
+
+
+def test_validate_core_config_accepts_valid_configuration(base_config: CoreConfig) -> None:
+    result = validate_core_config(base_config)
+    assert result.is_valid()
+    assert result.errors == []
+
+
+def test_validate_core_config_detects_missing_risk_profile(base_config: CoreConfig) -> None:
+    invalid_env = replace(base_config.environments["paper"], risk_profile="unknown")
+    config = replace(base_config, environments={"paper": invalid_env})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "profil ryzyka 'unknown'" in result.errors[0]
+
+
+def test_validate_core_config_detects_unknown_alert_channel(base_config: CoreConfig) -> None:
+    invalid_env = replace(base_config.environments["paper"], alert_channels=("telegram:missing",))
+    config = replace(base_config, environments={"paper": invalid_env})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "kanał alertowy 'telegram:missing'" in result.errors[0]
+
+
+def test_validate_core_config_detects_missing_default_strategy(base_config: CoreConfig) -> None:
+    invalid_env = replace(base_config.environments["paper"], default_strategy=None)
+    config = replace(base_config, environments={"paper": invalid_env})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "default_strategy" in result.errors[0]
+
+
+def test_validate_core_config_detects_unknown_default_strategy(base_config: CoreConfig) -> None:
+    invalid_env = replace(base_config.environments["paper"], default_strategy="missing")
+    config = replace(base_config, environments={"paper": invalid_env})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "domyślna strategia" in result.errors[0]
+
+
+def test_validate_core_config_detects_missing_default_controller(base_config: CoreConfig) -> None:
+    invalid_env = replace(base_config.environments["paper"], default_controller=None)
+    config = replace(base_config, environments={"paper": invalid_env})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "default_controller" in result.errors[0]
+
+
+def test_validate_core_config_detects_unknown_default_controller(base_config: CoreConfig) -> None:
+    invalid_env = replace(base_config.environments["paper"], default_controller="missing")
+    config = replace(base_config, environments={"paper": invalid_env})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "domyślny kontroler" in result.errors[0]
+
+
+def test_validate_core_config_detects_controller_interval_without_backfill(
+    base_config: CoreConfig,
+) -> None:
+    config_with_universe = _config_with_universe(base_config)
+    controller = replace(
+        config_with_universe.runtime_controllers["daily_trend_core"], interval="1h"
+    )
+    environment = replace(
+        config_with_universe.environments["paper"],
+        instrument_universe="core",
+    )
+    config = replace(
+        config_with_universe,
+        runtime_controllers={"daily_trend_core": controller},
+        environments={"paper": environment},
+    )
+
+    result = validate_core_config(config)
+
+    assert not result.is_valid()
+    assert "interwału '1h'" in result.errors[0]
+
+
+def test_validate_core_config_detects_overlapping_permissions(base_config: CoreConfig) -> None:
+    invalid_env = replace(
+        base_config.environments["paper"],
+        required_permissions=("read",),
+        forbidden_permissions=("read",),
+    )
+    config = replace(base_config, environments={"paper": invalid_env})
+
+    with pytest.raises(ConfigValidationError):
+        assert_core_config_valid(config)
+
+
+def test_validate_core_config_detects_negative_risk_values(base_config: CoreConfig) -> None:
+    broken_risk = replace(base_config.risk_profiles["balanced"], max_daily_loss_pct=-0.1)
+    config = replace(base_config, risk_profiles={"balanced": broken_risk})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "max_daily_loss_pct" in result.errors[0]
+
+
+def _config_with_universe(base_config: CoreConfig) -> CoreConfig:
+    instrument = InstrumentConfig(
+        name="BTC_USDT",
+        base_asset="BTC",
+        quote_asset="USDT",
+        categories=("core",),
+        exchange_symbols={"binance_spot": "BTCUSDT"},
+        backfill_windows=(InstrumentBackfillWindow(interval="1d", lookback_days=30),),
+    )
+    universe = InstrumentUniverseConfig(
+        name="core",
+        description="test universe",
+        instruments=(instrument,),
+    )
+    return replace(base_config, instrument_universes={"core": universe})
+
+
+def test_validate_core_config_detects_empty_instrument_list(base_config: CoreConfig) -> None:
+    empty_universe = InstrumentUniverseConfig(name="core", description="desc", instruments=())
+    config = replace(base_config, instrument_universes={"core": empty_universe})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "musi zawierać co najmniej jeden instrument" in result.errors[0]
+
+
+def test_validate_core_config_detects_missing_exchange_symbols(base_config: CoreConfig) -> None:
+    universe_config = _config_with_universe(base_config)
+    instrument = replace(
+        next(iter(universe_config.instrument_universes["core"].instruments)),
+        exchange_symbols={},
+    )
+    broken_universe = replace(
+        universe_config.instrument_universes["core"], instruments=(instrument,)
+    )
+    config = replace(universe_config, instrument_universes={"core": broken_universe})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert "powiązanie giełdowe" in result.errors[0]
+
+
+def test_validate_core_config_detects_invalid_backfill_window(base_config: CoreConfig) -> None:
+    universe_config = _config_with_universe(base_config)
+    instrument = replace(
+        next(iter(universe_config.instrument_universes["core"].instruments)),
+        backfill_windows=(InstrumentBackfillWindow(interval="", lookback_days=-1),),
+    )
+    broken_universe = replace(
+        universe_config.instrument_universes["core"], instruments=(instrument,)
+    )
+    config = replace(universe_config, instrument_universes={"core": broken_universe})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert any("backfill" in err for err in result.errors)
+
+
+def test_validate_core_config_detects_invalid_backfill_interval_format(base_config: CoreConfig) -> None:
+    universe_config = _config_with_universe(base_config)
+    instrument = replace(
+        next(iter(universe_config.instrument_universes["core"].instruments)),
+        backfill_windows=(InstrumentBackfillWindow(interval="1x", lookback_days=10),),
+    )
+    broken_universe = replace(
+        universe_config.instrument_universes["core"], instruments=(instrument,)
+    )
+    config = replace(universe_config, instrument_universes={"core": broken_universe})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert any("niepoprawny format" in err or "nieobsługiwany" in err for err in result.errors)
+
+
+def test_validate_core_config_detects_universe_without_exchange_mapping(base_config: CoreConfig) -> None:
+    instrument = InstrumentConfig(
+        name="BTC_USDT",
+        base_asset="BTC",
+        quote_asset="USDT",
+        categories=("core",),
+        exchange_symbols={"kraken_spot": "XBTUSDT"},
+        backfill_windows=(InstrumentBackfillWindow(interval="1d", lookback_days=30),),
+    )
+    universe = InstrumentUniverseConfig(
+        name="core",
+        description="test universe",
+        instruments=(instrument,),
+    )
+    environment = replace(
+        base_config.environments["paper"],
+        instrument_universe="core",
+    )
+    config = replace(
+        base_config,
+        instrument_universes={"core": universe},
+        environments={"paper": environment},
+    )
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert any("nie zawiera powiązań" in err for err in result.errors)
+
+
+def test_validate_core_config_detects_invalid_strategy_settings(base_config: CoreConfig) -> None:
+    strategy = DailyTrendMomentumStrategyConfig(
+        name="invalid",
+        fast_ma=20,
+        slow_ma=10,
+        breakout_lookback=5,
+        momentum_window=3,
+        atr_window=7,
+        atr_multiplier=2.0,
+        min_trend_strength=0.001,
+        min_momentum=0.001,
+    )
+    config = replace(base_config, strategies={"invalid": strategy})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert any("fast_ma" in err for err in result.errors)
+
+
+def test_validate_core_config_detects_invalid_runtime_controller(base_config: CoreConfig) -> None:
+    controller = ControllerRuntimeConfig(tick_seconds=0.0, interval=" ")
+    config = replace(base_config, runtime_controllers={"bad": controller})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert any("tick_seconds" in err for err in result.errors)
+    assert any("interval" in err for err in result.errors)
+
+
+def test_validate_core_config_detects_unknown_runtime_interval(base_config: CoreConfig) -> None:
+    controller = ControllerRuntimeConfig(tick_seconds=60.0, interval="daily")
+    config = replace(base_config, runtime_controllers={"daily": controller})
+
+    result = validate_core_config(config)
+    assert not result.is_valid()
+    assert any("niepoprawny format" in err or "nieobsługiwany" in err for err in result.errors)
+
+
+def test_validate_core_config_warns_on_tick_mismatch(base_config: CoreConfig) -> None:
+    controller = ControllerRuntimeConfig(tick_seconds=30.0, interval="1m")
+    env = replace(base_config.environments["paper"], default_controller="fast")
+    config = replace(
+        base_config,
+        runtime_controllers={"fast": controller},
+        environments={"paper": env},
+    )
+
+    result = validate_core_config(config)
+    assert result.is_valid()
+    assert any("tick_seconds" in warn for warn in result.warnings)

--- a/tests/test_pipeline_smoke_binance.py
+++ b/tests/test_pipeline_smoke_binance.py
@@ -274,5 +274,8 @@ def test_daily_trend_pipeline_smoke(tmp_path: Path, _fixture_cache: Path) -> Non
     assert ledger_files and ledger_files[0].exists()
 
     profile_name = pipeline.bootstrap.environment.risk_profile
-    state = pipeline.bootstrap.risk_engine._states[profile_name]
-    assert not state.force_liquidation, "Profil ryzyka nie powinien przejść w tryb awaryjny."
+    risk_snapshot = pipeline.bootstrap.risk_engine.snapshot_state(profile_name)
+    assert risk_snapshot is not None
+    assert not bool(risk_snapshot.get("force_liquidation")), (
+        "Profil ryzyka nie powinien przejść w tryb awaryjny."
+    )

--- a/tests/test_run_daily_trend_script.py
+++ b/tests/test_run_daily_trend_script.py
@@ -1,14 +1,29 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import sys
+import sqlite3
+import tempfile
+import zipfile
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Iterable
+from typing import Any
 
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+from bot_core.config.models import (
+    CoreReportingConfig,
+    InstrumentBackfillWindow,
+    InstrumentConfig,
+    InstrumentUniverseConfig,
+    SmokeArchiveLocalConfig,
+    SmokeArchiveUploadConfig,
+)
 from bot_core.exchanges.base import Environment, OrderResult
 
 
@@ -16,14 +31,26 @@ from bot_core.exchanges.base import Environment, OrderResult
 def _patch_secret_manager(monkeypatch: pytest.MonkeyPatch) -> None:
     from scripts import run_daily_trend
 
-    monkeypatch.setattr(run_daily_trend, "_create_secret_manager", lambda args: SimpleNamespace())
+    secret_manager = SimpleNamespace(
+        load_secret_value=lambda key, **_: "",  # pragma: no cover - tylko stub
+    )
+    monkeypatch.setattr(run_daily_trend, "_create_secret_manager", lambda args: secret_manager)
 
 
 def _fake_pipeline(env: Environment) -> SimpleNamespace:
     environment = SimpleNamespace(environment=env, risk_profile="balanced")
-    bootstrap = SimpleNamespace(environment=environment, alert_router=SimpleNamespace())
+    bootstrap = SimpleNamespace(
+        environment=environment,
+        alert_router=SimpleNamespace(),
+        core_config=SimpleNamespace(reporting=None),
+    )
     controller = SimpleNamespace()
-    return SimpleNamespace(bootstrap=bootstrap, controller=controller)
+    return SimpleNamespace(
+        bootstrap=bootstrap,
+        controller=controller,
+        strategy_name="core_daily_trend",
+        controller_name="daily_trend_core",
+    )
 
 
 def test_run_once_executes_single_iteration(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -51,10 +78,18 @@ def test_run_once_executes_single_iteration(monkeypatch: pytest.MonkeyPatch) -> 
     calls: list[str] = []
 
     class DummyRunner:
-        def __init__(self, *, controller: Any, trading_controller: Any, history_bars: int) -> None:
+        def __init__(
+            self,
+            *,
+            controller: Any,
+            trading_controller: Any,
+            history_bars: int,
+            clock=None,
+        ) -> None:
             assert controller is pipeline.controller
             assert trading_controller is trading_controller_obj
             captured_args["history_bars"] = history_bars
+            captured_args["clock"] = clock
             calls.append("init")
 
         def run_once(self) -> Iterable[OrderResult]:
@@ -102,3 +137,760 @@ def test_dry_run_returns_success(monkeypatch: pytest.MonkeyPatch) -> None:
     exit_code = run_daily_trend.main(["--config", "config/core.yaml", "--dry-run"])
 
     assert exit_code == 0
+
+
+def test_paper_smoke_uses_date_window(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from scripts import run_daily_trend
+
+    dispatch_calls: list[Any] = []
+    sync_calls: list[dict[str, Any]] = []
+    collected_calls: list[dict[str, int]] = []
+
+    start_dt = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end_dt = datetime(2024, 2, 15, 23, 59, 59, 999000, tzinfo=timezone.utc)
+    start_ms = int(start_dt.timestamp() * 1000)
+    end_ms = int(end_dt.timestamp() * 1000)
+
+    class DummyController:
+        symbols = ("BTCUSDT",)
+        interval = "1d"
+        tick_seconds = 86400.0
+
+        def collect_signals(self, *, start: int, end: int) -> list[Any]:
+            collected_calls.append({"start": start, "end": end})
+            return []
+
+    class DummyBackfill:
+        def synchronize(self, **kwargs: Any) -> None:
+            sync_calls.append(kwargs)
+
+    class DummyExecutionService:
+        def ledger(self) -> list[dict[str, Any]]:
+            return []
+
+    history_bars_cap = 180
+    tick_ms = int(DummyController.tick_seconds * 1000)
+    window_duration_ms = max(0, end_ms - start_ms)
+    approx_bars = max(1, int(window_duration_ms / tick_ms) + 1)
+    expected_history = max(1, min(history_bars_cap, approx_bars))
+    runner_start_ms = max(0, end_ms - expected_history * tick_ms)
+    sync_start_ms = min(start_ms, runner_start_ms)
+    required_bars = max(expected_history, max(1, int((end_ms - sync_start_ms) / tick_ms) + 1))
+
+    class DummyStorage:
+        def metadata(self) -> dict[str, str]:
+            return {
+                f"row_count::BTCUSDT::1d": str(required_bars + 5),
+                f"last_timestamp::BTCUSDT::1d": str(end_ms + tick_ms),
+            }
+
+        def read(self, key: str) -> dict[str, Any]:
+            assert key == "BTCUSDT::1d"
+            return {
+                "rows": [
+                    [float(sync_start_ms - tick_ms), 0.0, 0.0, 0.0, 0.0, 0.0],
+                    [float(end_ms + tick_ms), 0.0, 0.0, 0.0, 0.0, 0.0],
+                ]
+            }
+
+    class DummyAlertRouter:
+        def dispatch(self, message: Any) -> None:
+            dispatch_calls.append(message)
+
+        def health_snapshot(self) -> dict[str, Any]:
+            return {"telegram": {"status": "ok"}}
+
+    environment_cfg = SimpleNamespace(environment=Environment.PAPER, risk_profile="balanced")
+
+    archive_store = tmp_path / "archives"
+    reporting_cfg = CoreReportingConfig(
+        smoke_archive_upload=SmokeArchiveUploadConfig(
+            backend="local",
+            credential_secret=None,
+            local=SmokeArchiveLocalConfig(
+                directory=str(archive_store),
+                filename_pattern="{environment}_{timestamp}_{hash}.zip",
+                fsync=False,
+            ),
+        ),
+    )
+
+    pipeline = SimpleNamespace(
+        controller=DummyController(),
+        backfill_service=DummyBackfill(),
+        execution_service=DummyExecutionService(),
+        bootstrap=SimpleNamespace(
+            environment=environment_cfg,
+            alert_router=DummyAlertRouter(),
+            core_config=reporting_cfg,
+        ),
+        data_source=SimpleNamespace(storage=DummyStorage()),
+        strategy_name="core_daily_trend",
+        controller_name="daily_trend_core",
+    )
+
+    captured_args: dict[str, Any] = {}
+
+    def fake_build_pipeline(**kwargs: Any) -> SimpleNamespace:
+        captured_args.update(kwargs)
+        return pipeline
+
+    monkeypatch.setattr(run_daily_trend, "build_daily_trend_pipeline", fake_build_pipeline)
+
+    trading_controller = SimpleNamespace(
+        maybe_report_health=lambda: None,
+        process_signals=lambda signals: [],
+    )
+
+    monkeypatch.setattr(
+        run_daily_trend,
+        "create_trading_controller",
+        lambda pipeline_arg, alert_router, **kwargs: trading_controller,
+    )
+
+    captured_runner: dict[str, Any] = {}
+
+    class DummyRunner:
+        def __init__(
+            self,
+            *,
+            controller: Any,
+            trading_controller: Any,
+            history_bars: int,
+            clock=None,
+        ) -> None:
+            captured_runner.update(
+                {
+                    "controller": controller,
+                    "trading_controller": trading_controller,
+                    "history_bars": history_bars,
+                    "clock": clock,
+                }
+            )
+
+        def run_once(self) -> list[OrderResult]:
+            now = captured_runner["clock"]()
+            captured_runner["now"] = now
+            controller = captured_runner["controller"]
+            tick_ms_local = int(getattr(controller, "tick_seconds", 86400.0) * 1000)
+            history = int(captured_runner["history_bars"])
+            end_ms_local = int(now.timestamp() * 1000)
+            start_ms_local = max(0, end_ms_local - history * tick_ms_local)
+            controller.collect_signals(start=start_ms_local, end=end_ms_local)
+            return []
+
+    monkeypatch.setattr(run_daily_trend, "DailyTrendRealtimeRunner", DummyRunner)
+
+    report_dir = tmp_path / "smoke"
+
+    def fake_mkdtemp(*_args: Any, **_kwargs: Any) -> str:
+        report_dir.mkdir(parents=True, exist_ok=True)
+        return str(report_dir)
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    def fake_export_smoke_report(
+        *,
+        report_dir: Path,
+        results: Iterable[Any],
+        ledger: Iterable[Mapping[str, Any]],
+        window: Mapping[str, str],
+        environment: str,
+        alert_snapshot: Mapping[str, Mapping[str, str]],
+        risk_state: Mapping[str, object] | None,
+        data_checks: Mapping[str, object] | None = None,
+    ) -> Path:
+        ledger_path = report_dir / "ledger.jsonl"
+        ledger_path.write_text("", encoding="utf-8")
+        summary = {
+            "environment": environment,
+            "window": dict(window),
+            "orders": [
+                {
+                    "order_id": "OID-1",
+                    "status": "filled",
+                    "filled_quantity": "0.10",
+                    "avg_price": "45000",
+                }
+            ],
+            "ledger_entries": len(list(ledger)),
+            "alert_snapshot": alert_snapshot,
+            "risk_state": dict(risk_state or {}),
+        }
+        if data_checks is not None:
+            summary["data_checks"] = json.loads(json.dumps(data_checks))
+        summary_path = report_dir / "summary.json"
+        summary_path.write_text(json.dumps(summary), encoding="utf-8")
+        return summary_path
+
+    monkeypatch.setattr(run_daily_trend, "_export_smoke_report", fake_export_smoke_report)
+
+    caplog.set_level("INFO")
+
+    exit_code = run_daily_trend.main(
+        [
+            "--config",
+            "config/core.yaml",
+            "--environment",
+            "binance_paper",
+            "--paper-smoke",
+            "--archive-smoke",
+            "--date-window",
+            "2024-01-01:2024-02-15",
+        ]
+    )
+
+    assert exit_code == 0
+    assert "adapter_factories" in captured_args
+    assert "binance_spot" in captured_args["adapter_factories"]
+
+    end_dt = datetime.fromisoformat("2024-02-15T23:59:59.999000+00:00")
+    start_dt = datetime.fromisoformat("2024-01-01T00:00:00+00:00")
+    start_ms = int(start_dt.timestamp() * 1000)
+    end_ms = int(end_dt.timestamp() * 1000)
+    tick_ms = int(pipeline.controller.tick_seconds * 1000)
+    window_duration_ms = max(0, end_ms - start_ms)
+    approx_bars = max(1, int(window_duration_ms / tick_ms) + 1)
+    expected_history = max(1, min(180, approx_bars))
+    expected_runner_start = max(0, end_ms - expected_history * tick_ms)
+
+    assert captured_runner["history_bars"] == expected_history
+    assert captured_runner["now"] == end_dt
+
+    assert sync_calls
+    assert sync_calls[0]["start"] == min(start_ms, expected_runner_start)
+    assert sync_calls[0]["end"] == end_ms
+
+    assert collected_calls
+    assert collected_calls[0]["start"] == expected_runner_start
+    assert collected_calls[0]["end"] >= end_ms
+
+    assert dispatch_calls, "Kanał alertów powinien otrzymać powiadomienie smoke"
+    summary_bytes = (report_dir / "summary.json").read_bytes()
+    summary_payload = json.loads(summary_bytes.decode("utf-8"))
+    expected_hash = hashlib.sha256(summary_bytes).hexdigest()
+    alert_context = getattr(dispatch_calls[0], "context")
+    assert alert_context["summary_sha256"] == expected_hash
+    assert alert_context["summary_text_path"] == str(report_dir / "summary.txt")
+    assert alert_context["readme_path"] == str(report_dir / "README.txt")
+
+    data_checks = summary_payload.get("data_checks")
+    assert data_checks, "summary.json powinno zawierać sekcję data_checks"
+    cache_info = data_checks.get("cache", {})
+    assert "BTCUSDT" in cache_info
+    cache_entry = cache_info["BTCUSDT"]
+    assert int(cache_entry["required_bars"]) >= expected_history
+    assert int(cache_entry["row_count"]) >= expected_history
+
+    summary_txt = (report_dir / "summary.txt").read_text(encoding="utf-8")
+    assert "Zakres dat" in summary_txt
+    assert "SHA-256 summary.json" in summary_txt
+    assert "Cache offline:" in summary_txt
+
+    readme_txt = (report_dir / "README.txt").read_text(encoding="utf-8")
+    assert "Daily Trend – smoke test" in readme_txt
+
+    archive_path = report_dir.with_suffix(".zip")
+    assert archive_path.exists()
+    assert alert_context["archive_path"] == str(archive_path)
+    assert alert_context["archive_upload_backend"] == "local"
+    upload_location = alert_context["archive_upload_location"]
+    assert upload_location.endswith(".zip")
+    uploaded_files = list(archive_store.glob("*.zip"))
+    assert uploaded_files, "Archiwum powinno zostać skopiowane do magazynu lokalnego"
+    assert uploaded_files[0].name in upload_location
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        names = set(archive.namelist())
+    assert {"summary.json", "summary.txt", "ledger.jsonl", "README.txt"}.issubset(names)
+
+    log_messages = [record.message for record in caplog.records if "Podsumowanie smoke testu" in record.message]
+    assert log_messages
+    joined_log = "\n".join(log_messages)
+    assert "Środowisko: binance_paper" in joined_log
+    assert "Alerty:" in joined_log
+
+
+def test_paper_smoke_requires_seeded_cache(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from scripts import run_daily_trend
+
+    caplog.set_level("ERROR")
+
+    class DummyController:
+        symbols = ("BTCUSDT",)
+        interval = "1d"
+        tick_seconds = 86400.0
+
+        def collect_signals(self, *, start: int, end: int) -> list[Any]:  # pragma: no cover - nie powinno zostać wywołane
+            raise AssertionError("collect_signals nie powinno być wywołane przy braku cache")
+
+    class DummyBackfill:
+        def __init__(self) -> None:
+            self.called = False
+
+        def synchronize(self, **kwargs: Any) -> None:  # pragma: no cover - nie powinno zostać wywołane
+            self.called = True
+            raise AssertionError("backfill nie powinien być wywołany przy braku cache")
+
+    class DummyExecutionService:
+        def ledger(self) -> list[dict[str, Any]]:  # pragma: no cover - nie powinno zostać wywołane
+            raise AssertionError("ledger nie powinien być odczytany")
+
+    class EmptyStorage:
+        def metadata(self) -> dict[str, str]:
+            return {}
+
+        def read(self, key: str) -> dict[str, Any]:
+            raise KeyError(key)
+
+    class DummyAlertRouter:
+        def dispatch(self, message: Any) -> None:  # pragma: no cover - nie powinno zostać wywołane
+            raise AssertionError("dispatch nie powinien być wywołany")
+
+        def health_snapshot(self) -> dict[str, Any]:  # pragma: no cover - nie powinno zostać wywołane
+            return {}
+
+    environment_cfg = SimpleNamespace(environment=Environment.PAPER, risk_profile="balanced")
+    pipeline = SimpleNamespace(
+        controller=DummyController(),
+        backfill_service=DummyBackfill(),
+        execution_service=DummyExecutionService(),
+        bootstrap=SimpleNamespace(environment=environment_cfg, alert_router=DummyAlertRouter()),
+        data_source=SimpleNamespace(storage=EmptyStorage()),
+        strategy_name="core_daily_trend",
+        controller_name="daily_trend_core",
+    )
+
+    def fake_build_pipeline(**kwargs: Any) -> SimpleNamespace:
+        assert kwargs["environment_name"] == "binance_paper"
+        return pipeline
+
+    monkeypatch.setattr(run_daily_trend, "build_daily_trend_pipeline", fake_build_pipeline)
+    monkeypatch.setattr(
+        run_daily_trend,
+        "create_trading_controller",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("create_trading_controller nie powinien być wywołany")),
+    )
+    monkeypatch.setattr(
+        run_daily_trend,
+        "DailyTrendRealtimeRunner",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("runner nie powinien być uruchomiony")),
+    )
+
+    exit_code = run_daily_trend.main(
+        [
+            "--config",
+            "config/core.yaml",
+            "--environment",
+            "binance_paper",
+            "--paper-smoke",
+            "--date-window",
+            "2024-01-01:2024-02-15",
+        ]
+    )
+
+    assert exit_code == 1
+    assert any("Cache offline" in record.message for record in caplog.records)
+
+
+def test_paper_smoke_manifest_gap_blocks_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from scripts import run_daily_trend
+
+    caplog.set_level("ERROR")
+
+    end_dt = datetime(2024, 2, 15, 23, 59, 59, 999000, tzinfo=timezone.utc)
+    end_ms = int(end_dt.timestamp() * 1000)
+
+    class DummyController:
+        symbols = ("BTCUSDT",)
+        interval = "1d"
+        tick_seconds = 86400.0
+
+        def collect_signals(self, *, start: int, end: int) -> list[Any]:  # pragma: no cover
+            raise AssertionError("collect_signals nie powinno być wywołane przy błędzie manifestu")
+
+    class DummyBackfill:
+        def synchronize(self, **kwargs: Any) -> None:  # pragma: no cover
+            raise AssertionError("Backfill nie powinien zostać uruchomiony przy błędzie manifestu")
+
+    class DummyExecutionService:
+        def ledger(self) -> list[dict[str, Any]]:  # pragma: no cover
+            raise AssertionError("Ledger nie powinien być odczytany")
+
+    class DummyStorage:
+        def metadata(self) -> dict[str, str]:
+            return {}
+
+        def read(self, key: str) -> dict[str, Any]:  # pragma: no cover
+            raise AssertionError("Odczyt danych nie powinien następować przy błędzie manifestu")
+
+    class DummyAlertRouter:
+        def dispatch(self, message: Any) -> None:  # pragma: no cover
+            raise AssertionError("Alert nie powinien zostać wysłany")
+
+        def health_snapshot(self) -> dict[str, Any]:  # pragma: no cover
+            return {}
+
+    instrument = InstrumentConfig(
+        name="BTC",
+        base_asset="BTC",
+        quote_asset="USDT",
+        categories=("majors",),
+        exchange_symbols={"binance_spot": "BTCUSDT"},
+        backfill_windows=(InstrumentBackfillWindow(interval="1d", lookback_days=90),),
+    )
+    universe = InstrumentUniverseConfig(
+        name="paper_universe",
+        description="test",
+        instruments=(instrument,),
+    )
+
+    core_config = SimpleNamespace(instrument_universes={"paper_universe": universe})
+
+    manifest_path = tmp_path / "ohlcv_manifest.sqlite"
+    connection = sqlite3.connect(manifest_path)
+    try:
+        connection.execute("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        insufficient_rows = 5
+        last_ts = end_ms - int(DummyController.tick_seconds * 1000) * 2
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES (?, ?)",
+            ("row_count::BTCUSDT::1d", str(insufficient_rows)),
+        )
+        connection.execute(
+            "INSERT INTO metadata(key, value) VALUES (?, ?)",
+            ("last_timestamp::BTCUSDT::1d", str(last_ts)),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    environment_cfg = SimpleNamespace(
+        environment=Environment.PAPER,
+        risk_profile="balanced",
+        instrument_universe="paper_universe",
+        data_cache_path=str(tmp_path),
+        exchange="binance_spot",
+    )
+
+    pipeline = SimpleNamespace(
+        controller=DummyController(),
+        backfill_service=DummyBackfill(),
+        execution_service=DummyExecutionService(),
+        bootstrap=SimpleNamespace(
+            environment=environment_cfg,
+            alert_router=DummyAlertRouter(),
+            core_config=core_config,
+        ),
+        data_source=SimpleNamespace(storage=DummyStorage()),
+        strategy_name="core_daily_trend",
+        controller_name="daily_trend_core",
+    )
+
+    def fake_build_pipeline(**kwargs: Any) -> SimpleNamespace:
+        assert kwargs["environment_name"] == "binance_paper"
+        return pipeline
+
+    monkeypatch.setattr(run_daily_trend, "build_daily_trend_pipeline", fake_build_pipeline)
+    monkeypatch.setattr(
+        run_daily_trend,
+        "create_trading_controller",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("controller nie powinien być tworzony")),
+    )
+    monkeypatch.setattr(
+        run_daily_trend,
+        "DailyTrendRealtimeRunner",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("runner nie powinien być uruchomiony")),
+    )
+
+    exit_code = run_daily_trend.main(
+        [
+            "--config",
+            "config/core.yaml",
+            "--environment",
+            "binance_paper",
+            "--paper-smoke",
+            "--date-window",
+            "2024-01-01:2024-02-15",
+        ]
+    )
+
+    assert exit_code == 1
+    assert any("Manifest danych OHLCV" in record.message for record in caplog.records)
+
+
+def test_render_smoke_summary_formats_alerts() -> None:
+    from scripts import run_daily_trend
+
+    summary = {
+        "environment": "binance_paper",
+        "window": {"start": "2024-01-01T00:00:00+00:00", "end": "2024-02-01T23:59:59+00:00"},
+        "orders": [
+            {"order_id": "O1", "status": "filled", "filled_quantity": "0.1", "avg_price": "42000"},
+            {"order_id": "O2", "status": "cancelled", "filled_quantity": "0.0", "avg_price": None},
+        ],
+        "ledger_entries": 3,
+        "alert_snapshot": {
+            "telegram": {"status": "ok"},
+            "email": {"status": "warn", "detail": "DNS failure"},
+        },
+    }
+
+    rendered = run_daily_trend._render_smoke_summary(summary=summary, summary_sha256="deadbeef")
+
+    assert "Środowisko: binance_paper" in rendered
+    assert "Zakres dat: 2024-01-01T00:00:00+00:00 → 2024-02-01T23:59:59+00:00" in rendered
+    assert "Liczba zleceń: 2" in rendered
+    assert "Liczba wpisów w ledgerze: 3" in rendered
+    assert "telegram: OK" in rendered
+    assert "email: WARN (DNS failure)" in rendered
+    assert rendered.endswith("SHA-256 summary.json: deadbeef")
+
+
+def test_export_smoke_report_includes_metrics(tmp_path: Path) -> None:
+    from scripts import run_daily_trend
+
+    report_dir = tmp_path / "report"
+    window = {
+        "start": "2024-01-01T00:00:00+00:00",
+        "end": "2024-01-08T23:59:59+00:00",
+    }
+
+    results = [
+        OrderResult(
+            order_id="OID-1",
+            status="filled",
+            filled_quantity=0.1,
+            avg_price=40000.0,
+            raw_response={},
+        ),
+        OrderResult(
+            order_id="OID-2",
+            status="filled",
+            filled_quantity=0.1,
+            avg_price=42000.0,
+            raw_response={},
+        ),
+    ]
+
+    ledger = [
+        {
+            "timestamp": 1704067200.0,
+            "order_id": "OID-1",
+            "symbol": "BTCUSDT",
+            "side": "buy",
+            "quantity": 0.1,
+            "price": 40000.0,
+            "fee": 1.2,
+            "fee_asset": "USDT",
+            "status": "filled",
+            "leverage": 1.0,
+            "position_value": 4000.0,
+        },
+        {
+            "timestamp": 1704672000.0,
+            "order_id": "OID-2",
+            "symbol": "BTCUSDT",
+            "side": "sell",
+            "quantity": 0.1,
+            "price": 42000.0,
+            "fee": 1.1,
+            "fee_asset": "USDT",
+            "status": "filled",
+            "leverage": 1.0,
+            "position_value": 0.0,
+        },
+    ]
+
+    risk_state = {
+        "profile": "balanced",
+        "active_positions": 1,
+        "gross_notional": 4_200.0,
+        "daily_loss_pct": 0.01,
+        "drawdown_pct": 0.02,
+        "force_liquidation": False,
+        "limits": {
+            "max_positions": 5,
+            "max_leverage": 3.0,
+            "daily_loss_limit": 0.5,
+            "drawdown_limit": 0.1,
+            "max_position_pct": 0.25,
+            "target_volatility": 0.12,
+            "stop_loss_atr_multiple": 2.5,
+        },
+    }
+
+    summary_path = run_daily_trend._export_smoke_report(
+        report_dir=report_dir,
+        results=results,
+        ledger=ledger,
+        window=window,
+        environment="binance_paper",
+        alert_snapshot={"telegram": {"status": "ok"}},
+        risk_state=risk_state,
+    )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    metrics = summary["metrics"]
+
+    assert metrics["side_counts"]["buy"] == 1
+    assert metrics["side_counts"]["sell"] == 1
+    assert metrics["notional"]["buy"] == pytest.approx(4000.0)
+    assert metrics["notional"]["sell"] == pytest.approx(4200.0)
+    assert metrics["notional"]["total"] == pytest.approx(8200.0)
+    assert metrics["total_fees"] == pytest.approx(2.3)
+    assert metrics["last_position_value"] == pytest.approx(0.0)
+    assert summary["risk_state"]["profile"] == "balanced"
+    assert summary["risk_state"]["active_positions"] == 1
+    assert summary["risk_state"]["gross_notional"] == pytest.approx(4_200.0)
+    assert summary["risk_state"]["limits"]["max_positions"] == 5
+
+    ledger_path = report_dir / "ledger.jsonl"
+    assert ledger_path.exists()
+    lines = [line for line in ledger_path.read_text(encoding="utf-8").splitlines() if line]
+    assert len(lines) == 2
+
+
+def test_export_smoke_report_serializes_data_checks(tmp_path: Path) -> None:
+    from scripts import run_daily_trend
+
+    report_dir = tmp_path / "report_data"
+    window = {"start": "2024-03-01T00:00:00+00:00", "end": "2024-03-02T23:59:59+00:00"}
+    data_checks = {
+        "interval": "1d",
+        "cache": {
+            "BTCUSDT": {
+                "coverage_bars": 3,
+                "required_bars": 3,
+                "row_count": 4,
+            }
+        },
+    }
+
+    summary_path = run_daily_trend._export_smoke_report(
+        report_dir=report_dir,
+        results=[],
+        ledger=[],
+        window=window,
+        environment="binance_paper",
+        alert_snapshot={},
+        risk_state=None,
+        data_checks=data_checks,
+    )
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["data_checks"]["cache"]["BTCUSDT"]["row_count"] == 4
+    assert summary["data_checks"]["interval"] == "1d"
+
+
+def test_render_smoke_summary_with_metrics() -> None:
+    from scripts import run_daily_trend
+
+    summary = {
+        "environment": "binance_paper",
+        "window": {"start": "2024-01-01T00:00:00+00:00", "end": "2024-01-08T23:59:59+00:00"},
+        "orders": [],
+        "ledger_entries": 3,
+        "alert_snapshot": {},
+        "metrics": {
+            "side_counts": {"buy": 2, "sell": 1},
+            "notional": {"buy": 1234.5, "sell": 987.6, "total": 2222.1},
+            "total_fees": 0.987654,
+            "last_position_value": 4321.0,
+        },
+    }
+
+    text = run_daily_trend._render_smoke_summary(summary=summary, summary_sha256="abc123")
+
+    assert "Zlecenia BUY/SELL: 2/1" in text
+    assert "Wolumen BUY: 1 234.50 | SELL: 987.60 | Razem: 2 222.10" in text
+    assert "Łączne opłaty: 0.9877" in text
+    assert "Ostatnia wartość pozycji: 4 321.00" in text
+    assert "SHA-256 summary.json: abc123" in text
+
+
+def test_render_smoke_summary_includes_risk_state() -> None:
+    from scripts import run_daily_trend
+
+    summary = {
+        "environment": "binance_paper",
+        "window": {"start": "2024-01-01", "end": "2024-01-31"},
+        "orders": [],
+        "ledger_entries": 0,
+        "alert_snapshot": {"telegram": {"status": "ok"}},
+        "metrics": {},
+        "risk_state": {
+            "profile": "balanced",
+            "active_positions": 2,
+            "gross_notional": 12_500.0,
+            "daily_loss_pct": 0.0125,
+            "drawdown_pct": 0.034,
+            "force_liquidation": False,
+            "limits": {
+                "max_positions": 5,
+                "max_position_pct": 0.25,
+                "max_leverage": 3.0,
+                "daily_loss_limit": 0.05,
+                "drawdown_limit": 0.15,
+                "target_volatility": 0.12,
+                "stop_loss_atr_multiple": 2.5,
+            },
+        },
+    }
+
+    text = run_daily_trend._render_smoke_summary(summary=summary, summary_sha256="deadbeef")
+
+    assert "Profil ryzyka: balanced" in text
+    assert "Aktywne pozycje: 2 | Ekspozycja brutto: 12 500.00" in text
+    assert "Dzienna strata: 1.25% | Obsunięcie: 3.40%" in text
+    assert "Force liquidation: NIE" in text
+    assert "Limity: max pozycje 5" in text
+
+
+def test_render_smoke_summary_includes_data_checks() -> None:
+    from scripts import run_daily_trend
+
+    summary = {
+        "environment": "binance_paper",
+        "window": {"start": "2024-01-01", "end": "2024-01-31"},
+        "orders": [],
+        "ledger_entries": 0,
+        "alert_snapshot": {},
+        "data_checks": {
+            "manifest": {
+                "status": "ok",
+                "entries": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "interval": "1d",
+                        "issues": [],
+                        "row_count": 31,
+                        "required_rows": 31,
+                        "gap_minutes": 0,
+                        "last_timestamp_ms": 1706659199999,
+                        "last_timestamp_iso": "2024-01-31T23:59:59+00:00",
+                    }
+                ],
+            },
+            "cache": {
+                "BTCUSDT": {
+                    "coverage_bars": 31,
+                    "required_bars": 31,
+                    "row_count": 35,
+                }
+            },
+        },
+    }
+
+    text = run_daily_trend._render_smoke_summary(summary=summary, summary_sha256="feedbeef")
+
+    assert "Manifest OHLCV:" in text
+    assert "Cache offline:" in text
+    assert text.endswith("SHA-256 summary.json: feedbeef")

--- a/tests/test_seed_paper_cache.py
+++ b/tests/test_seed_paper_cache.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot_core.data.ohlcv import ParquetCacheStorage, SQLiteCacheStorage
+
+from scripts.seed_paper_cache import GeneratedSeries, generate_smoke_cache
+
+
+def _write_config(path: Path, data_path: Path) -> None:
+    path.write_text(
+        f"""
+risk_profiles:
+  balanced:
+    max_daily_loss_pct: 0.01
+    max_position_pct: 0.05
+    target_volatility: 0.1
+    max_leverage: 2.0
+    stop_loss_atr_multiple: 1.5
+    max_open_positions: 5
+    hard_drawdown_pct: 0.1
+
+instrument_universes:
+  test_universe:
+    description: smoke
+    instruments:
+      AAA_USDT:
+        base_asset: AAA
+        quote_asset: USDT
+        categories: []
+        exchanges:
+          binance_spot: AAAUSDT
+        backfill:
+          - interval: "1d"
+            lookback_days: 30
+      BBB_USDT:
+        base_asset: BBB
+        quote_asset: USDT
+        categories: []
+        exchanges:
+          binance_spot: BBBUSDT
+        backfill:
+          - interval: "1d"
+            lookback_days: 30
+
+environments:
+  test_env:
+    exchange: binance_spot
+    environment: paper
+    keychain_key: test
+    credential_purpose: trading
+    data_cache_path: {data_path!s}
+    risk_profile: balanced
+    alert_channels: []
+    ip_allowlist: []
+    required_permissions: [trade]
+    forbidden_permissions: []
+    instrument_universe: test_universe
+    adapter_settings:
+      paper_trading:
+        valuation_asset: USDT
+        position_size: 0.1
+        initial_balances:
+          USDT: 1000.0
+""",
+        encoding="utf-8",
+    )
+
+
+def test_generate_smoke_cache_writes_parquet_and_manifest(tmp_path):
+    data_path = tmp_path / "cache"
+    config_path = tmp_path / "core.yaml"
+    _write_config(config_path, data_path)
+
+    start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    results = generate_smoke_cache(
+        config_path=config_path,
+        environment_name="test_env",
+        interval="1d",
+        days=5,
+        start_date=start_date,
+        seed=42,
+    )
+
+    assert results
+    assert all(isinstance(entry, GeneratedSeries) for entry in results)
+    symbols = {entry.symbol for entry in results}
+    assert symbols == {"AAAUSDT", "BBBUSDT"}
+
+    parquet_storage = ParquetCacheStorage(data_path / "ohlcv_parquet", namespace="binance_spot")
+    manifest_storage = SQLiteCacheStorage(data_path / "ohlcv_manifest.sqlite", store_rows=False)
+
+    for entry in results:
+        payload = parquet_storage.read(f"{entry.symbol}::{entry.interval}")
+        rows = payload["rows"]
+        assert len(rows) == entry.candles
+        assert rows[0][0] == entry.start_timestamp
+        assert rows[-1][0] == entry.end_timestamp
+        key = f"row_count::{entry.symbol}::{entry.interval}"
+        metadata = manifest_storage.metadata()
+        assert metadata[key] == str(entry.candles)
+        last_key = f"last_timestamp::{entry.symbol}::{entry.interval}"
+        assert metadata[last_key] == str(entry.end_timestamp)

--- a/tests/test_validate_config_script.py
+++ b/tests/test_validate_config_script.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import validate_config
+
+
+_VALID_CONFIG = """
+risk_profiles:
+  balanced:
+    max_daily_loss_pct: 0.01
+    max_position_pct: 0.02
+    target_volatility: 0.06
+    max_leverage: 2.0
+    stop_loss_atr_multiple: 1.0
+    max_open_positions: 3
+    hard_drawdown_pct: 0.05
+
+alerts:
+  telegram_channels:
+    primary:
+      chat_id: "123"
+      token_secret: telegram_primary_token
+
+environments:
+  binance_paper:
+    exchange: binance_spot
+    environment: paper
+    keychain_key: binance_paper_trading
+    data_cache_path: ./var/data/binance_paper
+    risk_profile: balanced
+    alert_channels: ["telegram:primary"]
+    required_permissions: [read]
+    forbidden_permissions: [withdraw]
+"""
+
+
+_INVALID_CONFIG = """
+risk_profiles:
+  balanced:
+    max_daily_loss_pct: -0.1
+    max_position_pct: 0.02
+    target_volatility: 0.06
+    max_leverage: 2.0
+    stop_loss_atr_multiple: 1.0
+    max_open_positions: 3
+    hard_drawdown_pct: 0.05
+
+environments:
+  binance_paper:
+    exchange: binance_spot
+    environment: paper
+    keychain_key: binance_paper_trading
+    data_cache_path: ./var/data/binance_paper
+    risk_profile: unknown
+    alert_channels: ["telegram:primary"]
+    required_permissions: [read]
+    forbidden_permissions: [read]
+"""
+
+
+def _write_config(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(content)
+    return path
+
+
+def test_validate_config_script_returns_success_for_valid_config(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, _VALID_CONFIG)
+    exit_code = validate_config.main(["--config", str(config_path), "--json"])
+    assert exit_code == 0
+
+
+def test_validate_config_script_returns_error_for_invalid_config(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, _INVALID_CONFIG)
+    exit_code = validate_config.main(["--config", str(config_path)])
+    assert exit_code == 1


### PR DESCRIPTION
## Summary
- zapisuj wyniki weryfikacji manifestu i cache w sekcji `data_checks` eksportowanego raportu smoke oraz w podsumowaniu tekstowym, aby audyt otrzymywał pełny obraz pokrycia danych
- rozszerz kontrolę cache o zwracanie szczegółowych metryk i raport manifestu wykorzystywanych później w raporcie JSON
- zaktualizuj scenariusze CLI i testy jednostkowe tak, by weryfikowały obecność nowych informacji o danych oraz dodaj dedykowane testy serializacji `data_checks`

## Testing
- pytest --override-ini=addopts= tests/test_run_daily_trend_script.py

------
https://chatgpt.com/codex/tasks/task_e_68daff44fa8c832a9c7049b9af610f1d