### PR TITLE
Add assisted/autonomous provenance fields and boolean handling to opportunity tracking

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -209,6 +209,9 @@ _OPPORTUNITY_AUTONOMY_PROVENANCE_KEYS = (
     "autonomy_upstream_effective_mode",
     "autonomy_local_guard_effective_mode",
     "autonomy_final_mode",
+    "autonomous_execution_allowed",
+    "assisted_override_used",
+    "blocking_reason",
     "autonomy_decisive_stage",
     "autonomy_decisive_reason",
     "autonomy_primary_reason",
@@ -264,6 +267,9 @@ class _OpportunityOpenOutcomeTracker:
     autonomy_upstream_effective_mode: str | None = None
     autonomy_local_guard_effective_mode: str | None = None
     autonomy_final_mode: str | None = None
+    autonomous_execution_allowed: str | None = None
+    assisted_override_used: str | None = None
+    blocking_reason: str | None = None
     autonomy_decisive_stage: str | None = None
     autonomy_decisive_reason: str | None = None
     autonomy_primary_reason: str | None = None
@@ -706,6 +712,9 @@ class TradingController:
                     "autonomy_local_guard_effective_mode"
                 ),
                 autonomy_final_mode=autonomy_chain.get("autonomy_final_mode"),
+                autonomous_execution_allowed=autonomy_chain.get("autonomous_execution_allowed"),
+                assisted_override_used=autonomy_chain.get("assisted_override_used"),
+                blocking_reason=autonomy_chain.get("blocking_reason"),
                 autonomy_decisive_stage=autonomy_chain.get("autonomy_decisive_stage"),
                 autonomy_decisive_reason=autonomy_chain.get("autonomy_decisive_reason"),
                 autonomy_primary_reason=autonomy_chain.get("autonomy_primary_reason"),
@@ -792,7 +801,10 @@ class TradingController:
             raw_value = metadata.get(key)
             if raw_value is None:
                 continue
-            candidate = str(raw_value).strip()
+            if isinstance(raw_value, bool):
+                candidate = "true" if raw_value else "false"
+            else:
+                candidate = str(raw_value).strip()
             if candidate:
                 chain[key] = candidate
         return chain
@@ -809,6 +821,9 @@ class TradingController:
                 "autonomy_upstream_effective_mode": tracker.autonomy_upstream_effective_mode,
                 "autonomy_local_guard_effective_mode": tracker.autonomy_local_guard_effective_mode,
                 "autonomy_final_mode": tracker.autonomy_final_mode,
+                "autonomous_execution_allowed": tracker.autonomous_execution_allowed,
+                "assisted_override_used": tracker.assisted_override_used,
+                "blocking_reason": tracker.blocking_reason,
                 "autonomy_decisive_stage": tracker.autonomy_decisive_stage,
                 "autonomy_decisive_reason": tracker.autonomy_decisive_reason,
                 "autonomy_primary_reason": tracker.autonomy_primary_reason,
@@ -2778,6 +2793,17 @@ class TradingController:
                     tracked.autonomy_final_mode = tracked.autonomy_final_mode or autonomy_chain.get(
                         "autonomy_final_mode"
                     )
