### PR TITLE
Add Windows QML isolation contract test and include pytest-xdist in test extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ test = [
   "pytest>=7.4",
   "pytest-asyncio>=0.23",
   "pytest-cov>=4.1",
+  "pytest-xdist>=3.5",
   "grpcio-tools>=1.62,<2",
   "PyYAML>=6.0",
   "pyarrow>=12.0",

--- a/tests/scripts/test_qml_windows_isolation_contract.py
+++ b/tests/scripts/test_qml_windows_isolation_contract.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - only for Python < 3.11 in local tooling
+    tomllib = None
+
+
+def _read_test_extra_entries(pyproject_text: str) -> list[str]:
+    if tomllib is not None:
+        pyproject = tomllib.loads(pyproject_text)
+        return list(pyproject["project"]["optional-dependencies"]["test"])
+
+    entries: list[str] = []
+    in_test_block = False
+    for raw_line in pyproject_text.splitlines():
+        line = raw_line.strip()
+        if not in_test_block and line == "test = [":
+            in_test_block = True
+            continue
+        if in_test_block:
+            if line == "]":
+                break
+            if line.startswith('"') and line.endswith('",'):
+                entries.append(line[1:-2])
+    return entries
+
+
+def test_windows_qml_runner_isolation_contract_matches_test_extras() -> None:
+    script = Path("scripts/run_qml_tests_windows.ps1").read_text(encoding="utf-8")
+    requires_boxed = "import xdist" in script and "--boxed" in script
+    supports_forked_fallback = "import pytest_forked" in script and "--forked" in script
+
+    assert requires_boxed or supports_forked_fallback, (
+        "Windows QML runner must require at least one pytest isolation mechanism "
+        "(xdist/--boxed or pytest-forked/--forked)."
+    )
+    assert "pytest isolation unavailable" in script
+
+    test_extra = _read_test_extra_entries(Path("pyproject.toml").read_text(encoding="utf-8"))
+    provides_xdist = any(dep.startswith("pytest-xdist") for dep in test_extra)
+    provides_forked = any(dep.startswith("pytest-forked") for dep in test_extra)
+
+    if requires_boxed:
+        assert provides_xdist, (
+            "project.optional-dependencies.test must include pytest-xdist for "
+            "scripts/run_qml_tests_windows.ps1 isolation preflight"
+        )
+    else:
+        assert supports_forked_fallback and provides_forked, (
+            "project.optional-dependencies.test must include pytest-forked when "
+            "Windows QML runner relies on --forked isolation"
+        )


### PR DESCRIPTION
### Motivation

- Ensure the Windows QML test runner script has its isolation mechanism requirements mirrored in the project's test extras so CI and local runs install the necessary isolation tooling.  
- Make explicit that either `pytest-xdist` or `pytest-forked` is provided when the runner relies on `--boxed`/`--forked` isolation in `scripts/run_qml_tests_windows.ps1`.

### Description

- Add `tests/scripts/test_qml_windows_isolation_contract.py` which verifies that `scripts/run_qml_tests_windows.ps1` requires an isolation mechanism and that the corresponding dependency (`pytest-xdist` or `pytest-forked`) is present in `project.optional-dependencies.test`.  
- Update `pyproject.toml` to include `pytest-xdist>=3.5` in the `test` optional-dependencies list.

### Testing

- No automated test run was executed as part of this rollout; the new contract test is intended to be executed via `pytest` in CI and will fail if the script and `pyproject.toml` become out of sync.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8dcf5e570832ab79d950399145b46)