### PR TITLE
Add retry logic and extra pip args to wheelhouse downloader; add unit tests

### DIFF
--- a/scripts/ci/build_wheelhouse.py
+++ b/scripts/ci/build_wheelhouse.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import os
+import time
 import subprocess
 import sys
 from pathlib import Path
@@ -34,6 +35,7 @@ def build_download_cmd(
     args: argparse.Namespace,
     packages: Iterable[str],
     python_executable: str,
+    extra_pip_args: Iterable[str] | None = None,
 ) -> list[str]:
     cmd = [python_executable, "-m", "pip", "download", "--dest", str(wheelhouse)]
     if args.no_binary:
@@ -46,6 +48,8 @@ def build_download_cmd(
         cmd.extend(["--find-links", args.find_links])
     if args.only_binary:
         cmd.extend(["--only-binary", args.only_binary])
+    if extra_pip_args:
+        cmd.extend(extra_pip_args)
     cmd.extend(packages)
     return cmd
 
@@ -71,11 +75,24 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def download(wheelhouse: Path, cmd: list[str]) -> None:
-    print("[wheelhouse]", " ".join(cmd))
-    result = subprocess.run(cmd, check=False)
-    if result.returncode != 0:
-        raise SystemExit(f"Download failed with exit code {result.returncode}")
+def download(wheelhouse: Path, cmd: list[str], *, attempts: int = 1, retry_delay_seconds: int = 5) -> None:
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    for attempt in range(1, attempts + 1):
+        print("[wheelhouse]", " ".join(cmd))
+        if attempts > 1:
+            print(f"[wheelhouse] attempt {attempt}/{attempts}")
+        result = subprocess.run(cmd, check=False)
+        if result.returncode == 0:
+            return
+        if attempt < attempts:
+            print(
+                f"[wheelhouse] download failed with exit code {result.returncode}; "
+                f"retrying in {retry_delay_seconds}s"
+            )
+            time.sleep(retry_delay_seconds)
+    raise SystemExit(f"Download failed with exit code {result.returncode}")
 
 
 def main(argv: list[str]) -> int:
@@ -90,7 +107,26 @@ def main(argv: list[str]) -> int:
         f"PySide6_Essentials=={args.pyside6_version}",
         f"shiboken6=={args.pyside6_version}",
     ]
-    download(wheelhouse, build_download_cmd(wheelhouse, args, pyside_packages, args.python))
+    download(
+        wheelhouse,
+        build_download_cmd(
+            wheelhouse,
+            args,
+            pyside_packages,
+            args.python,
+            extra_pip_args=[
+                "--no-cache-dir",
+                "--progress-bar",
+                "off",
+                "--timeout",
+                "120",
+                "--retries",
+                "5",
+            ],
+        ),
+        attempts=3,
+        retry_delay_seconds=5,
+    )
 
     # PEP 517 build backend tooling required by pyproject.toml
     bootstrap_packages = ["wheel", "setuptools>=68"]

--- a/tests/scripts/test_build_wheelhouse.py
+++ b/tests/scripts/test_build_wheelhouse.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.ci import build_wheelhouse
+
+
+def test_build_download_cmd_appends_extra_pip_args() -> None:
+    args = SimpleNamespace(
+        no_binary=None,
+        index_url=None,
+        extra_index_url=None,
+        find_links=None,
+        only_binary=":all:",
+    )
+
+    cmd = build_wheelhouse.build_download_cmd(
+        wheelhouse=Path("wheelhouse"),
+        args=args,
+        packages=["PySide6==6.10.2"],
+        python_executable="python",
+        extra_pip_args=["--no-cache-dir", "--timeout", "120"],
+    )
+
+    assert "--only-binary" in cmd
+    assert ":all:" in cmd
+    assert cmd[-4:] == ["--no-cache-dir", "--timeout", "120", "PySide6==6.10.2"]
+
+
+def test_download_retries_and_succeeds_on_third_attempt(monkeypatch, capsys) -> None:
+    returncodes = iter([1, 1, 0])
+    run_calls: list[list[str]] = []
+    sleep_calls: list[int] = []
+
+    def fake_run(cmd, check):
+        run_calls.append(cmd)
+        assert check is False
+        return SimpleNamespace(returncode=next(returncodes))
+
+    monkeypatch.setattr(build_wheelhouse.subprocess, "run", fake_run)
+    monkeypatch.setattr(build_wheelhouse.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+    build_wheelhouse.download(
+        wheelhouse=Path("wheelhouse"),
+        cmd=["python", "-m", "pip", "download", "PySide6==6.10.2"],
+        attempts=3,
+        retry_delay_seconds=7,
+    )
+
+    captured = capsys.readouterr()
+    assert len(run_calls) == 3
+    assert sleep_calls == [7, 7]
+    assert "attempt 1/3" in captured.out
+    assert "attempt 3/3" in captured.out
+
+
+def test_download_raises_after_last_failed_attempt(monkeypatch) -> None:
+    sleep_calls: list[int] = []
+
+    def fake_run(_cmd, check):
+        assert check is False
+        return SimpleNamespace(returncode=2)
+
+    monkeypatch.setattr(build_wheelhouse.subprocess, "run", fake_run)
+    monkeypatch.setattr(build_wheelhouse.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+    with pytest.raises(SystemExit, match="Download failed with exit code 2"):
+        build_wheelhouse.download(
+            wheelhouse=Path("wheelhouse"),
+            cmd=["python", "-m", "pip", "download", "PySide6==6.10.2"],
+            attempts=3,
+            retry_delay_seconds=5,
+        )
+
+    assert sleep_calls == [5, 5]
+
+
+@pytest.mark.parametrize("attempts", [0, -1])
+def test_download_rejects_attempts_less_than_one(attempts: int) -> None:
+    with pytest.raises(ValueError, match="attempts must be >= 1"):
+        build_wheelhouse.download(
+            wheelhouse=Path("wheelhouse"),
+            cmd=["python", "-m", "pip", "download", "PySide6==6.10.2"],
+            attempts=attempts,
+        )


### PR DESCRIPTION
### Motivation
- Make wheelhouse downloads more robust against transient network or pip failures by introducing retry behavior and configurable pip arguments.
- Allow passing additional pip flags such as timeouts and disabling cache to ensure deterministic downloads for known problematic packages like PySide6.

### Description
- Add an `extra_pip_args` parameter to `build_download_cmd` and include those args when constructing the pip download command.
- Extend `download` to accept `attempts` and `retry_delay_seconds`, retrying failed downloads with `time.sleep` and raising `SystemExit` after the last failure, and validate `attempts >= 1`.
- Apply `extra_pip_args` and `attempts=3`/`retry_delay_seconds=5` when downloading the PySide6 stack, and import `time` for retry delays.
- Add `tests/scripts/test_build_wheelhouse.py` with unit tests covering `extra_pip_args` handling, retry behavior, failure after retries, and validation of `attempts`.

### Testing
- Ran the new unit tests in `tests/scripts/test_build_wheelhouse.py` with `pytest`, which exercise `build_download_cmd` and `download` retry semantics and they passed.
- The tests mock `subprocess.run` and `time.sleep` to verify retry attempts, delays, and final error behavior and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8cc039dd4832ab0442d05a90dc3b8)