### PR TITLE
Handle legacy secrets missing environment

### DIFF
--- a/bot_core/security/base.py
+++ b/bot_core/security/base.py
@@ -213,17 +213,23 @@ class SecretManager:
             permissions = data.get("scopes")
 
         environment_value = _first_present("environment", "env")
-        if not environment_value:
+
+        environment: Environment | None = None
+        if environment_value not in (None, ""):
+            if isinstance(environment_value, Environment):
+                environment = environment_value
+            else:
+                try:
+                    environment = Environment(str(environment_value).lower())
+                except ValueError as exc:  # pragma: no cover - walidacja formatu
+                    raise ValueError(
+                        f"nieobsługiwane środowisko w sekrecie: {environment_value}"
+                    ) from exc
+
+        if environment is None:
             if expected_environment is None:
                 raise ValueError("sekret nie zawiera pola 'environment'")
             environment = expected_environment
-        else:
-            try:
-                environment = Environment(str(environment_value).lower())
-            except ValueError as exc:  # pragma: no cover - walidacja formatu
-                raise ValueError(
-                    f"nieobsługiwane środowisko w sekrecie: {environment_value}"
-                ) from exc
 
         return SecretPayload(
             key_id=str(key_id),

--- a/tests/test_security_manager_legacy.py
+++ b/tests/test_security_manager_legacy.py
@@ -67,11 +67,20 @@ def test_load_exchange_credentials_supports_keyid_alias() -> None:
 
 
 def test_load_exchange_credentials_missing_environment_defaults_to_expected() -> None:
-    manager = _manager_with({"api_key": "abc"})
+    manager = _manager_with(
+        {
+            "api_key": "legacy-key",
+            "api_secret": "legacy-secret",
+            "permissions": ["TRADE"],
+        }
+    )
 
     creds = manager.load_exchange_credentials(
         "binance_paper_trading",
         expected_environment=Environment.PAPER,
     )
 
+    assert creds.key_id == "legacy-key"
+    assert creds.secret == "legacy-secret"
+    assert creds.permissions == ("trade",)
     assert creds.environment is Environment.PAPER


### PR DESCRIPTION
## Summary
- fall back to the expected environment when deserializing secrets that omit the environment field
- keep load_exchange_credentials forwarding the expected environment into the deserializer
- extend the legacy secret tests to cover entries missing the environment field

## Testing
- PYTHONPATH=. pytest --override-ini=addopts= tests/test_security_manager_legacy.py


------
https://chatgpt.com/codex/tasks/task_e_68e120494c78832a845bf25678d1af56