### PR TITLE
Fix default environment handling for legacy secrets

### DIFF
--- a/bot_core/security/base.py
+++ b/bot_core/security/base.py
@@ -79,10 +79,12 @@ class SecretManager:
                 f"Brak sekretu '{storage_key}'. Dodaj klucze przy użyciu narzędzia konfiguracyjnego."
             )
 
+        environment = expected_environment
+
         try:
             payload = self._deserialize(
                 raw_value,
-                expected_environment=expected_environment,
+                expected_environment=environment,
             )
         except ValueError as exc:  # pragma: no cover - ochrona przed zepsutymi danymi
             raise SecretStorageError(
@@ -228,10 +230,11 @@ class SecretManager:
                     raise ValueError(
                         f"nieobsługiwane środowisko w sekrecie: {environment_value}"
                     ) from exc
-        elif expected_environment is not None:
+
+        if environment is None:
+            if expected_environment is None:
+                raise ValueError("sekret nie zawiera pola 'environment'")
             environment = expected_environment
-        else:
-            raise ValueError("sekret nie zawiera pola 'environment'")
 
         return SecretPayload(
             key_id=str(key_id),

--- a/tests/test_security_manager_legacy.py
+++ b/tests/test_security_manager_legacy.py
@@ -85,3 +85,23 @@ def test_load_exchange_credentials_missing_environment_defaults_to_expected() ->
     assert creds.secret == "legacy-secret"
     assert creds.permissions == ("trade",)
     assert creds.environment is Environment.PAPER
+
+
+def test_load_exchange_credentials_missing_environment_defaults_to_expected_live() -> None:
+    manager = _manager_with(
+        {
+            "key_id": "live-id",
+            "secret": "sekret-live",
+            "permissions": ["withdraw"],
+        }
+    )
+
+    creds = manager.load_exchange_credentials(
+        "binance_live_trading",
+        expected_environment=Environment.LIVE,
+    )
+
+    assert creds.key_id == "live-id"
+    assert creds.secret == "sekret-live"
+    assert creds.permissions == ("withdraw",)
+    assert creds.environment is Environment.LIVE


### PR DESCRIPTION
## Summary
- ensure `SecretManager.load_exchange_credentials` forwards the expected environment to the deserializer
- let the deserializer fall back to the provided environment when the field is missing
- add regression coverage for loading legacy secrets without an explicit environment

## Testing
- PYTHONPATH=. pytest --override-ini addopts= tests/test_security_manager_legacy.py

------
https://chatgpt.com/codex/tasks/task_e_68e124e4cd88832a9f5c498f22ebad61