### PR TITLE
Preserve restored tracker lineage when scope continuity is missing

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2598,6 +2598,21 @@ class TradingController:
                         scope_resolution = "restored_tracker"
             return scope_environment, scope_portfolio, scope_resolution
 
+        def _is_restored_tracker_scope_gap(
+            tracker_hint: _OpportunityOpenOutcomeTracker | None,
+        ) -> bool:
+            # Auditable precedence exception: when a tracker was restored from legacy/open outcomes
+            # but lacks full scope continuity, close/proxy lineage must stay conservative and
+            # preserve restored tracker provenance instead of promoting shadow/opportunity lineage.
+            return bool(
+                tracker_hint is not None
+                and tracker_hint.restored_from_repository
+                and (
+                    tracker_hint.environment_scope is None
+                    or tracker_hint.portfolio_scope is None
+                )
+            )
+
         correlation_key = str(request_metadata.get("opportunity_shadow_record_key") or "").strip()
         side = str(request.side or "").upper()
         is_filled_or_partial = (
@@ -2882,7 +2897,10 @@ class TradingController:
                     if OpportunityShadowRepository._quality_rank(
                         existing_quality
                     ) < OpportunityShadowRepository._quality_rank("partial_exit_unconfirmed"):
-                        preserve_tracker_model_version = not tracked.restored_from_repository
+                        preserve_tracker_model_version = (
+                            not tracked.restored_from_repository
+                            or _is_restored_tracker_scope_gap(tracked)
+                        )
                         request_payload_raw = request_metadata.get("opportunity_autonomy_decision")
                         if isinstance(request_payload_raw, Mapping):
                             payload_model_raw = request_payload_raw.get("model_version")
@@ -3081,6 +3099,7 @@ class TradingController:
             model_version, decision_source = _resolve_runtime_lineage(
                 correlation_key,
                 tracker_hint=proxy_tracker,
+                prefer_tracker_model_version=_is_restored_tracker_scope_gap(proxy_tracker),
             )
             scope_environment, scope_portfolio, scope_resolution = _resolve_runtime_scope(
                 proxy_tracker

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -11381,6 +11381,141 @@ def test_controller_proxy_attach_after_restart_with_legacy_scope_gap_is_auditabl
     assert labels[0].provenance.get("decision_source") == "legacy-source"
 
 
+def test_controller_partial_close_after_restart_with_legacy_scope_gap_preserves_lineage_contract(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    shadow_repo.upsert_open_outcome(
+        shadow_repo.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "legacy_without_scope",
+                "model_version": "legacy-v1",
+                "decision_source": "legacy-source",
+            },
+        )
+    )
+
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=StatusExecutionService(
+            status="partially_filled",
+            filled_quantity=0.4,
+            avg_price=110.0,
+        ),
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="wrong-portfolio-after-restart",
+        environment="live",
+        risk_profile="balanced",
+        decision_journal=CollectingDecisionJournal(),
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _signal("SELL", price=110.0)
+    signal.metadata = {
+        **dict(signal.metadata),
+        "opportunity_shadow_record_key": correlation_key,
+    }
+    controller.process_signals([signal])
+
+    labels = shadow_repo.load_outcome_labels()
+    assert len(labels) == 1
+    assert labels[0].label_quality == "partial_exit_unconfirmed"
+    assert labels[0].provenance.get("scope_continuity") == "restored_tracker_scope_missing"
+    assert labels[0].provenance.get("model_version") == "legacy-v1"
+    assert labels[0].provenance.get("decision_source") == "legacy-source"
+    assert labels[0].provenance.get("upstream_autonomy_inference_model") is None
+    assert labels[0].provenance.get("upstream_autonomy_inference_model_version") is None
+
+
+def test_controller_proxy_attach_after_restart_with_legacy_scope_gap_preserves_lineage_contract(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    shadow_repo.upsert_open_outcome(
+        shadow_repo.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "legacy_without_scope",
+                "model_version": "legacy-v1",
+                "decision_source": "legacy-source",
+            },
+        )
+    )
+
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=StatusExecutionService(
+            status="rejected",
+            filled_quantity=0.0,
+            avg_price=None,
+        ),
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="wrong-portfolio-after-restart",
+        environment="live",
+        risk_profile="balanced",
+        decision_journal=CollectingDecisionJournal(),
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _signal("BUY", price=99.0)
+    signal.metadata = {
+        **dict(signal.metadata),
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_decision_timestamp": decision_timestamp.isoformat(),
+    }
+    controller.process_signals([signal])
+
+    labels = shadow_repo.load_outcome_labels()
+    assert len(labels) == 1
+    assert labels[0].label_quality == "execution_proxy_pending_exit"
+    assert labels[0].provenance.get("scope_continuity") == "restored_tracker_scope_missing"
+    assert labels[0].provenance.get("model_version") == "legacy-v1"
+    assert labels[0].provenance.get("decision_source") == "legacy-source"
+    assert labels[0].provenance.get("upstream_autonomy_inference_model") is None
+    assert labels[0].provenance.get("upstream_autonomy_inference_model_version") is None
+
+
 def test_controller_multihop_restart_partial_then_final_persists_recovered_lineage(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Ensure lineage provenance from restored/open-outcome trackers is not unintentionally promoted when the restored tracker lacks environment or portfolio scope continuity.

### Description
- Add helper `_is_restored_tracker_scope_gap` to detect restored trackers missing `environment_scope` or `portfolio_scope` and document the auditable precedence exception. 
- Keep restored tracker model lineage when a scope gap is detected by changing the `preserve_tracker_model_version` logic to honor `_is_restored_tracker_scope_gap`. 
- Prefer the tracker model version for proxy attachment resolution by passing `_is_restored_tracker_scope_gap(proxy_tracker)` into `_resolve_runtime_lineage`.
- Update provenance emitted on outcome labels to reflect `scope_continuity == "restored_tracker_scope_missing"` and preserve legacy `model_version`/`decision_source` where applicable.

### Testing
- Added unit tests `test_controller_partial_close_after_restart_with_legacy_scope_gap_preserves_lineage_contract` and `test_controller_proxy_attach_after_restart_with_legacy_scope_gap_preserves_lineage_contract` to assert preserved provenance and scope continuity. 
- Ran `pytest tests/test_trading_controller.py -q` and the modified tests passed. 
- Existing related outcome/provenance tests also passed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c8e0d480832a9e39ccf67a513ec3)