### PR TITLE
Apply Ruff formatter-only fixes in controller and tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2801,8 +2801,8 @@ class TradingController:
                         tracked.assisted_override_used
                         or autonomy_chain.get("assisted_override_used")
                     )
-                    tracked.blocking_reason = (
-                        tracked.blocking_reason or autonomy_chain.get("blocking_reason")
+                    tracked.blocking_reason = tracked.blocking_reason or autonomy_chain.get(
+                        "blocking_reason"
                     )
                     tracked.autonomy_decisive_stage = (
                         tracked.autonomy_decisive_stage
@@ -2930,8 +2930,8 @@ class TradingController:
                             tracked.assisted_override_used
                             or autonomy_chain.get("assisted_override_used")
                         )
-                        tracked.blocking_reason = (
-                            tracked.blocking_reason or autonomy_chain.get("blocking_reason")
+                        tracked.blocking_reason = tracked.blocking_reason or autonomy_chain.get(
+                            "blocking_reason"
                         )
                         tracked.autonomy_decisive_stage = (
                             tracked.autonomy_decisive_stage
@@ -3027,9 +3027,7 @@ class TradingController:
                         "autonomy_local_guard_effective_mode"
                     ),
                     autonomy_final_mode=autonomy_chain.get("autonomy_final_mode"),
-                    autonomous_execution_allowed=autonomy_chain.get(
-                        "autonomous_execution_allowed"
-                    ),
+                    autonomous_execution_allowed=autonomy_chain.get("autonomous_execution_allowed"),
                     assisted_override_used=autonomy_chain.get("assisted_override_used"),
                     blocking_reason=autonomy_chain.get("blocking_reason"),
                     autonomy_decisive_stage=autonomy_chain.get("autonomy_decisive_stage"),

--- a/tests/test_futures_spread_strategy.py
+++ b/tests/test_futures_spread_strategy.py
@@ -74,7 +74,9 @@ def test_futures_spread_strategy_no_trade_below_threshold_and_spread_z_alias() -
 
 def test_futures_spread_strategy_basis_and_time_exits_reset_state() -> None:
     basis_strategy = FuturesSpreadStrategy(
-        FuturesSpreadSettings(entry_z=1.0, exit_z=0.1, max_bars=5, funding_exit=9.0, basis_exit=0.01)
+        FuturesSpreadSettings(
+            entry_z=1.0, exit_z=0.1, max_bars=5, funding_exit=9.0, basis_exit=0.01
+        )
     )
     basis_strategy.on_data(_snapshot(spread=1.2, basis=0.0, funding=0.0))
     basis_exit = basis_strategy.on_data(_snapshot(spread=1.1, basis=-0.02, funding=0.0))

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -6795,7 +6795,9 @@ def test_opportunity_autonomy_assisted_approval_open_and_persistence_contract_st
     _assert_autonomy_contract_consistent_with_provenance(open_event, final_labels[0].provenance)
 
 
-def test_opportunity_autonomy_assisted_without_approval_blocks_without_execution_persistence() -> None:
+def test_opportunity_autonomy_assisted_without_approval_blocks_without_execution_persistence() -> (
+    None
+):
     repository = _autonomy_shadow_repository_with_final_outcomes(
         [16.0, 14.0, 12.0, 10.0, 8.0, 6.0], environment="live", portfolio_id="live-1"
     )


### PR DESCRIPTION
### Motivation
- Address Ruff formatter drift reported in three files while keeping changes strictly formatting-only and scope-limited.
- Ensure no logic, naming, or behavioral changes were introduced during formatting.

### Description
- `bot_core/runtime/controller.py`: reformatted three expression/argument line breaks (two `blocking_reason` assignments and one `autonomous_execution_allowed` argument) to satisfy Ruff line/paren style without changing semantics.
- `tests/test_futures_spread_strategy.py`: wrapped a long `FuturesSpreadSettings(...)` call across multiple lines for readability per Ruff.
- `tests/test_trading_controller.py`: reformatted the test function return annotation to a multiline form to satisfy Ruff.
- Changes were committed with a scoped commit message and only the three targeted files were modified.

### Testing
- Ran `python -m ruff format bot_core/runtime/controller.py tests/test_futures_spread_strategy.py tests/test_trading_controller.py`, which reported the 3 files left unchanged after applying the patch.
- Ran `python -m pre_commit run --all-files --show-diff-on-failure`, which failed in this environment with `No module named pre_commit` (hook runner not available).
- Ran `python -m pytest -q tests/test_futures_spread_strategy.py -xvv`, which failed during collection with `ModuleNotFoundError: No module named 'pandas'`.
- Ran `python -m pytest -q tests/test_trading_controller.py -xvv`, which failed during collection with `ModuleNotFoundError: No module named 'numpy'`.
- Verified `git diff` and `git status --short` showing only the three scoped files were changed and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c78510ec832aab74229dbd10eb12)