### PR TITLE
ci: reformat pytest invocation in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,51 +216,51 @@ jobs:
 
       - name: Pytest (unit suite) with coverage
         shell: bash
-        run: >-
-          python -m pytest
-          --cov=bot_core.runtime.multi_strategy_scheduler
-          --cov=bot_core.runtime.journal
-          --cov=bot_core.strategies.base
-          --cov=bot_core.strategies.market_params
-          --cov=bot_core.strategies._volatility
-          --cov=bot_core.strategies.daily_trend
-          --cov=bot_core.strategies.day_trading
-          --cov=bot_core.strategies.mean_reversion
-          --cov=bot_core.strategies.volatility_target
-          --cov=bot_core.strategies.futures_spread
-          --cov=bot_core.strategies.cross_exchange_arbitrage
-          --cov=bot_core.strategies.cross_exchange_hedge
-          --cov=bot_core.strategies.regime_workflow
-          --cov-config=.coveragerc
-          --cov-report=xml
-          --cov-report=term
-          --cov-fail-under=75
-          --junitxml=test-results/pytest-unit.xml
-          tests/test_pipeline_paper.py
-          tests/test_risk_profiles.py
-          tests/test_mean_reversion_strategy.py
-          tests/test_volatility_target_strategy.py
-          tests/test_cross_exchange_arbitrage_strategy.py
-          tests/test_multi_strategy_scheduler.py
-          tests/test_backtest_dataset_library.py
-          tests/test_telemetry_risk_profiles.py
-          tests/test_trading_decision_journal.py
-          tests/test_smoke_demo_strategies_cli.py
-          tests/runtime/test_stage6_hypercare_cycle_runtime.py
-          tests/runtime/test_multi_strategy_scheduler_async.py
-          tests/test_journal_analysis.py
-          tests/test_journal_aggregation.py
-          # Intentional narrow blocking-gate subset for autonomy/governance contracts.
-          # Do not replace with full-file inclusion; broader autonomy regression stays in py-tests-* --fast.
-          tests/ai/test_opportunity_lifecycle.py::test_performance_guard_fail_closed_on_invalid_snapshot
-          tests/ai/test_opportunity_lifecycle.py::test_execution_permission_denied_blocks_all_environments
-          tests/ai/test_opportunity_lifecycle.py::test_execution_permission_live_assisted_requires_live_override
-          tests/test_trading_controller.py::test_opportunity_autonomy_runtime_lineage_payload_precedes_stale_request_metadata
-          tests/test_trading_controller.py::test_opportunity_autonomy_permission_failure_fails_closed
-          tests/test_trading_controller.py::test_opportunity_autonomy_enforcement_contract_keys_present_for_fail_closed_guard_paths
-          tests/strategies/test_regime_workflow.py
-          tests/strategies/test_day_trading_strategy.py
-          tests/test_futures_spread_strategy.py
+        # Intentional narrow blocking-gate subset for autonomy/governance contracts.
+        # Do not replace with full-file inclusion; broader autonomy regression stays in py-tests-* --fast.
+        run: |
+          python -m pytest \
+            --cov=bot_core.runtime.multi_strategy_scheduler \
+            --cov=bot_core.runtime.journal \
+            --cov=bot_core.strategies.base \
+            --cov=bot_core.strategies.market_params \
+            --cov=bot_core.strategies._volatility \
+            --cov=bot_core.strategies.daily_trend \
+            --cov=bot_core.strategies.day_trading \
+            --cov=bot_core.strategies.mean_reversion \
+            --cov=bot_core.strategies.volatility_target \
+            --cov=bot_core.strategies.futures_spread \
+            --cov=bot_core.strategies.cross_exchange_arbitrage \
+            --cov=bot_core.strategies.cross_exchange_hedge \
+            --cov=bot_core.strategies.regime_workflow \
+            --cov-config=.coveragerc \
+            --cov-report=xml \
+            --cov-report=term \
+            --cov-fail-under=75 \
+            --junitxml=test-results/pytest-unit.xml \
+            tests/test_pipeline_paper.py \
+            tests/test_risk_profiles.py \
+            tests/test_mean_reversion_strategy.py \
+            tests/test_volatility_target_strategy.py \
+            tests/test_cross_exchange_arbitrage_strategy.py \
+            tests/test_multi_strategy_scheduler.py \
+            tests/test_backtest_dataset_library.py \
+            tests/test_telemetry_risk_profiles.py \
+            tests/test_trading_decision_journal.py \
+            tests/test_smoke_demo_strategies_cli.py \
+            tests/runtime/test_stage6_hypercare_cycle_runtime.py \
+            tests/runtime/test_multi_strategy_scheduler_async.py \
+            tests/test_journal_analysis.py \
+            tests/test_journal_aggregation.py \
+            tests/ai/test_opportunity_lifecycle.py::test_performance_guard_fail_closed_on_invalid_snapshot \
+            tests/ai/test_opportunity_lifecycle.py::test_execution_permission_denied_blocks_all_environments \
+            tests/ai/test_opportunity_lifecycle.py::test_execution_permission_live_assisted_requires_live_override \
+            tests/test_trading_controller.py::test_opportunity_autonomy_runtime_lineage_payload_precedes_stale_request_metadata \
+            tests/test_trading_controller.py::test_opportunity_autonomy_permission_failure_fails_closed \
+            tests/test_trading_controller.py::test_opportunity_autonomy_enforcement_contract_keys_present_for_fail_closed_guard_paths \
+            tests/strategies/test_regime_workflow.py \
+            tests/strategies/test_day_trading_strategy.py \
+            tests/test_futures_spread_strategy.py \
           tests/test_cross_exchange_hedge_strategy.py
 
       - name: Upload coverage report


### PR DESCRIPTION
### Motivation

- Improve readability and reliability of the CI `pytest` invocation and ensure the autonomy/gating comment is not embedded inside the shell command.

### Description

- Move the "Intentional narrow blocking-gate for autonomy/governance contracts" comment above the `run` key so it is not part of the shell block.
- Replace the folded `run: >-` block with a multiline `run: |` and break the `python -m pytest` invocation onto multiple lines using backslashes for clarity.
- Preserve the original coverage flags, `--junitxml` output, and the same narrow subset of test files that act as the blocking gate.

### Testing

- The repository `pre-commit` lint step (`python -m pre_commit run --all-files`) was executed as part of CI and passed.
- The updated `python -m pytest` unit-suite command was executed in CI and produced the coverage report (`coverage.xml`) and junit artifact (`test-results/pytest-unit.xml`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8db114430832a93568ac6665cdc03)