### PR TITLE
chore: fix Ruff formatter drift in trading controller scope

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1459,8 +1459,7 @@ class TradingController:
             }
             if (
                 duplicate_open_guard_enabled
-                and
-                existing_open_tracker is not None
+                and existing_open_tracker is not None
                 and str(existing_open_tracker.symbol) == str(request.symbol)
                 and not self._is_closing_side(str(existing_open_tracker.side), str(request.side))
             ):
@@ -2638,10 +2637,7 @@ class TradingController:
             return bool(
                 tracker_hint is not None
                 and tracker_hint.restored_from_repository
-                and (
-                    tracker_hint.environment_scope is None
-                    or tracker_hint.portfolio_scope is None
-                )
+                and (tracker_hint.environment_scope is None or tracker_hint.portfolio_scope is None)
             )
 
         correlation_key = str(request_metadata.get("opportunity_shadow_record_key") or "").strip()

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -9181,7 +9181,11 @@ def test_opportunity_autonomy_duplicate_open_reentry_same_runtime_is_suppressed(
         [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
     )
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     controller, execution, journal = _build_autonomy_controller(
         environment="paper",
@@ -9217,9 +9221,7 @@ def test_opportunity_autonomy_duplicate_open_reentry_same_runtime_is_suppressed(
         tracker_contract_before_replay
     )
     assert repository.load_outcome_labels() == labels_before_replay
-    skipped_events = [
-        event for event in journal.export() if event["event"] == "signal_skipped"
-    ]
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
     assert skipped_events
     assert skipped_events[-1]["reason"] == "duplicate_autonomous_open_reentry_suppressed"
     assert skipped_events[-1]["proxy_correlation_key"] == correlation_key
@@ -9239,11 +9241,17 @@ def test_opportunity_autonomy_duplicate_open_reentry_after_restart_is_suppressed
         [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
     )
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     controller_open, _journal_open = _build_autonomy_controller_with_execution(
         environment="paper",
-        execution_service=StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=100.0),
+        execution_service=StatusExecutionService(
+            status="filled", filled_quantity=1.0, avg_price=100.0
+        ),
         opportunity_shadow_repository=repository,
     )
     controller_open.process_signals(
@@ -9322,7 +9330,11 @@ def test_opportunity_autonomy_duplicate_open_guard_does_not_suppress_legit_close
         [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
     )
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     execution = SequencedExecutionService(
         [


### PR DESCRIPTION
### Motivation
- Fix Ruff formatter-only drift observed in two files to keep code style consistent without changing runtime behavior.

### Description
- Applied formatter-only whitespace and line-break adjustments in `bot_core/runtime/controller.py` to collapse multi-line boolean/list expressions into Ruff-preferred forms without altering semantics.
- Reformatted several list and call argument blocks in `tests/test_trading_controller.py` to satisfy Ruff style, preserving test logic and behavior.
- Only the two files `bot_core/runtime/controller.py` and `tests/test_trading_controller.py` were modified and no functional changes were made.

### Testing
- Ran `python -m ruff format bot_core/runtime/controller.py tests/test_trading_controller.py` which reported `2 files left unchanged` after formatting.
- Attempted `python -m pre_commit run --all-files --show-diff-on-failure` which failed in this environment due to missing `pre_commit` module.
- Ran `python -m pytest -q tests/test_trading_controller.py -xvv` which failed during collection due to missing dependency `numpy` (environment limitation, not related to the patch).
- Changes were committed with hash `08d8e51`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d0c057b8832aaaacc8efe7961f5a)