### PR TITLE
Relax latency parsing in runtime overview UI test

### DIFF
--- a/tests/ui/test_runtime_overview.py
+++ b/tests/ui/test_runtime_overview.py
@@ -2507,7 +2507,15 @@ def test_runtime_overview_cards_react_to_live_signals(tmp_path: Path) -> None:
         latency_label = cycle_group.findChild(QObject, "runtimeOverviewCycleLatency")
         assert latency_label is not None
         latency_text = latency_label.property("text")
-        assert "2450" in latency_text
+        latency_match = re.search(
+            r"p50:\s*(?P<p50>.+?)\s*ms\s*•\s*p95:\s*(?P<p95>.+?)\s*ms",
+            latency_text,
+        )
+        assert latency_match is not None
+        p50_compact = re.sub(r"\D", "", latency_match.group("p50"))
+        p95_compact = re.sub(r"\D", "", latency_match.group("p95"))
+        assert p50_compact == "1250"
+        assert p95_compact == "2450"
 
         runtime_service.push_longpoll_metrics(
             [


### PR DESCRIPTION
### Motivation
- Make the latency assertion in the runtime overview UI test robust to formatted or localized latency text by extracting numeric p50/p95 values instead of relying on a raw substring match.

### Description
- Replace the direct substring assertion against `latency_text` with a regex that extracts `p50` and `p95` fields and then compact them with `re.sub(r"\D", "", ...)` before asserting numeric equality to `1250` and `2450`.

### Testing
- Ran `pytest tests/ui/test_runtime_overview.py::test_runtime_overview_cards_react_to_live_signals` and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d1a1e7c8832ab94c91c1d172f889)