+                    tracked.autonomous_execution_allowed = (
+                        tracked.autonomous_execution_allowed
+                        or autonomy_chain.get("autonomous_execution_allowed")
+                    )
+                    tracked.assisted_override_used = (
+                        tracked.assisted_override_used
+                        or autonomy_chain.get("assisted_override_used")
+                    )
+                    tracked.blocking_reason = (
+                        tracked.blocking_reason or autonomy_chain.get("blocking_reason")
+                    )
                     tracked.autonomy_decisive_stage = (
                         tracked.autonomy_decisive_stage
                         or autonomy_chain.get("autonomy_decisive_stage")
@@ -2896,6 +2922,17 @@ class TradingController:
                         tracked.autonomy_final_mode = (
                             tracked.autonomy_final_mode or autonomy_chain.get("autonomy_final_mode")
                         )
+                        tracked.autonomous_execution_allowed = (
+                            tracked.autonomous_execution_allowed
+                            or autonomy_chain.get("autonomous_execution_allowed")
+                        )
+                        tracked.assisted_override_used = (
+                            tracked.assisted_override_used
+                            or autonomy_chain.get("assisted_override_used")
+                        )
+                        tracked.blocking_reason = (
+                            tracked.blocking_reason or autonomy_chain.get("blocking_reason")
+                        )
                         tracked.autonomy_decisive_stage = (
                             tracked.autonomy_decisive_stage
                             or autonomy_chain.get("autonomy_decisive_stage")
@@ -2990,6 +3027,11 @@ class TradingController:
                         "autonomy_local_guard_effective_mode"
                     ),
                     autonomy_final_mode=autonomy_chain.get("autonomy_final_mode"),
+                    autonomous_execution_allowed=autonomy_chain.get(
+                        "autonomous_execution_allowed"
+                    ),
+                    assisted_override_used=autonomy_chain.get("assisted_override_used"),
+                    blocking_reason=autonomy_chain.get("blocking_reason"),
                     autonomy_decisive_stage=autonomy_chain.get("autonomy_decisive_stage"),
                     autonomy_decisive_reason=autonomy_chain.get("autonomy_decisive_reason"),
                     autonomy_primary_reason=autonomy_chain.get("autonomy_primary_reason"),

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -381,6 +381,9 @@ _AUTONOMY_CHAIN_EXPECTED_KEYS = (
 
 _AUTONOMY_CONTRACT_CROSS_SINK_KEYS = (
     "autonomy_final_mode",
+    "autonomous_execution_allowed",
+    "assisted_override_used",
+    "blocking_reason",
     "autonomy_decisive_stage",
     "autonomy_decisive_reason",
     "autonomy_primary_reason",
@@ -394,6 +397,9 @@ _AUTONOMY_CONTRACT_UPSTREAM_PROVENANCE_KEYS = (
 
 _AUTONOMY_PERSISTENCE_NO_LEAK_KEYS = (
     "autonomy_final_mode",
+    "autonomous_execution_allowed",
+    "assisted_override_used",
+    "blocking_reason",
     "autonomy_decisive_stage",
     "autonomy_decisive_reason",
     "autonomy_primary_reason",
@@ -6710,6 +6716,591 @@ def test_opportunity_autonomy_truthfulness_conflicting_policy_close_payload_does
         final_labels_after_replay[0].provenance.get("upstream_autonomy_inference_model_version")
         == "2026.05.02"
     )
+
+
+def test_opportunity_autonomy_assisted_approval_open_and_persistence_contract_stays_coherent() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [16.0, 14.0, 12.0, 10.0, 8.0, 6.0], environment="live", portfolio_id="live-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 105.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="live",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+            )
+        ]
+    )
+    open_event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert open_event["status"] == "allowed"
+    assert open_event["autonomy_mode"] == "live_assisted"
+    assert open_event["autonomy_primary_reason"] == "reason:live_assisted"
+    assert open_event["autonomous_execution_allowed"] == "true"
+    assert open_event["assisted_override_used"] == "true"
+    assert open_event.get("blocking_reason") in {None, ""}
+    open_rows = repository.load_open_outcomes()
+    assert len(open_rows) == 1
+    _assert_autonomy_contract_consistent_with_provenance(open_event, open_rows[0].provenance)
+    assert open_rows[0].provenance.get("upstream_autonomy_decision_source") is None
+    assert open_rows[0].provenance.get("upstream_autonomy_inference_model") is None
+    assert open_rows[0].provenance.get("upstream_autonomy_inference_model_version") is None
+
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="SELL",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                include_mode=False,
+            )
+        ]
+    )
+    final_labels = [
+        label
+        for label in repository.load_outcome_labels()
+        if label.correlation_key == correlation_key and label.label_quality == "final"
+    ]
+    assert len(final_labels) == 1
+    _assert_autonomy_contract_consistent_with_provenance(open_event, final_labels[0].provenance)
+
+
+def test_opportunity_autonomy_assisted_without_approval_blocks_without_execution_persistence() -> None:
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [16.0, 14.0, 12.0, 10.0, 8.0, 6.0], environment="live", portfolio_id="live-1"
+    )
+    baseline_label_count = len(repository.load_outcome_labels())
+    controller, execution, journal = _build_autonomy_controller(
+        environment="live",
+        opportunity_shadow_repository=repository,
+    )
+    result = controller.process_signals(
+        [
+            _opportunity_autonomy_signal(
+                "live_assisted",
+                assisted_approval=False,
+            )
+        ]
+    )
+    assert result == []
+    assert execution.requests == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "blocked"
+    assert event["autonomy_mode"] == "live_assisted"
+    assert event["autonomy_primary_reason"] == "reason:live_assisted"
+    assert event["autonomous_execution_allowed"] == "false"
+    assert event["assisted_override_used"] == "false"
+    assert event["blocking_reason"] == "live_assisted_requires_explicit_approval"
+    assert repository.load_open_outcomes() == []
+    assert len(repository.load_outcome_labels()) == baseline_label_count
+
+
+def test_opportunity_autonomy_assisted_downgrade_preserves_upstream_provenance_and_permission_trail() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_mixed_lineage_outcomes(
+        [
+            (16.0, "live", "live-1", "hybrid-open-v1", "hybrid"),
+            (14.0, "live", "live-1", "hybrid-open-v1", "hybrid"),
+            (12.0, "live", "live-1", "hybrid-open-v1", "hybrid"),
+            (10.0, "live", "live-1", "hybrid-open-v1", "hybrid"),
+            (8.0, "live", "live-1", "hybrid-open-v1", "hybrid"),
+            (6.0, "live", "live-1", "hybrid-open-v1", "hybrid"),
+        ]
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="live",
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_autonomous",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+                model_version="hybrid-open-v1",
+                decision_source="hybrid",
+                include_decision_payload=True,
+                decision_effective_mode="live_assisted",
+                decision_primary_reason="upstream_hybrid_requires_assisted",
+                decision_payload_decision_source="hybrid",
+                decision_payload_inference_model="hybrid_model",
+                decision_payload_inference_model_version="2026.06.10",
+            )
+        ]
+    )
+    open_event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert open_event["status"] == "allowed"
+    assert open_event["autonomy_mode"] == "live_assisted"
+    assert open_event["autonomy_primary_reason"] == "upstream_hybrid_requires_assisted"
+    assert open_event["autonomous_execution_allowed"] == "true"
+    assert open_event["assisted_override_used"] == "true"
+    assert open_event["upstream_autonomy_decision_source"] == "hybrid"
+    assert open_event["upstream_autonomy_inference_model"] == "hybrid_model"
+    assert open_event["upstream_autonomy_inference_model_version"] == "2026.06.10"
+    open_rows = repository.load_open_outcomes()
+    assert len(open_rows) == 1
+    _assert_autonomy_contract_consistent_with_provenance(open_event, open_rows[0].provenance)
+
+
+def test_opportunity_autonomy_assisted_contract_survives_conflicting_close_and_replay_payload() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_mixed_lineage_outcomes(
+        [
+            (16.0, "live", "live-1", "assisted-open-v1", "model"),
+            (14.0, "live", "live-1", "assisted-open-v1", "model"),
+            (12.0, "live", "live-1", "assisted-open-v1", "model"),
+            (10.0, "live", "live-1", "assisted-open-v1", "model"),
+            (8.0, "live", "live-1", "assisted-open-v1", "model"),
+            (6.0, "live", "live-1", "assisted-open-v1", "model"),
+        ]
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    controller, journal_open = _build_autonomy_controller_with_execution(
+        environment="live",
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 102.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+                model_version="assisted-open-v1",
+                decision_source="model",
+                include_decision_payload=True,
+                decision_effective_mode="live_assisted",
+                decision_primary_reason="live_assisted_with_explicit_approval",
+                decision_payload_decision_source="model",
+                decision_payload_inference_model="open_assisted_model",
+                decision_payload_inference_model_version="2026.06.11",
+            )
+        ]
+    )
+    open_event = _last_event(journal_open, "opportunity_autonomy_enforcement")
+    assert open_event["autonomous_execution_allowed"] == "true"
+    assert open_event["assisted_override_used"] == "true"
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="live_assisted",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        assisted_approval=True,
+        model_version="assisted-open-v1",
+        decision_source="model",
+        include_mode=True,
+        include_decision_payload=True,
+        decision_effective_mode="live_autonomous",
+        decision_primary_reason="conflicting_close_reason",
+        decision_payload_decision_source="model",
+    )
+    controller.process_signals([close_signal])
+    final_labels = [
+        label
+        for label in repository.load_outcome_labels()
+        if label.correlation_key == correlation_key and label.label_quality == "final"
+    ]
+    assert len(final_labels) == 1
+    _assert_autonomy_contract_consistent_with_provenance(open_event, final_labels[0].provenance)
+    assert final_labels[0].provenance.get("autonomous_execution_allowed") == "true"
+    assert final_labels[0].provenance.get("assisted_override_used") == "true"
+    assert final_labels[0].provenance.get("autonomy_final_mode") == "live_assisted"
+    assert final_labels[0].provenance.get("autonomy_primary_reason") == (
+        "live_assisted_with_explicit_approval"
+    )
+    assert final_labels[0].provenance.get("upstream_autonomy_decision_source") == "model"
+    assert final_labels[0].provenance.get("upstream_autonomy_inference_model") == (
+        "open_assisted_model"
+    )
+    assert final_labels[0].provenance.get("upstream_autonomy_inference_model_version") == (
+        "2026.06.11"
+    )
+
+    replay_journal = CollectingDecisionJournal()
+    controller_replay = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=DummyExecutionService(),
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="live-1",
+        environment="live",
+        risk_profile="balanced",
+        decision_journal=replay_journal,
+        opportunity_shadow_repository=repository,
+    )
+    controller_replay.process_signals([close_signal])
+    final_labels_after_replay = [
+        label
+        for label in repository.load_outcome_labels()
+        if label.correlation_key == correlation_key and label.label_quality == "final"
+    ]
+    assert len(final_labels_after_replay) == 1
+    assert _autonomy_persistence_snapshot(final_labels_after_replay[0].provenance) == (
+        _autonomy_persistence_snapshot(final_labels[0].provenance)
+    )
+
+
+def test_opportunity_autonomy_assisted_partial_persistence_keeps_permission_trail() -> None:
+    decision_timestamp = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [16.0, 14.0, 12.0, 10.0, 8.0, 6.0], environment="live", portfolio_id="live-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="live",
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+                {"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 101.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+            )
+        ]
+    )
+    open_event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert open_event["autonomous_execution_allowed"] == "true"
+    assert open_event["assisted_override_used"] == "true"
+    assert open_event.get("blocking_reason") in {None, ""}
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="SELL",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                include_mode=False,
+            )
+        ]
+    )
+    partial_labels = [
+        label
+        for label in repository.load_outcome_labels()
+        if label.correlation_key == correlation_key
+        and label.label_quality == "partial_exit_unconfirmed"
+    ]
+    assert len(partial_labels) == 1
+    partial_provenance = partial_labels[0].provenance
+    _assert_autonomy_contract_consistent_with_provenance(open_event, partial_provenance)
+    assert partial_provenance.get("autonomous_execution_allowed") == "true"
+    assert partial_provenance.get("assisted_override_used") == "true"
+    assert partial_provenance.get("blocking_reason") is None
+    assert partial_provenance.get("autonomy_final_mode") == "live_assisted"
+    assert partial_provenance.get("autonomy_primary_reason") == "reason:live_assisted"
+    assert partial_provenance.get("upstream_autonomy_decision_source") is None
+    assert partial_provenance.get("upstream_autonomy_inference_model") is None
+    assert partial_provenance.get("upstream_autonomy_inference_model_version") is None
+
+
+def test_opportunity_autonomy_assisted_partial_persistence_preserves_upstream_hybrid_provenance() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_mixed_lineage_outcomes(
+        [
+            (16.0, "live", "live-1", "hybrid-partial-v1", "hybrid"),
+            (14.0, "live", "live-1", "hybrid-partial-v1", "hybrid"),
+            (12.0, "live", "live-1", "hybrid-partial-v1", "hybrid"),
+            (10.0, "live", "live-1", "hybrid-partial-v1", "hybrid"),
+            (8.0, "live", "live-1", "hybrid-partial-v1", "hybrid"),
+            (6.0, "live", "live-1", "hybrid-partial-v1", "hybrid"),
+        ]
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="live",
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+                {"status": "partially_filled", "filled_quantity": 0.2, "avg_price": 102.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_autonomous",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+                model_version="hybrid-partial-v1",
+                decision_source="hybrid",
+                include_decision_payload=True,
+                decision_effective_mode="live_assisted",
+                decision_primary_reason="hybrid_assisted_partial_contract",
+                decision_payload_decision_source="hybrid",
+                decision_payload_inference_model="hybrid_partial_model",
+                decision_payload_inference_model_version="2026.06.12",
+            )
+        ]
+    )
+    open_event = _last_event(journal, "opportunity_autonomy_enforcement")
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="SELL",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+                include_mode=False,
+            )
+        ]
+    )
+    partial_labels = [
+        label
+        for label in repository.load_outcome_labels()
+        if label.correlation_key == correlation_key
+        and label.label_quality == "partial_exit_unconfirmed"
+    ]
+    assert len(partial_labels) == 1
+    partial_provenance = partial_labels[0].provenance
+    _assert_autonomy_contract_consistent_with_provenance(open_event, partial_provenance)
+    assert partial_provenance.get("upstream_autonomy_decision_source") == "hybrid"
+    assert partial_provenance.get("upstream_autonomy_inference_model") == "hybrid_partial_model"
+    assert partial_provenance.get("upstream_autonomy_inference_model_version") == "2026.06.12"
+    assert partial_provenance.get("autonomous_execution_allowed") == "true"
+    assert partial_provenance.get("assisted_override_used") == "true"
+    assert partial_provenance.get("autonomy_final_mode") == "live_assisted"
+
+
+def test_opportunity_autonomy_assisted_partial_upgrade_to_final_preserves_permission_trail_under_conflicting_close_payload() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_mixed_lineage_outcomes(
+        [
+            (16.0, "live", "live-1", "assisted-partial-v1", "model"),
+            (14.0, "live", "live-1", "assisted-partial-v1", "model"),
+            (12.0, "live", "live-1", "assisted-partial-v1", "model"),
+            (10.0, "live", "live-1", "assisted-partial-v1", "model"),
+            (8.0, "live", "live-1", "assisted-partial-v1", "model"),
+            (6.0, "live", "live-1", "assisted-partial-v1", "model"),
+        ]
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="live",
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+                {"status": "partially_filled", "filled_quantity": 0.3, "avg_price": 101.0},
+                {"status": "filled", "filled_quantity": 0.7, "avg_price": 103.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+                model_version="assisted-partial-v1",
+                decision_source="model",
+                include_decision_payload=True,
+                decision_effective_mode="live_assisted",
+                decision_primary_reason="open_assisted_partial_contract",
+                decision_payload_decision_source="model",
+                decision_payload_inference_model="assisted_partial_open_model",
+                decision_payload_inference_model_version="2026.06.13",
+            )
+        ]
+    )
+    open_event = _last_event(journal, "opportunity_autonomy_enforcement")
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="SELL",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+                include_mode=False,
+            )
+        ]
+    )
+    partial_labels = [
+        label
+        for label in repository.load_outcome_labels()
+        if label.correlation_key == correlation_key
+        and label.label_quality == "partial_exit_unconfirmed"
+    ]
+    assert len(partial_labels) == 1
+    partial_snapshot = _autonomy_persistence_snapshot(partial_labels[0].provenance)
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="live_assisted",
+                side="SELL",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                assisted_approval=True,
+                model_version="assisted-partial-v1",
+                decision_source="model",
+                include_mode=True,
+                include_decision_payload=True,
+                decision_effective_mode="live_autonomous",
+                decision_primary_reason="conflicting_partial_upgrade_reason",
+                decision_payload_decision_source="model",
+                decision_payload_inference_model="conflicting_partial_upgrade_model",
+                decision_payload_inference_model_version="2027.01.05",
+            )
+        ]
+    )
+    final_labels = [
+        label
+        for label in repository.load_outcome_labels()
+        if label.correlation_key == correlation_key and label.label_quality == "final"
+    ]
+    partial_labels_after_final = [
+        label
+        for label in repository.load_outcome_labels()
+        if label.correlation_key == correlation_key
+        and label.label_quality == "partial_exit_unconfirmed"
+    ]
+    assert len(final_labels) == 1
+    assert partial_labels_after_final == []
+    assert _autonomy_persistence_snapshot(final_labels[0].provenance) == partial_snapshot
+    assert final_labels[0].provenance.get("autonomous_execution_allowed") == "true"
+    assert final_labels[0].provenance.get("assisted_override_used") == "true"
+    assert final_labels[0].provenance.get("autonomy_final_mode") == "live_assisted"
+    assert final_labels[0].provenance.get("autonomy_primary_reason") == (
+        "open_assisted_partial_contract"
+    )
+    assert final_labels[0].provenance.get("upstream_autonomy_inference_model") == (
+        "assisted_partial_open_model"
+    )
+    _assert_autonomy_contract_consistent_with_provenance(open_event, final_labels[0].provenance)
 
 
 def test_opportunity_autonomy_close_replay_partial_attach_conflict_is_non_destructive_without_provenance_drift(


### PR DESCRIPTION
### Motivation
- Preserve and propagate additional autonomy provenance about assisted approvals and blocking reasons so persistence and decision journals retain the permission trail for assisted/live-autonomous flows.
- Ensure boolean provenance values are consistently serialized into the provenance chain so downstream sinks and persistence see canonical string values.

### Description
- Added new provenance keys `autonomous_execution_allowed`, `assisted_override_used`, and `blocking_reason` to `_OPPORTUNITY_AUTONOMY_PROVENANCE_KEYS` and relevant contract key tuples.
- Extended the `_OpportunityOpenOutcomeTracker` dataclass with `autonomous_execution_allowed`, `assisted_override_used`, and `blocking_reason` fields and populated them when restoring, creating, and resolving trackers.
- Updated `_extract_opportunity_autonomy_provenance_chain` to convert boolean metadata values to literal strings (`"true"`/`"false"`) while preserving other values as strings.
- Included the new fields when extracting provenance from a tracker in `_extract_opportunity_autonomy_provenance_chain_from_tracker` so persistence and event payloads include the permission trail.
- Added comprehensive tests in `tests/test_trading_controller.py` to verify assisted-autonomy behaviors, persistence of the permission trail across partial/final outcomes, blocking when approval is absent, and resilience to conflicting/replay payloads.

### Testing
- Added and ran unit tests in `tests/test_trading_controller.py` covering assisted/autonomous scenarios (tests named `test_opportunity_autonomy_assisted_*`); all new tests passed under `pytest`.
- Ran the modified trading controller test file (`pytest tests/test_trading_controller.py`) as part of CI and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81b271528832aad88d38ed76c54a4)