### PR TITLE
Fix formatter-only line-wrapping drift in controller, wheelhouse script, and trading tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1537,7 +1537,9 @@ class TradingController:
                     },
                 )
                 return None
-        correlation_key = str((request.metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+        correlation_key = str(
+            (request.metadata or {}).get("opportunity_shadow_record_key") or ""
+        ).strip()
         existing_open_tracker = (
             self._opportunity_open_outcomes.get(correlation_key) if correlation_key else None
         )

--- a/scripts/ci/build_wheelhouse.py
+++ b/scripts/ci/build_wheelhouse.py
@@ -75,7 +75,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def download(wheelhouse: Path, cmd: list[str], *, attempts: int = 1, retry_delay_seconds: int = 5) -> None:
+def download(
+    wheelhouse: Path, cmd: list[str], *, attempts: int = 1, retry_delay_seconds: int = 5
+) -> None:
     if attempts < 1:
         raise ValueError("attempts must be >= 1")
 

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -9405,7 +9405,11 @@ def test_opportunity_autonomy_duplicate_close_replay_same_runtime_is_suppressed(
         [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
     )
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     execution = SequencedExecutionService(
         [
@@ -9501,7 +9505,11 @@ def test_opportunity_autonomy_duplicate_close_replay_after_restart_is_suppressed
         [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
     )
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     execution_open = SequencedExecutionService(
         [
@@ -9592,7 +9600,11 @@ def test_opportunity_autonomy_duplicate_close_guard_does_not_suppress_legit_part
         [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
     )
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     execution = SequencedExecutionService(
         [
@@ -9660,7 +9672,11 @@ def test_opportunity_autonomy_duplicate_close_guard_does_not_apply_to_live_assis
         [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="live", portfolio_id="live-1"
     )
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     execution = SequencedExecutionService(
         [
@@ -9719,7 +9735,11 @@ def test_opportunity_autonomy_duplicate_close_guard_does_not_apply_to_non_autono
         [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
     )
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     execution = SequencedExecutionService(
         [


### PR DESCRIPTION
### Motivation
- Address formatter-only drift (line-wrapping) detected by the repository formatter in three files without changing behavior or logic.
- Keep the change minimal and strictly scoped to formatting in the specified files to satisfy lint/format checks.

### Description
- Reflowed a long inline expression into a multi-line assignment in `bot_core/runtime/controller.py` for `correlation_key` without altering semantics.
- Broke the `download(...)` signature into multiple lines in `scripts/ci/build_wheelhouse.py` for consistent formatting with no functional change.
- Reformatted several single-line list literals used in `repository.append_shadow_records(...)` to multi-line blocks in `tests/test_trading_controller.py` with no test logic changes.
- Changes were limited to exactly `bot_core/runtime/controller.py`, `scripts/ci/build_wheelhouse.py`, and `tests/test_trading_controller.py` and are formatter-only.

### Testing
- Ran `python -m ruff format bot_core/runtime/controller.py scripts/ci/build_wheelhouse.py tests/test_trading_controller.py`, which reported the files as formatted/left unchanged after the applied patches.
- Attempted `python -m pre_commit run --all-files --show-diff-on-failure`, but `pre_commit` is not available in the environment (`No module named pre_commit`).
- Ran `python -m pytest -q tests/test_trading_controller.py -xvv`, which failed during collection due to a missing dependency (`numpy`) unrelated to the formatter-only edits.
- Located and ran the narrow existing test file for the wheelhouse script with `python -m pytest -q tests/scripts/test_build_wheelhouse.py -xvv`, which passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d6862ac0832a8bd7252f3148e962)