### PR TITLE
Enforce data-quality thresholds in coverage CLI

### DIFF
--- a/bot_core/alerts/__init__.py
+++ b/bot_core/alerts/__init__.py
@@ -16,6 +16,7 @@ from bot_core.alerts.channels import (
     TelegramChannel,
     get_sms_provider,
 )
+from bot_core.alerts.coverage import build_coverage_alert_context
 from bot_core.alerts.router import DefaultAlertRouter
 from bot_core.alerts.throttle import AlertThrottle
 
@@ -43,6 +44,7 @@ __all__ = [
     "AlertDeliveryError",
     "AlertMessage",
     "AlertRouter",
+    "build_coverage_alert_context",
     "DefaultAlertRouter",
     "AlertThrottle",
     "EmailChannel",

--- a/bot_core/alerts/coverage.py
+++ b/bot_core/alerts/coverage.py
@@ -1,0 +1,105 @@
+"""Pomocnicze funkcje do budowy kontekstu alertów dla jakości danych."""
+from __future__ import annotations
+
+import json
+from typing import Mapping, Sequence
+
+from bot_core.data.ohlcv import CoverageSummary, coerce_summary_mapping
+from bot_core.data.ohlcv.coverage_check import SummaryThresholdResult
+
+
+def _format_float(value: float, *, precision: int = 4) -> str:
+    return f"{value:.{precision}f}"
+
+
+def build_coverage_alert_context(
+    *,
+    summary: CoverageSummary | Mapping[str, object] | None,
+    threshold_result: SummaryThresholdResult | Mapping[str, object] | None = None,
+    extra_issues: Sequence[str] | None = None,
+) -> dict[str, str]:
+    """Serializuje zagregowane metryki pokrycia do kontekstu alertu."""
+
+    normalized = coerce_summary_mapping(summary)
+    context: dict[str, str] = {
+        "summary": json.dumps(normalized, ensure_ascii=False),
+        "summary_status": str(normalized.get("status")),
+        "summary_total": str(normalized.get("total")),
+        "summary_ok": str(normalized.get("ok")),
+        "summary_warning": str(normalized.get("warning")),
+        "summary_error": str(normalized.get("error")),
+        "summary_stale_entries": str(normalized.get("stale_entries")),
+    }
+
+    ok_ratio = normalized.get("ok_ratio")
+    if isinstance(ok_ratio, (int, float)):
+        context["summary_ok_ratio"] = _format_float(float(ok_ratio))
+    else:
+        try:
+            context["summary_ok_ratio"] = _format_float(float(ok_ratio))
+        except (TypeError, ValueError):
+            context["summary_ok_ratio"] = "n/a"
+
+    worst_gap = normalized.get("worst_gap")
+    if isinstance(worst_gap, Mapping):
+        symbol = worst_gap.get("symbol")
+        interval = worst_gap.get("interval")
+        gap_value = worst_gap.get("gap_minutes")
+        if symbol is not None:
+            context["summary_worst_gap_symbol"] = str(symbol)
+        if interval is not None:
+            context["summary_worst_gap_interval"] = str(interval)
+        if gap_value is not None:
+            try:
+                context["summary_worst_gap_minutes"] = _format_float(float(gap_value))
+            except (TypeError, ValueError):
+                context["summary_worst_gap_minutes"] = str(gap_value)
+        else:
+            context["summary_worst_gap_minutes"] = "n/a"
+    else:
+        context["summary_worst_gap_minutes"] = "n/a"
+
+    threshold_mapping: Mapping[str, object] | None = None
+    if isinstance(threshold_result, SummaryThresholdResult):
+        threshold_mapping = threshold_result.to_mapping()
+    elif isinstance(threshold_result, Mapping):
+        threshold_mapping = threshold_result
+
+    if threshold_mapping is not None:
+        thresholds = threshold_mapping.get("thresholds") or {}
+        if isinstance(thresholds, Mapping) and thresholds:
+            normalized_thresholds: dict[str, float] = {}
+            for key, value in thresholds.items():
+                try:
+                    normalized_thresholds[key] = float(value)
+                except (TypeError, ValueError):
+                    continue
+            if normalized_thresholds:
+                context["thresholds"] = json.dumps(normalized_thresholds, ensure_ascii=False)
+                for key, value in normalized_thresholds.items():
+                    precision = 4 if key == "min_ok_ratio" else 2
+                    context[f"threshold_{key}"] = _format_float(value, precision=precision)
+
+        issues = threshold_mapping.get("issues") or ()
+        if isinstance(issues, Sequence) and issues:
+            context["threshold_issues"] = json.dumps(list(issues), ensure_ascii=False)
+
+        observed = threshold_mapping.get("observed") or {}
+        if isinstance(observed, Mapping):
+            for key, value in observed.items():
+                if value is None:
+                    continue
+                try:
+                    numeric = float(value)
+                except (TypeError, ValueError):
+                    continue
+                precision = 4 if key in {"ok_ratio"} else 2
+                context[f"observed_{key}"] = _format_float(numeric, precision=precision)
+
+    if extra_issues:
+        context["additional_issues"] = json.dumps(list(extra_issues), ensure_ascii=False)
+
+    return context
+
+
+__all__ = ["build_coverage_alert_context"]

--- a/bot_core/config/models.py
+++ b/bot_core/config/models.py
@@ -68,6 +68,7 @@ class EnvironmentConfig:
     forbidden_permissions: Sequence[str] = field(default_factory=tuple)
     alert_throttle: AlertThrottleConfig | None = None
     alert_audit: AlertAuditConfig | None = None
+    data_quality: EnvironmentDataQualityConfig | None = None
     decision_journal: DecisionJournalConfig | None = None
     default_strategy: str | None = None
     default_controller: str | None = None

--- a/bot_core/data/ohlcv/__init__.py
+++ b/bot_core/data/ohlcv/__init__.py
@@ -5,7 +5,12 @@ from bot_core.data.ohlcv.backfill import BackfillSummary, OHLCVBackfillService
 from bot_core.data.ohlcv.cache import CachedOHLCVSource, PublicAPIDataSource
 from bot_core.data.ohlcv.coverage_check import (
     CoverageStatus,
+    CoverageSummary,
+    SummaryThresholdResult,
+    coerce_summary_mapping,
     evaluate_coverage,
+    evaluate_summary_thresholds,
+    summarize_coverage,
     summarize_issues,
 )
 from bot_core.data.ohlcv.gap_monitor import DataGapIncidentTracker, GapAlertPolicy
@@ -26,6 +31,9 @@ __all__ = [
     "JSONLGapAuditLogger",
     "CachedOHLCVSource",
     "CoverageStatus",
+    "CoverageSummary",
+    "SummaryThresholdResult",
+    "coerce_summary_mapping",
     "DataGapIncidentTracker",
     "GapAlertPolicy",
     "ManifestEntry",
@@ -34,6 +42,8 @@ __all__ = [
     "ParquetCacheStorage",
     "PublicAPIDataSource",
     "evaluate_coverage",
+    "evaluate_summary_thresholds",
+    "summarize_coverage",
     "generate_manifest_report",
     "summarize_status",
     "summarize_issues",

--- a/bot_core/data/ohlcv/coverage_check.py
+++ b/bot_core/data/ohlcv/coverage_check.py
@@ -1,9 +1,10 @@
 """Kontrola pokrycia danych OHLCV względem wymagań backfillu."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections import Counter
+from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime, timezone
-from math import ceil
+from math import ceil, isnan
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
@@ -24,6 +25,53 @@ class CoverageStatus:
     @property
     def status(self) -> str:
         return "ok" if not self.issues else "error"
+
+
+@dataclass(slots=True)
+class CoverageSummary:
+    """Zbiorcze metryki jakości manifestu danych OHLCV."""
+
+    total: int
+    ok: int
+    error: int
+    warning: int
+    manifest_status_counts: Mapping[str, int]
+    issue_counts: Mapping[str, int]
+    issue_examples: Mapping[str, str]
+    stale_entries: int
+    worst_gap: Mapping[str, object] | None
+
+    @property
+    def ok_ratio(self) -> float | None:
+        if self.total <= 0:
+            return None
+        return self.ok / self.total
+
+    @property
+    def status(self) -> str:
+        if self.error > 0:
+            return "error"
+        if self.warning > 0 or self.stale_entries > 0:
+            return "warning"
+        return "ok"
+
+    def to_mapping(self) -> dict[str, object]:
+        """Reprezentacja słownikowa używana przez raporty i CLI."""
+
+        payload: dict[str, object] = {
+            "status": self.status,
+            "total": self.total,
+            "ok": self.ok,
+            "warning": self.warning,
+            "error": self.error,
+            "ok_ratio": self.ok_ratio,
+            "manifest_status_counts": dict(self.manifest_status_counts),
+            "issue_counts": dict(self.issue_counts),
+            "issue_examples": dict(self.issue_examples),
+            "stale_entries": self.stale_entries,
+            "worst_gap": self.worst_gap,
+        }
+        return payload
 
 
 def _interval_minutes(interval: str) -> int:
@@ -132,4 +180,235 @@ def summarize_issues(statuses: Iterable[CoverageStatus]) -> list[str]:
     return issues
 
 
-__all__ = ["CoverageStatus", "evaluate_coverage", "summarize_issues"]
+def _issue_code(issue: object) -> str:
+    raw = str(issue)
+    prefix, _, _ = raw.partition(":")
+    return prefix or raw
+
+
+def _build_worst_gap(statuses: Sequence[CoverageStatus]) -> Mapping[str, object] | None:
+    worst: tuple[float, CoverageStatus] | None = None
+    for status in statuses:
+        entry = status.manifest_entry
+        gap = entry.gap_minutes
+        if gap is None:
+            continue
+        try:
+            gap_value = float(gap)
+        except (TypeError, ValueError):
+            continue
+        if isnan(gap_value):
+            continue
+        if worst is None or gap_value > worst[0]:
+            worst = (gap_value, status)
+
+    if worst is None:
+        return None
+
+    gap_value, status = worst
+    entry = status.manifest_entry
+    payload: dict[str, object] = {
+        "symbol": status.symbol,
+        "interval": status.interval,
+        "gap_minutes": gap_value,
+        "manifest_status": entry.status,
+    }
+    if entry.threshold_minutes is not None:
+        payload["threshold_minutes"] = int(entry.threshold_minutes)
+    if entry.last_timestamp_iso is not None:
+        payload["last_timestamp_iso"] = entry.last_timestamp_iso
+    return payload
+
+
+def summarize_coverage(statuses: Sequence[CoverageStatus]) -> CoverageSummary:
+    """Buduje zagregowane metryki przydatne w automatycznych pre-checkach."""
+
+    normalized = list(statuses)
+    total = len(normalized)
+
+    status_counts = Counter(status.status for status in normalized)
+    manifest_counts = Counter(status.manifest_entry.status for status in normalized)
+
+    issue_counts = Counter()
+    issue_examples: dict[str, str] = {}
+    stale_entries = 0
+
+    for status in normalized:
+        entry = status.manifest_entry
+        for issue in status.issues:
+            code = _issue_code(issue)
+            issue_counts[code] += 1
+            issue_examples.setdefault(code, str(issue))
+
+        gap = entry.gap_minutes
+        threshold = entry.threshold_minutes
+        if gap is not None and threshold is not None:
+            try:
+                gap_value = float(gap)
+                threshold_value = float(threshold)
+            except (TypeError, ValueError):
+                continue
+            if not isnan(gap_value) and gap_value >= threshold_value:
+                stale_entries += 1
+
+    ok = int(status_counts.get("ok", 0))
+    error = int(total - ok)
+    warning = int(manifest_counts.get("warning", 0))
+
+    worst_gap = _build_worst_gap(normalized)
+
+    summary = CoverageSummary(
+        total=total,
+        ok=ok,
+        error=error,
+        warning=warning,
+        manifest_status_counts=dict(manifest_counts),
+        issue_counts=dict(issue_counts),
+        issue_examples=issue_examples,
+        stale_entries=stale_entries,
+        worst_gap=worst_gap,
+    )
+    return summary
+
+
+@dataclass(slots=True)
+class SummaryThresholdResult:
+    """Opisuje wynik porównania podsumowania z progami jakości."""
+
+    issues: tuple[str, ...]
+    thresholds: Mapping[str, float]
+    observed: Mapping[str, float | None]
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "issues": list(self.issues),
+            "thresholds": dict(self.thresholds),
+            "observed": dict(self.observed),
+        }
+
+
+def _coerce_float(value: object | None) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)  # type: ignore[return-value]
+    except (TypeError, ValueError):
+        return None
+
+
+def evaluate_summary_thresholds(
+    summary: CoverageSummary | Mapping[str, object] | None,
+    *,
+    max_gap_minutes: float | None = None,
+    min_ok_ratio: float | None = None,
+) -> SummaryThresholdResult:
+    """Porównuje zagregowane metryki pokrycia z progami jakości."""
+
+    normalized = coerce_summary_mapping(summary)
+
+    thresholds: dict[str, float] = {}
+    observed: dict[str, float | None] = {}
+    issues: list[str] = []
+
+    if max_gap_minutes is not None:
+        try:
+            threshold_gap = float(max_gap_minutes)
+        except (TypeError, ValueError):
+            threshold_gap = None
+        if threshold_gap is not None:
+            thresholds["max_gap_minutes"] = threshold_gap
+            worst_gap = normalized.get("worst_gap")
+            gap_minutes = None
+            if isinstance(worst_gap, Mapping):
+                gap_minutes = _coerce_float(worst_gap.get("gap_minutes"))
+            observed["worst_gap_minutes"] = gap_minutes
+            if gap_minutes is not None and gap_minutes > threshold_gap:
+                issues.append(f"max_gap_exceeded:{gap_minutes}>{threshold_gap}")
+
+    ok_ratio_value = _coerce_float(normalized.get("ok_ratio"))
+    observed["ok_ratio"] = ok_ratio_value
+    total_entries = _coerce_float(normalized.get("total"))
+    if total_entries is not None:
+        observed.setdefault("total_entries", total_entries)
+
+    if min_ok_ratio is not None:
+        try:
+            threshold_ratio = float(min_ok_ratio)
+        except (TypeError, ValueError):
+            threshold_ratio = None
+        if threshold_ratio is not None:
+            thresholds["min_ok_ratio"] = threshold_ratio
+            if ok_ratio_value is not None and ok_ratio_value < threshold_ratio:
+                issues.append(
+                    f"ok_ratio_below_threshold:{ok_ratio_value:.4f}<{threshold_ratio:.4f}"
+                )
+            elif ok_ratio_value is None and threshold_ratio > 0:
+                if total_entries is not None and total_entries <= 0:
+                    issues.append("manifest_empty_for_threshold")
+
+    return SummaryThresholdResult(
+        issues=tuple(issues),
+        thresholds=thresholds,
+        observed=observed,
+    )
+
+
+def coerce_summary_mapping(
+    summary: CoverageSummary | Mapping[str, object] | None,
+) -> dict[str, object]:
+    """Normalizuje wynik `summarize_coverage` do słownika z kompletem pól."""
+
+    defaults: dict[str, object] = {
+        "status": "unknown",
+        "total": 0,
+        "ok": 0,
+        "warning": 0,
+        "error": 0,
+        "ok_ratio": None,
+        "manifest_status_counts": {},
+        "issue_counts": {},
+        "issue_examples": {},
+        "stale_entries": 0,
+        "worst_gap": None,
+    }
+
+    if summary is None:
+        return dict(defaults)
+
+    payload: Mapping[str, object] | dict[str, object] | None = None
+
+    if isinstance(summary, CoverageSummary):
+        payload = summary.to_mapping()
+    elif hasattr(summary, "to_mapping"):
+        try:
+            candidate = summary.to_mapping()  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - defensywne dla nietypowych implementacji
+            candidate = None
+        if isinstance(candidate, Mapping):
+            payload = candidate
+
+    if payload is None and is_dataclass(summary):
+        payload = asdict(summary)
+
+    if payload is None and isinstance(summary, Mapping):
+        payload = summary
+
+    if payload is None:
+        payload = {"status": getattr(summary, "status", defaults["status"])}
+
+    normalized = dict(payload)
+    for key, default in defaults.items():
+        normalized.setdefault(key, default)
+    return normalized
+
+
+__all__ = [
+    "CoverageStatus",
+    "CoverageSummary",
+    "SummaryThresholdResult",
+    "coerce_summary_mapping",
+    "evaluate_summary_thresholds",
+    "evaluate_coverage",
+    "summarize_coverage",
+    "summarize_issues",
+]

--- a/tests/test_backfill_cli.py
+++ b/tests/test_backfill_cli.py
@@ -8,11 +8,12 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from bot_core.config.loader import load_core_config
 from bot_core.config.models import (
+    EnvironmentDataQualityConfig,
     InstrumentBackfillWindow,
     InstrumentConfig,
     InstrumentUniverseConfig,
 )
-from bot_core.data.ohlcv import ManifestEntry, SQLiteCacheStorage
+from bot_core.data.ohlcv import CoverageStatus, ManifestEntry, SQLiteCacheStorage
 from bot_core.exchanges.base import Environment
 from bot_core.exchanges.binance.futures import BinanceFuturesAdapter
 from bot_core.exchanges.binance.spot import BinanceSpotAdapter
@@ -217,7 +218,7 @@ def test_report_manifest_health_does_not_alert_when_everything_ok(tmp_path):
 
     metadata = storage.metadata()
     metadata["last_timestamp::BTCUSDT::1h"] = str(int((as_of - timedelta(minutes=30)).timestamp() * 1000))
-    metadata["row_count::BTCUSDT::1h"] = "120"
+    metadata["row_count::BTCUSDT::1h"] = "720"
 
     backfill._report_manifest_health(
         manifest_path=manifest,
@@ -225,6 +226,7 @@ def test_report_manifest_health_does_not_alert_when_everything_ok(tmp_path):
         exchange_name="binance_spot",
         environment_name="binance_paper",
         alert_router=router,
+        data_quality=None,
         as_of=as_of,
     )
 
@@ -266,6 +268,7 @@ def test_report_manifest_health_emits_warning_for_long_gap(tmp_path):
         exchange_name="binance_spot",
         environment_name="binance_paper",
         alert_router=router,
+        data_quality=None,
         as_of=as_of,
     )
 
@@ -274,6 +277,36 @@ def test_report_manifest_health_emits_warning_for_long_gap(tmp_path):
     assert message.severity == "warning"
     assert "BTCUSDT" in message.body
     assert message.context["environment"] == "binance_paper"
+
+
+def test_report_manifest_health_alerts_on_threshold_only(tmp_path):
+    manifest = tmp_path / "manifest.sqlite"
+    storage = SQLiteCacheStorage(manifest, store_rows=False)
+    universe = _build_universe("BTC_USDT", "1h")
+    router = _CollectingRouter()
+    as_of = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    metadata = storage.metadata()
+    metadata["last_timestamp::BTCUSDT::1h"] = str(int((as_of - timedelta(minutes=60)).timestamp() * 1000))
+    metadata["row_count::BTCUSDT::1h"] = "720"
+
+    data_quality = EnvironmentDataQualityConfig(max_gap_minutes=30.0, min_ok_ratio=None)
+
+    backfill._report_manifest_health(
+        manifest_path=manifest,
+        universe=universe,
+        exchange_name="binance_spot",
+        environment_name="binance_paper",
+        alert_router=router,
+        data_quality=data_quality,
+        as_of=as_of,
+    )
+
+    assert len(router.messages) == 1
+    message = router.messages[0]
+    assert message.severity == "warning"
+    assert "Alert progów jakości danych" in message.body
+    assert "max_gap_exceeded" in message.context.get("threshold_issues", "")
 
 
 def test_report_manifest_health_emits_critical_for_missing_metadata(tmp_path):
@@ -289,6 +322,7 @@ def test_report_manifest_health_emits_critical_for_missing_metadata(tmp_path):
         exchange_name="binance_spot",
         environment_name="binance_paper",
         alert_router=router,
+        data_quality=None,
         as_of=as_of,
     )
 
@@ -340,7 +374,23 @@ def test_report_manifest_health_prints_table(monkeypatch, tmp_path, capsys):
         ),
     ]
 
-    monkeypatch.setattr(backfill, "generate_manifest_report", lambda **_: entries)
+    def _status(entry: ManifestEntry) -> CoverageStatus:
+        issues = ()
+        if entry.status != "ok":
+            issues = (f"manifest_status:{entry.status}",)
+        return CoverageStatus(
+            symbol=entry.symbol,
+            interval=entry.interval,
+            manifest_entry=entry,
+            required_rows=None,
+            issues=issues,
+        )
+
+    monkeypatch.setattr(
+        backfill,
+        "evaluate_coverage",
+        lambda **_: [_status(entry) for entry in entries],
+    )
 
     manifest = tmp_path / "manifest.sqlite"
     manifest.touch()
@@ -352,6 +402,7 @@ def test_report_manifest_health_prints_table(monkeypatch, tmp_path, capsys):
         exchange_name="binance_spot",
         environment_name="binance_paper",
         alert_router=None,
+        data_quality=None,
         as_of=datetime(2024, 1, 1, tzinfo=timezone.utc),
         output_format="table",
     )
@@ -376,7 +427,20 @@ def test_report_manifest_health_prints_json(monkeypatch, tmp_path, capsys):
         )
     ]
 
-    monkeypatch.setattr(backfill, "generate_manifest_report", lambda **_: entries)
+    def _status(entry: ManifestEntry) -> CoverageStatus:
+        return CoverageStatus(
+            symbol=entry.symbol,
+            interval=entry.interval,
+            manifest_entry=entry,
+            required_rows=None,
+            issues=(),
+        )
+
+    monkeypatch.setattr(
+        backfill,
+        "evaluate_coverage",
+        lambda **_: [_status(entry) for entry in entries],
+    )
 
     manifest = tmp_path / "manifest.sqlite"
     manifest.touch()
@@ -388,6 +452,7 @@ def test_report_manifest_health_prints_json(monkeypatch, tmp_path, capsys):
         exchange_name="binance_spot",
         environment_name="binance_paper",
         alert_router=None,
+        data_quality=None,
         as_of=datetime(2024, 1, 1, tzinfo=timezone.utc),
         output_format="json",
     )
@@ -397,4 +462,6 @@ def test_report_manifest_health_prints_json(monkeypatch, tmp_path, capsys):
     assert payload["environment"] == "binance_paper"
     assert payload["exchange"] == "binance_spot"
     assert payload["summary"]["ok"] == 1
+    assert payload["summary"]["manifest_status_counts"]["ok"] == 1
+    assert payload["summary"]["issue_counts"] == {}
     assert payload["entries"][0]["symbol"] == "BTCUSDT"

--- a/tests/test_check_data_coverage_script.py
+++ b/tests/test_check_data_coverage_script.py
@@ -1,186 +1,350 @@
-"""CLI do weryfikacji pokrycia danych OHLCV względem wymagań backfillu."""
+"""Testy skryptu check_data_coverage oraz współdzielone helpery CLI."""
 from __future__ import annotations
 
-import argparse
 import json
+import sqlite3
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence
 
-from bot_core.config import load_core_config
-from bot_core.data.ohlcv import CoverageStatus, evaluate_coverage, summarize_issues
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import check_data_coverage as cli  # noqa: E402  - import po modyfikacji sys.path
 
 
-def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Sprawdza manifest danych OHLCV dla środowiska paper/testnet.",
+def _last_row_iso(rows: Sequence[Sequence[float]]) -> str:
+    timestamp_ms = int(float(rows[-1][0]))
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).isoformat()
+
+
+def test_check_data_coverage_success(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cache_dir = tmp_path / "cache_success"
+    rows = _generate_rows(datetime(2024, 1, 1, tzinfo=timezone.utc), 40)
+    _write_cache(cache_dir, rows)
+    config_path = _write_config(tmp_path, cache_dir)
+
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--environment",
+            "binance_smoke",
+            "--as-of",
+            _last_row_iso(rows),
+            "--json",
+        ]
     )
-    parser.add_argument("--config", default="config/core.yaml", help="Ścieżka do CoreConfig")
-    parser.add_argument(
-        "--environment",
-        required=True,
-        help="Nazwa środowiska z sekcji environments",
-    )
-    parser.add_argument(
-        "--as-of",
-        default=None,
-        help="Znacznik czasu ISO8601 używany do oceny opóźnień danych (domyślnie teraz, UTC)",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Zwróć wynik w formacie JSON (łatwy do integracji z CI)",
-    )
-    parser.add_argument(
-        "--output",
-        help=(
-            "Ścieżka do pliku, w którym zostanie zapisany wynik w formacie JSON. "
-            "Katalogi zostaną utworzone automatycznie."
-        ),
-    )
-    parser.add_argument(
-        "--symbol",
-        dest="symbols",
-        action="append",
-        default=None,
-        help=(
-            "Filtruj wynik do wskazanego symbolu (można podać wiele razy). "
-            "Obsługiwane są zarówno nazwy instrumentów z konfiguracji (np. BTC_USDT), "
-            "jak i symbole giełdowe (np. BTCUSDT)."
-        ),
-    )
-    return parser.parse_args(argv)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "ok"
+    summary = payload["summary"]
+    assert summary["status"] == "ok"
+    assert summary["total"] == 1
+    assert summary["ok"] == 1
+    assert summary["issue_counts"] == {}
+    assert summary["issue_examples"] == {}
+    assert summary["stale_entries"] == 0
 
 
-def _parse_as_of(arg: str | None) -> datetime:
-    if not arg:
-        return datetime.now(timezone.utc)
-    dt = datetime.fromisoformat(arg)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
+def test_check_data_coverage_insufficient_rows(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cache_dir = tmp_path / "cache_failure"
+    rows = _generate_rows(datetime(2024, 1, 1, tzinfo=timezone.utc), 5)
+    _write_cache(cache_dir, rows)
+    config_path = _write_config(
+        tmp_path,
+        cache_dir,
+        backfill={"BTC_USDT": [{"interval": "1d", "lookback_days": 60}]},
+    )
+
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--environment",
+            "binance_smoke",
+            "--as-of",
+            _last_row_iso(rows),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "error"
+    summary = payload["summary"]
+    assert summary["status"] == "error"
+    assert summary["total"] == 1
+    assert summary["error"] == 1
+    assert "insufficient_rows" in summary["issue_counts"]
+    assert summary["issue_counts"]["insufficient_rows"] == 1
+    assert "insufficient_rows" in summary["issue_examples"]
+    issues = payload["issues"]
+    assert any("insufficient_rows" in issue for issue in issues)
 
 
-def _format_status(status: CoverageStatus) -> dict[str, object]:
-    entry = status.manifest_entry
-    return {
-        "symbol": status.symbol,
-        "interval": status.interval,
-        "status": status.status,
-        "manifest_status": entry.status,
-        "row_count": entry.row_count,
-        "required_rows": status.required_rows,
-        "last_timestamp_iso": entry.last_timestamp_iso,
-        "gap_minutes": entry.gap_minutes,
-        "issues": list(status.issues),
+def test_check_data_coverage_interval_and_symbol_filters(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cache_dir = tmp_path / "cache_filters"
+    rows_daily = _generate_rows(datetime(2024, 1, 1, tzinfo=timezone.utc), 45, interval="1d")
+    rows_hourly = _generate_rows(datetime(2024, 1, 1, tzinfo=timezone.utc), 12, interval="1h")
+    _write_cache(cache_dir, rows_daily, interval="1d")
+    _write_cache(cache_dir, rows_hourly, interval="1h")
+    config_path = _write_config(
+        tmp_path,
+        cache_dir,
+        backfill={
+            "BTC_USDT": [
+                {"interval": "1d", "lookback_days": 30},
+                {"interval": "1h", "lookback_days": 24},
+            ]
+        },
+    )
+
+    as_of_iso = _last_row_iso(rows_daily if rows_daily[-1][0] >= rows_hourly[-1][0] else rows_hourly)
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--environment",
+            "binance_smoke",
+            "--symbol",
+            "BTC_USDT",
+            "--interval",
+            "1d",
+            "--as-of",
+            as_of_iso,
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "ok"
+    entries = payload["entries"]
+    assert len(entries) == 1
+    assert entries[0]["symbol"] == "BTCUSDT"
+    assert entries[0]["interval"] == "1d"
+    summary = payload["summary"]
+    assert summary["total"] == 1
+    assert summary["status"] == "ok"
+
+
+def test_check_data_coverage_threshold_violation(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cache_dir = tmp_path / "cache_threshold"
+    rows = _generate_rows(datetime(2024, 1, 1, tzinfo=timezone.utc), 40)
+    _write_cache(cache_dir, rows)
+    config_path = _write_config(
+        tmp_path,
+        cache_dir,
+        data_quality={"max_gap_minutes": 60.0},
+    )
+
+    last_iso = _last_row_iso(rows)
+    last_dt = datetime.fromisoformat(last_iso)
+    future_dt = last_dt + timedelta(hours=4)
+
+    exit_code = cli.main(
+        [
+            "--config",
+            str(config_path),
+            "--environment",
+            "binance_smoke",
+            "--as-of",
+            future_dt.isoformat(),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "error"
+    assert payload["issues"] == []
+    threshold_payload = payload["threshold_evaluation"]
+    assert payload["threshold_issues"]
+    assert any(
+        issue.startswith("max_gap_exceeded") for issue in payload["threshold_issues"]
+    )
+    assert any(
+        issue.startswith("max_gap_exceeded") for issue in threshold_payload["issues"]
+    )
+    observed = threshold_payload["observed"]
+    assert observed["worst_gap_minutes"] is not None
+
+
+# --- Współdzielone helpery dla scenariuszy CLI ---
+
+
+def _generate_rows(start: datetime, count: int, *, interval: str = "1d") -> list[list[float]]:
+    """Buduje syntetyczne świece OHLCV dla testów CLI."""
+
+    if count < 0:
+        raise ValueError("count musi być nieujemny")
+
+    step_map: Mapping[str, timedelta] = {
+        "1d": timedelta(days=1),
+        "1h": timedelta(hours=1),
+        "15m": timedelta(minutes=15),
     }
+    try:
+        step = step_map[interval]
+    except KeyError as exc:  # pragma: no cover - nie używane w obecnych testach
+        raise ValueError("Nieobsługiwany interwał testowy: {interval}".format(interval=interval)) from exc
 
-
-def main(argv: Sequence[str] | None = None) -> int:
-    args = _parse_args(argv)
-    config = load_core_config(Path(args.config))
-
-    environment = config.environments.get(args.environment)
-    if environment is None:
-        print(f"Nie znaleziono środowiska: {args.environment}", file=sys.stderr)
-        return 2
-
-    if not environment.instrument_universe:
-        print(
-            f"Środowisko {environment.name} nie ma przypisanego instrument_universe", file=sys.stderr
+    rows: list[list[float]] = []
+    current = start.astimezone(timezone.utc)
+    price = 10_000.0
+    for _ in range(count):
+        timestamp = int(current.timestamp() * 1000)
+        open_price = price
+        close_price = max(0.0001, open_price * 1.001)
+        high_price = max(open_price, close_price) * 1.001
+        low_price = min(open_price, close_price) * 0.999
+        volume = 100.0 + len(rows)
+        rows.append(
+            [
+                float(timestamp),
+                float(round(open_price, 6)),
+                float(round(high_price, 6)),
+                float(round(low_price, 6)),
+                float(round(close_price, 6)),
+                float(round(volume, 6)),
+            ]
         )
-        return 2
+        price = close_price
+        current += step
+    return rows
 
-    universe = config.instrument_universes.get(environment.instrument_universe)
-    if universe is None:
-        print(
-            f"Brak definicji uniwersum instrumentów: {environment.instrument_universe}",
-            file=sys.stderr,
-        )
-        return 2
 
-    as_of = _parse_as_of(args.as_of)
-    manifest_path = Path(environment.data_cache_path) / "ohlcv_manifest.sqlite"
-    statuses = evaluate_coverage(
-        manifest_path=manifest_path,
-        universe=universe,
-        exchange_name=environment.exchange,
-        as_of=as_of,
-    )
+def _write_cache(
+    cache_dir: Path,
+    rows: Sequence[Sequence[float]],
+    *,
+    symbol: str = "BTCUSDT",
+    interval: str = "1d",
+) -> Path:
+    """Zapisuje manifest SQLite z metadanymi wykorzystanymi w testach."""
 
-    # Filtrowanie po symbolach (opcjonalnie)
-    if args.symbols:
-        filter_tokens = [token.upper() for token in args.symbols]
-        # mapowanie aliasów z nazw instrumentów na symbole giełdowe
-        alias_map: dict[str, str] = {}
-        for instrument in universe.instruments:
-            symbol = instrument.exchange_symbols.get(environment.exchange)
-            if symbol:
-                alias_map[instrument.name.upper()] = symbol
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = cache_dir / "ohlcv_manifest.sqlite"
 
-        available_symbols: dict[str, str] = {status.symbol.upper(): status.symbol for status in statuses}
-
-        resolved: set[str] = set()
-        unknown: list[str] = []
-        for token, raw in zip(filter_tokens, args.symbols, strict=True):
-            symbol = alias_map.get(token)
-            if symbol is None:
-                symbol = available_symbols.get(token)
-            if symbol is None:
-                unknown.append(raw)
-                continue
-            resolved.add(symbol)
-
-        if unknown:
-            print("Nieznane symbole: " + ", ".join(unknown), file=sys.stderr)
-            return 2
-
-        statuses = [status for status in statuses if status.symbol in resolved]
-        if not statuses:
-            print("Brak wpisów w manifeście dla wskazanych symboli.", file=sys.stderr)
-            return 2
-
-    issues = summarize_issues(statuses)
-    payload = {
-        "environment": environment.name,
-        "exchange": environment.exchange,
-        "manifest_path": str(manifest_path),
-        "as_of": as_of.isoformat(),
-        "entries": [_format_status(status) for status in statuses],
-        "issues": issues,
-        "status": "ok" if not issues else "error",
-    }
-
-    serialized = json.dumps(payload, ensure_ascii=False, indent=2)
-
-    # Zapis do pliku, jeśli wskazano --output
-    if args.output:
-        output_path = Path(args.output)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(serialized + "\n", encoding="utf-8")
-
-    if args.json:
-        print(serialized)
-    else:
-        print(f"Manifest: {payload['manifest_path']}")
-        print(f"Środowisko: {payload['environment']} ({payload['exchange']})")
-        print(f"Ocena na: {payload['as_of']}")
-        for entry in payload["entries"]:
-            print(
-                " - {symbol} {interval}: status={status} row_count={row_count} required={required_rows} gap={gap_minutes}".format(
-                    **entry
-                )
+    with sqlite3.connect(manifest_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
             )
-        if issues:
-            print("Problemy:")
-            for issue in issues:
-                print(f" * {issue}")
-        else:
-            print("Brak problemów z pokryciem danych")
+            """
+        )
 
-    return 0 if not issues else 1
+        if rows:
+            last_ts = int(float(rows[-1][0]))
+            row_count = len(rows)
+            entries = {
+                f"last_timestamp::{symbol}::{interval}": str(last_ts),
+                f"row_count::{symbol}::{interval}": str(row_count),
+            }
+            for key, value in entries.items():
+                connection.execute(
+                    """
+                    INSERT INTO metadata(key, value) VALUES(?, ?)
+                    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                    """,
+                    (key, value),
+                )
+
+    return manifest_path
 
 
-if __name__ == "__main__":  # pragma: no cover - wejście CLI
-    raise SystemExit(main())
+def _write_config(
+    tmp_path: Path,
+    cache_dir: Path,
+    *,
+    environment_name: str = "binance_smoke",
+    exchange_name: str = "binance_spot",
+    instrument_name: str = "BTC_USDT",
+    symbol: str = "BTCUSDT",
+    backfill: Mapping[str, Sequence[Mapping[str, int]]] | None = None,
+    data_quality: Mapping[str, float | None] | None = None,
+) -> Path:
+    """Generuje minimalną konfigurację CoreConfig dla testów CLI."""
+
+    universe_name = "smoke_universe"
+    instrument_backfill = None
+    if backfill:
+        instrument_backfill = backfill.get(instrument_name)
+    if instrument_backfill is None:
+        instrument_backfill = (
+            {"interval": "1d", "lookback_days": 30},
+        )
+
+    base_asset, _, quote_asset = instrument_name.partition("_")
+    if not quote_asset:
+        quote_asset = "USDT"
+
+    environment_payload: dict[str, object] = {
+        "exchange": exchange_name,
+        "environment": "paper",
+        "keychain_key": f"{exchange_name}_paper",  # fikcyjny wpis dla walidacji
+        "data_cache_path": str(cache_dir),
+        "risk_profile": "balanced",
+        "alert_channels": [],
+        "instrument_universe": universe_name,
+    }
+    if data_quality:
+        environment_payload["data_quality"] = {
+            "max_gap_minutes": data_quality.get("max_gap_minutes"),
+            "min_ok_ratio": data_quality.get("min_ok_ratio"),
+        }
+
+    config_payload = {
+        "risk_profiles": {
+            "balanced": {
+                "max_daily_loss_pct": 0.02,
+                "max_position_pct": 0.05,
+                "target_volatility": 0.1,
+                "max_leverage": 3.0,
+                "stop_loss_atr_multiple": 1.5,
+                "max_open_positions": 5,
+                "hard_drawdown_pct": 0.1,
+            }
+        },
+        "instrument_universes": {
+            universe_name: {
+                "description": "Testowe uniwersum dla scenariuszy CLI",
+                "instruments": {
+                    instrument_name: {
+                        "base_asset": base_asset,
+                        "quote_asset": quote_asset,
+                        "categories": ["core"],
+                        "exchanges": {exchange_name: symbol},
+                        "backfill": list(instrument_backfill),
+                    }
+                },
+            }
+        },
+        "environments": {
+            environment_name: environment_payload,
+        },
+    }
+
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(
+        yaml.safe_dump(config_payload, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    return config_path

--- a/tests/test_ohlcv_coverage_summary.py
+++ b/tests/test_ohlcv_coverage_summary.py
@@ -1,0 +1,298 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from bot_core.data.ohlcv.coverage_check import (
+    CoverageStatus,
+    CoverageSummary,
+    coerce_summary_mapping,
+    evaluate_summary_thresholds,
+    summarize_coverage,
+)
+from bot_core.data.ohlcv.manifest_report import ManifestEntry
+
+
+def _manifest_entry(
+    *,
+    symbol: str,
+    interval: str,
+    status: str,
+    gap_minutes: float | None,
+    threshold_minutes: int | None,
+    row_count: int | None = None,
+    timestamp: datetime | None = None,
+) -> ManifestEntry:
+    last_ts_ms = None
+    last_ts_iso = None
+    if timestamp is not None:
+        last_ts_ms = int(timestamp.timestamp() * 1000)
+        last_ts_iso = timestamp.astimezone(timezone.utc).isoformat()
+    return ManifestEntry(
+        symbol=symbol,
+        interval=interval,
+        row_count=row_count,
+        last_timestamp_ms=last_ts_ms,
+        last_timestamp_iso=last_ts_iso,
+        gap_minutes=gap_minutes,
+        threshold_minutes=threshold_minutes,
+        status=status,
+    )
+
+
+def test_summarize_coverage_builds_metrics() -> None:
+    entries = [
+        CoverageStatus(
+            symbol="BTCUSDT",
+            interval="1d",
+            manifest_entry=_manifest_entry(
+                symbol="BTCUSDT",
+                interval="1d",
+                status="ok",
+                gap_minutes=45.0,
+                threshold_minutes=2880,
+                row_count=365,
+                timestamp=datetime(2024, 5, 1, tzinfo=timezone.utc),
+            ),
+            required_rows=360,
+            issues=(),
+        ),
+        CoverageStatus(
+            symbol="ETHUSDT",
+            interval="1d",
+            manifest_entry=_manifest_entry(
+                symbol="ETHUSDT",
+                interval="1d",
+                status="warning",
+                gap_minutes=240.0,
+                threshold_minutes=180,
+                row_count=355,
+                timestamp=datetime(2024, 5, 2, tzinfo=timezone.utc),
+            ),
+            required_rows=360,
+            issues=("manifest_status:warning", "insufficient_rows:355<360"),
+        ),
+        CoverageStatus(
+            symbol="SOLUSDT",
+            interval="1h",
+            manifest_entry=_manifest_entry(
+                symbol="SOLUSDT",
+                interval="1h",
+                status="missing_metadata",
+                gap_minutes=None,
+                threshold_minutes=120,
+                row_count=None,
+                timestamp=None,
+            ),
+            required_rows=720,
+            issues=("manifest_status:missing_metadata", "missing_row_count"),
+        ),
+    ]
+
+    summary = summarize_coverage(entries)
+
+    assert isinstance(summary, CoverageSummary)
+    assert summary.total == 3
+    assert summary.ok == 1
+    assert summary.error == 2
+    assert summary.warning == 1
+    assert summary.stale_entries == 1  # ETH ma lukę większą niż próg
+    assert summary.ok_ratio == pytest.approx(1 / 3)
+    assert summary.manifest_status_counts["warning"] == 1
+    assert summary.issue_counts["manifest_status"] == 2
+    assert summary.issue_counts["missing_row_count"] == 1
+    assert summary.issue_examples["missing_row_count"] == "missing_row_count"
+    assert summary.status == "error"
+
+    payload = summary.to_mapping()
+    assert payload["status"] == "error"
+    assert payload["ok"] == 1
+    assert payload["warning"] == 1
+    assert payload["error"] == 2
+    assert payload["stale_entries"] == 1
+    assert payload["manifest_status_counts"]["missing_metadata"] == 1
+    assert payload["issue_counts"]["insufficient_rows"] == 1
+    assert payload["worst_gap"]["symbol"] == "ETHUSDT"
+    assert payload["worst_gap"]["gap_minutes"] == pytest.approx(240.0)
+    assert payload["worst_gap"]["manifest_status"] == "warning"
+    assert "last_timestamp_iso" in payload["worst_gap"]
+
+
+def test_summarize_coverage_handles_empty() -> None:
+    summary = summarize_coverage([])
+
+    assert summary.total == 0
+    assert summary.ok == 0
+    assert summary.error == 0
+    assert summary.warning == 0
+    assert summary.ok_ratio is None
+    assert summary.status == "ok"
+    assert summary.worst_gap is None
+
+    payload = summary.to_mapping()
+    assert payload["status"] == "ok"
+    assert payload["ok_ratio"] is None
+    assert payload["manifest_status_counts"] == {}
+    assert payload["issue_counts"] == {}
+
+
+def test_coerce_summary_mapping_handles_none() -> None:
+    payload = coerce_summary_mapping(None)
+
+    assert payload["status"] == "unknown"
+    assert payload["total"] == 0
+    assert payload["issue_counts"] == {}
+    assert payload["worst_gap"] is None
+
+
+def test_coerce_summary_mapping_completes_mapping() -> None:
+    payload = coerce_summary_mapping({"status": "warning", "total": 2})
+
+    assert payload["status"] == "warning"
+    assert payload["total"] == 2
+    assert payload["ok"] == 0  # uzupełnione domyślnie
+    assert "manifest_status_counts" in payload
+
+
+def test_coerce_summary_mapping_from_summary() -> None:
+    statuses = [
+        CoverageStatus(
+            symbol="BTCUSDT",
+            interval="1d",
+            manifest_entry=_manifest_entry(
+                symbol="BTCUSDT",
+                interval="1d",
+                status="ok",
+                gap_minutes=0.0,
+                threshold_minutes=120,
+                row_count=10,
+                timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            ),
+            required_rows=10,
+            issues=(),
+        )
+    ]
+
+    payload = coerce_summary_mapping(summarize_coverage(statuses))
+
+    assert payload["status"] == "ok"
+    assert payload["total"] == 1
+    assert payload["ok"] == 1
+
+
+def test_evaluate_summary_thresholds_flags_max_gap() -> None:
+    summary = summarize_coverage(
+        [
+            CoverageStatus(
+                symbol="BTCUSDT",
+                interval="1h",
+                manifest_entry=_manifest_entry(
+                    symbol="BTCUSDT",
+                    interval="1h",
+                    status="ok",
+                    gap_minutes=180.0,
+                    threshold_minutes=240,
+                    row_count=720,
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                ),
+                required_rows=720,
+                issues=(),
+            )
+        ]
+    )
+
+    result = evaluate_summary_thresholds(summary, max_gap_minutes=120.0)
+
+    assert result.thresholds["max_gap_minutes"] == pytest.approx(120.0)
+    assert "max_gap_exceeded:180.0>120.0" in result.issues
+    assert result.observed["worst_gap_minutes"] == pytest.approx(180.0)
+
+
+def test_evaluate_summary_thresholds_flags_ok_ratio() -> None:
+    statuses = [
+        CoverageStatus(
+            symbol="BTCUSDT",
+            interval="1d",
+            manifest_entry=_manifest_entry(
+                symbol="BTCUSDT",
+                interval="1d",
+                status="ok",
+                gap_minutes=10.0,
+                threshold_minutes=120,
+                row_count=100,
+                timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            ),
+            required_rows=100,
+            issues=(),
+        ),
+        CoverageStatus(
+            symbol="ETHUSDT",
+            interval="1d",
+            manifest_entry=_manifest_entry(
+                symbol="ETHUSDT",
+                interval="1d",
+                status="ok",
+                gap_minutes=15.0,
+                threshold_minutes=120,
+                row_count=100,
+                timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            ),
+            required_rows=100,
+            issues=(),
+        ),
+        CoverageStatus(
+            symbol="SOLUSDT",
+            interval="1d",
+            manifest_entry=_manifest_entry(
+                symbol="SOLUSDT",
+                interval="1d",
+                status="warning",
+                gap_minutes=300.0,
+                threshold_minutes=120,
+                row_count=40,
+                timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            ),
+            required_rows=100,
+            issues=("manifest_status:warning",),
+        ),
+        CoverageStatus(
+            symbol="XRPUSDT",
+            interval="1d",
+            manifest_entry=_manifest_entry(
+                symbol="XRPUSDT",
+                interval="1d",
+                status="error",
+                gap_minutes=400.0,
+                threshold_minutes=120,
+                row_count=20,
+                timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            ),
+            required_rows=100,
+            issues=("manifest_status:error",),
+        ),
+    ]
+
+    summary = summarize_coverage(statuses)
+    result = evaluate_summary_thresholds(summary, min_ok_ratio=0.9)
+
+    assert result.thresholds["min_ok_ratio"] == pytest.approx(0.9)
+    assert any(issue.startswith("ok_ratio_below_threshold:") for issue in result.issues)
+    assert result.observed["ok_ratio"] == pytest.approx(summary.ok_ratio or 0.0)
+
+
+def test_evaluate_summary_thresholds_handles_empty_manifest() -> None:
+    summary = CoverageSummary(
+        total=0,
+        ok=0,
+        error=0,
+        warning=0,
+        manifest_status_counts={},
+        issue_counts={},
+        issue_examples={},
+        stale_entries=0,
+        worst_gap=None,
+    )
+
+    result = evaluate_summary_thresholds(summary, min_ok_ratio=0.5)
+
+    assert "manifest_empty_for_threshold" in result.issues
+    assert result.thresholds["min_ok_ratio"] == pytest.approx(0.5)

--- a/tests/test_paper_precheck_script.py
+++ b/tests/test_paper_precheck_script.py
@@ -53,6 +53,9 @@ def test_paper_precheck_success(tmp_path: Path, capsys: pytest.CaptureFixture[st
     summary = payload["coverage"]["summary"]
     assert summary["status"] == "ok"
     assert summary.get("ok_ratio") == pytest.approx(1.0)
+    assert summary["stale_entries"] == 0
+    assert summary["issue_counts"] == {}
+    assert summary["issue_examples"] == {}
 
 
 def test_paper_precheck_invalid_config(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- evaluate configured data-quality thresholds in the `check_data_coverage` CLI and expose violations in both JSON and text outputs
- extend the CLI payload with threshold context so CI can fail when only thresholds (not manifest issues) are breached
- add regression coverage for threshold breaches and configuration helpers that inject `data_quality` into test environments

## Testing
- PYTHONPATH=. pytest --override-ini addopts="" tests/test_check_data_coverage_script.py
- PYTHONPATH=. pytest --override-ini addopts="" tests/test_ohlcv_coverage_summary.py tests/test_paper_precheck_script.py tests/test_backfill_cli.py
- PYTHONPATH=. pytest --override-ini addopts="" tests/test_alerts.py -k coverage


------
https://chatgpt.com/codex/tasks/task_e_68e14a83df34832ab0399bb068e69627