### PR TITLE
Handle missing environment in legacy secret payloads

### DIFF
--- a/bot_core/security/base.py
+++ b/bot_core/security/base.py
@@ -80,7 +80,7 @@ class SecretManager:
             )
 
         try:
-            payload = self._deserialize(raw_value)
+            payload = self._deserialize(raw_value, expected_environment=expected_environment)
         except ValueError as exc:  # pragma: no cover - ochrona przed zepsutymi danymi
             raise SecretStorageError(
                 f"Sekret '{storage_key}' ma niepoprawny format – usuń go i zapisz ponownie."
@@ -183,7 +183,11 @@ class SecretManager:
         )
 
     @staticmethod
-    def _deserialize(raw_value: str) -> SecretPayload:
+    def _deserialize(
+        raw_value: str,
+        *,
+        expected_environment: Environment | None = None,
+    ) -> SecretPayload:
         import json
 
         data = json.loads(raw_value)
@@ -210,12 +214,16 @@ class SecretManager:
 
         environment_value = _first_present("environment", "env")
         if not environment_value:
-            raise ValueError("sekret nie zawiera pola 'environment'")
-
-        try:
-            environment = Environment(str(environment_value).lower())
-        except ValueError as exc:  # pragma: no cover - walidacja formatu
-            raise ValueError(f"nieobsługiwane środowisko w sekrecie: {environment_value}") from exc
+            if expected_environment is None:
+                raise ValueError("sekret nie zawiera pola 'environment'")
+            environment = expected_environment
+        else:
+            try:
+                environment = Environment(str(environment_value).lower())
+            except ValueError as exc:  # pragma: no cover - walidacja formatu
+                raise ValueError(
+                    f"nieobsługiwane środowisko w sekrecie: {environment_value}"
+                ) from exc
 
         return SecretPayload(
             key_id=str(key_id),

--- a/tests/test_security_manager_legacy.py
+++ b/tests/test_security_manager_legacy.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from bot_core.exchanges.base import Environment
-from bot_core.security.base import SecretManager, SecretStorage, SecretStorageError
+from bot_core.security.base import SecretManager, SecretStorage
 
 
 class _StubStorage(SecretStorage):
@@ -68,11 +66,12 @@ def test_load_exchange_credentials_supports_keyid_alias() -> None:
     assert creds.secret == "sekret"
 
 
-def test_load_exchange_credentials_missing_environment_raises() -> None:
+def test_load_exchange_credentials_missing_environment_defaults_to_expected() -> None:
     manager = _manager_with({"api_key": "abc"})
 
-    with pytest.raises(SecretStorageError):
-        manager.load_exchange_credentials(
-            "binance_paper_trading",
-            expected_environment=Environment.PAPER,
-        )
+    creds = manager.load_exchange_credentials(
+        "binance_paper_trading",
+        expected_environment=Environment.PAPER,
+    )
+
+    assert creds.environment is Environment.PAPER


### PR DESCRIPTION
## Summary
- allow `SecretManager._deserialize` to default the environment to the expected value when legacy secrets omit it
- extend the legacy security manager tests to cover secrets without an environment field

## Testing
- PYTHONPATH=. pytest tests/test_security_manager_legacy.py


------
https://chatgpt.com/codex/tasks/task_e_68e11ef2e768832aa5aceeedb7280f0b