### PR TITLE
Increase curated strategy gate coverage with branch-focused tests

### DIFF
--- a/tests/strategies/test_day_trading_strategy.py
+++ b/tests/strategies/test_day_trading_strategy.py
@@ -1,5 +1,6 @@
 from bot_core.strategies.base import MarketSnapshot
 from bot_core.strategies.day_trading import DayTradingSettings, DayTradingStrategy
+import pytest
 
 
 def _snapshot(
@@ -73,3 +74,64 @@ def test_day_trading_strategy_short_stop_loss() -> None:
     stop = strategy.decide(_snapshot("ETHUSDT", 202.0, 0.01, high=203.0, low=201.5, timestamp=3))
     assert stop and stop[0].side == "buy"
     assert stop[0].metadata.get("exit_reason") == "stop_loss"
+
+
+def test_day_trading_settings_validation_and_from_parameters() -> None:
+    with pytest.raises(ValueError, match="exit_threshold must be lower"):
+        DayTradingSettings(entry_threshold=0.5, exit_threshold=0.5)
+
+    with pytest.raises(ValueError, match="bias_strength must be in the range"):
+        DayTradingSettings(bias_strength=1.2)
+
+    settings = DayTradingSettings.from_parameters(
+        {"momentum_window": "2", "entry_threshold": "0.4", "bias_strength": "0.3"}
+    )
+    assert settings.momentum_window == 2
+    assert settings.entry_threshold == 0.4
+    assert settings.bias_strength == 0.3
+
+
+def test_day_trading_strategy_time_exit_and_teardown() -> None:
+    strategy = DayTradingStrategy(
+        DayTradingSettings(
+            momentum_window=1,
+            volatility_window=1,
+            entry_threshold=0.1,
+            exit_threshold=0.05,
+            take_profit_atr=10.0,
+            stop_loss_atr=10.0,
+            max_holding_bars=1,
+            atr_floor=0.01,
+            bias_strength=0.0,
+        )
+    )
+    strategy.prepare()
+    assert strategy.decide(_snapshot("SOLUSDT", 10.0, 0.01)) == []
+    enter = strategy.decide(_snapshot("SOLUSDT", 10.2, 0.01, timestamp=2))
+    assert enter and enter[0].side == "buy"
+    exit_signal = strategy.decide(_snapshot("SOLUSDT", 10.21, 0.01, timestamp=3))
+    assert exit_signal and exit_signal[0].metadata.get("exit_reason") == "time_exit"
+    strategy.teardown()
+    assert strategy.decide(_snapshot("SOLUSDT", 10.3, 0.01, timestamp=4)) == []
+
+
+def test_day_trading_strategy_momentum_fade_exit_and_zero_bias_midpoint() -> None:
+    strategy = DayTradingStrategy(
+        DayTradingSettings(
+            momentum_window=1,
+            volatility_window=1,
+            entry_threshold=0.08,
+            exit_threshold=0.06,
+            take_profit_atr=10.0,
+            stop_loss_atr=10.0,
+            max_holding_bars=5,
+            atr_floor=0.01,
+            bias_strength=0.0,
+        )
+    )
+    strategy.prepare()
+    strategy.warmup([_snapshot("XRPUSDT", 1.0, 0.01)])
+    assert strategy.decide(_snapshot("XRPUSDT", 1.1, 0.01, timestamp=2))
+    faded = strategy.decide(_snapshot("XRPUSDT", 1.1005, 0.01, timestamp=3))
+    assert faded and faded[0].metadata.get("exit_reason") == "momentum_fade"
+    assert strategy._intraday_bias(_snapshot("XRPUSDT", 0.0, 0.01, high=0.0, low=0.0)) == 0.0

--- a/tests/strategies/test_regime_workflow.py
+++ b/tests/strategies/test_regime_workflow.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from collections import deque
 from datetime import date, datetime, time, timezone, timedelta
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from bot_core.ai import MarketRegime, MarketRegimeAssessment, RegimeHistory
 from bot_core.auto_trader.schedule import ScheduleWindow
@@ -16,6 +18,8 @@ from bot_core.strategies.regime_workflow import (
     ActivationUptimeStats,
     PresetAvailability,
     StrategyRegimeWorkflow,
+    _gather_strings,
+    _normalize_regime,
 )
 from bot_core.security.capabilities import build_capabilities_from_payload
 from bot_core.security.guards import install_capability_guard, reset_capability_guard
@@ -956,3 +960,89 @@ def test_activation_uptime_stats_tracks_regime_and_fallback_time() -> None:
     assert single_stats.regime_uptime[MarketRegime.DAILY] == timedelta(minutes=15)
     assert single_stats.preset_uptime[None] == timedelta(minutes=15)
     assert single_stats.fallback_uptime == timedelta(minutes=15)
+
+
+def test_regime_workflow_helper_guard_paths() -> None:
+    workflow = _workflow([MarketRegime.TREND])
+
+    assert _normalize_regime(MarketRegime.DAILY) is MarketRegime.DAILY
+    assert _normalize_regime("trend") is MarketRegime.TREND
+    with pytest.raises(ValueError, match="Unsupported market regime"):
+        _normalize_regime("nope")
+    assert _gather_strings((("a", " "), ("a", "b"))) == ("a", "b")
+
+    workflow._activation_history.extend([SimpleNamespace(), SimpleNamespace()])  # type: ignore[arg-type]
+    assert len(workflow._history_slice(None)) == 2
+    assert len(workflow._history_slice(0)) == 2
+    assert len(workflow._history_slice(1)) == 1
+    assert len(workflow._history_slice("bad")) == 2  # type: ignore[arg-type]
+
+    assert workflow._missing_data(("ohlcv", " ", "order_book"), {"ohlcv"}) == ("order_book",)
+
+    with pytest.raises(RuntimeError, match="Missing market data"):
+        workflow._resolve_fallback({"ohlcv"}, ("spread_history",))
+    with pytest.raises(RuntimeError, match="Decision schedule blocks"):
+        workflow._resolve_fallback({"ohlcv"}, ())
+
+    class _ExplodingWindow:
+        allow_trading = True
+
+        def contains(self, _: datetime) -> bool:
+            raise RuntimeError("boom")
+
+    workflow._schedule = (_ExplodingWindow(),)
+    assert workflow._is_within_schedule(datetime(2024, 1, 1, tzinfo=timezone.utc)) is False
+
+
+def test_regime_workflow_candidate_and_recommendation_helpers() -> None:
+    workflow = _workflow([MarketRegime.TREND])
+    version = workflow.register_preset(
+        MarketRegime.TREND,
+        name="trend-core",
+        entries=[{"engine": "daily_trend_momentum", "metadata": {"expected_probability": 5.0}}],
+        signing_key=b"k",
+        key_id="id",
+    )
+    registered = workflow._presets[MarketRegime.TREND]
+    candidates = workflow._build_candidates(registered.preset, version)
+    assert candidates[0].expected_probability == 1.0
+    assert candidates[0].metadata["preset"] == "trend-core"
+
+    class _Engine:
+        def select_strategy(self, regime: MarketRegime) -> str:
+            return regime.value
+
+    workflow._decision_engine = _Engine()  # type: ignore[assignment]
+    assert workflow._fetch_recommendation(MarketRegime.TREND) == "trend"
+
+    class _BrokenEngine:
+        def select_strategy(self, regime: MarketRegime) -> str:
+            raise RuntimeError(regime.value)
+
+    workflow._decision_engine = _BrokenEngine()  # type: ignore[assignment]
+    assert workflow._fetch_recommendation(MarketRegime.TREND) is None
+
+
+def test_regime_workflow_weight_and_plugin_metadata_helpers() -> None:
+    workflow = _workflow([MarketRegime.TREND])
+    workflow.register_preset(
+        MarketRegime.TREND,
+        name="trend-meta",
+        entries=[{"engine": "daily_trend_momentum", "name": "custom"}],
+        signing_key=b"k",
+        key_id="id",
+    )
+    activation = workflow.activate(
+        _market_frame(),
+        available_data={"ohlcv", "technical_indicators", "order_book", "spread_history"},
+        now=datetime(2024, 1, 7, 10, 0, tzinfo=timezone.utc),
+    )
+    weights = workflow._derive_weights(
+        activation,
+        SimpleNamespace(ensemble_weights={"": 1, "x": "NaN"}),
+    )
+    assert "custom" in weights
+    assert "day_trading" in weights
+    metadata = workflow._collect_plugin_metadata(weights)
+    assert "strategies" in metadata
+    assert "license_tiers" in metadata

--- a/tests/test_futures_spread_strategy.py
+++ b/tests/test_futures_spread_strategy.py
@@ -4,6 +4,7 @@ from bot_core.strategies.base import MarketSnapshot
 from bot_core.strategies.futures_spread import (
     FuturesSpreadSettings,
     FuturesSpreadStrategy,
+    _exit_reason,
 )
 
 
@@ -54,3 +55,43 @@ def test_futures_spread_strategy_triggers_exit_on_funding_risk() -> None:
     strategy.on_data(_snapshot(spread=1.2, basis=0.0, funding=0.0))
     exit_signals = strategy.on_data(_snapshot(spread=0.8, basis=0.0, funding=0.002))
     assert exit_signals and exit_signals[0].metadata["exit_reason"] == "funding_risk"
+
+
+def test_futures_spread_strategy_no_trade_below_threshold_and_spread_z_alias() -> None:
+    strategy = FuturesSpreadStrategy(FuturesSpreadSettings(entry_z=2.0, exit_z=0.2))
+    snapshot = MarketSnapshot(
+        symbol="BTC-USD",
+        timestamp=1,
+        open=20000.0,
+        high=20010.0,
+        low=19950.0,
+        close=20005.0,
+        volume=12.0,
+        indicators={"spread_z": 1.5, "basis": 0.0, "funding_rate": 0.0},
+    )
+    assert strategy.on_data(snapshot) == []
+
+
+def test_futures_spread_strategy_basis_and_time_exits_reset_state() -> None:
+    basis_strategy = FuturesSpreadStrategy(
+        FuturesSpreadSettings(entry_z=1.0, exit_z=0.1, max_bars=5, funding_exit=9.0, basis_exit=0.01)
+    )
+    basis_strategy.on_data(_snapshot(spread=1.2, basis=0.0, funding=0.0))
+    basis_exit = basis_strategy.on_data(_snapshot(spread=1.1, basis=-0.02, funding=0.0))
+    assert basis_exit and basis_exit[0].metadata["exit_reason"] == "basis_breakout"
+    assert basis_strategy.on_data(_snapshot(spread=0.0, basis=0.0, funding=0.0)) == []
+
+    time_strategy = FuturesSpreadStrategy(
+        FuturesSpreadSettings(entry_z=1.0, exit_z=0.1, max_bars=1, funding_exit=9.0, basis_exit=9.0)
+    )
+    time_strategy.on_data(_snapshot(spread=-1.2, basis=0.0, funding=0.0))
+    timed = time_strategy.on_data(_snapshot(spread=-1.1, basis=0.0, funding=0.0))
+    assert timed and timed[0].metadata["exit_reason"] == "time_stop"
+
+
+def test_exit_reason_helper_priorities_and_unknown() -> None:
+    assert _exit_reason(True, True, True, True) == "spread_mean_revert"
+    assert _exit_reason(False, True, True, True) == "funding_risk"
+    assert _exit_reason(False, False, True, True) == "basis_breakout"
+    assert _exit_reason(False, False, False, True) == "time_stop"
+    assert _exit_reason(False, False, False, False) == "unknown"


### PR DESCRIPTION
### Motivation
- The curated blocking gate failed because coverage for a narrow set of strategy modules was below the required 75%, with the largest gaps in `bot_core.strategies.regime_workflow`, `day_trading`, and `futures_spread`. 
- The change focuses on closing real, high-ROI coverage holes by adding branch- and guard-oriented tests rather than weakening the gate or changing coverage settings. 

### Description
- Added tests in `tests/strategies/test_day_trading_strategy.py` to cover `DayTradingSettings` validation, `from_parameters`, no-signal guard paths, `time_exit`, `momentum_fade`, `teardown` reset, and midpoint-zero bias behavior. 
- Extended `tests/test_futures_spread_strategy.py` to exercise no-trade below threshold, `spread_z` alias handling, basis/time exit branches, state reset after close, and `_exit_reason` priority/unknown cases. 
- Extended `tests/strategies/test_regime_workflow.py` with helper/guard tests for `_normalize_regime`, `_gather_strings`, history-slicing edge cases, `_missing_data`, `_resolve_fallback` error paths, schedule exception handling, candidate probability clamping and metadata, recommendation success/failure, and weight/plugin metadata derivation. 
- Changes modify only test files and add branch-oriented assertions; no production code or CI/workflow/coverage thresholds were changed. 

### Testing
- Reproduced the curated CI command locally via `python -m pytest --cov=...` and iteratively ran subsets while adding tests; the important commands used were `python -m pytest tests/strategies/test_day_trading_strategy.py tests/test_futures_spread_strategy.py tests/strategies/test_regime_workflow.py`, `python -m pytest tests/strategies/test_day_trading_strategy.py tests/test_futures_spread_strategy.py tests/test_cross_exchange_hedge_strategy.py tests/strategies/test_regime_workflow.py --cov=bot_core.strategies.day_trading --cov=bot_core.strategies.futures_spread --cov=bot_core.strategies.cross_exchange_hedge --cov=bot_core.strategies.regime_workflow --cov-report=term-missing -q`, and the full curated gate command used by CI. 
- Results: the focused test runs passed (e.g. `26 passed` for the immediate strategy tests), broader curated subset passed (`28 passed` for the focused coverage run of strategy modules), and the full CI-equivalent curated gate completed successfully with `157 passed` and final total coverage `81.38%`, which satisfies the `--cov-fail-under=75` requirement. 
- No production code changes were introduced and all new tests are deterministic and branch-oriented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81cb1485c832aa3379acfdda2ac8d)