### PR TITLE
Remove pytest isolation enforcement from Windows QML runner and update contract test

### DIFF
--- a/scripts/run_qml_tests_windows.ps1
+++ b/scripts/run_qml_tests_windows.ps1
@@ -32,26 +32,6 @@ $pytestArgs = @(
   "--log-file-level=INFO"
 )
 
-$supportsBoxed = $false
-$supportsForked = $false
-& python -c "import xdist" 2>$null
-if ($LASTEXITCODE -eq 0) {
-  $supportsBoxed = $true
-} else {
-  & python -c "import pytest_forked" 2>$null
-  if ($LASTEXITCODE -eq 0) {
-    $supportsForked = $true
-  }
-}
-if ($supportsBoxed) {
-  $pytestArgs += "--boxed"
-} elseif ($supportsForked) {
-  $pytestArgs += "--forked"
-} else {
-  Write-Error "pytest isolation unavailable: install pytest-xdist (--boxed) or pytest-forked (--forked)."
-  exit 1
-}
-
 if ($supportsTimeout) {
   $pytestArgs += "--timeout=$PytestTimeoutSeconds"
 } else {

--- a/tests/scripts/test_qml_windows_isolation_contract.py
+++ b/tests/scripts/test_qml_windows_isolation_contract.py
@@ -2,54 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - only for Python < 3.11 in local tooling
-    tomllib = None
-
-
-def _read_test_extra_entries(pyproject_text: str) -> list[str]:
-    if tomllib is not None:
-        pyproject = tomllib.loads(pyproject_text)
-        return list(pyproject["project"]["optional-dependencies"]["test"])
-
-    entries: list[str] = []
-    in_test_block = False
-    for raw_line in pyproject_text.splitlines():
-        line = raw_line.strip()
-        if not in_test_block and line == "test = [":
-            in_test_block = True
-            continue
-        if in_test_block:
-            if line == "]":
-                break
-            if line.startswith('"') and line.endswith('",'):
-                entries.append(line[1:-2])
-    return entries
-
-
-def test_windows_qml_runner_isolation_contract_matches_test_extras() -> None:
+def test_windows_qml_runner_isolation_contract() -> None:
     script = Path("scripts/run_qml_tests_windows.ps1").read_text(encoding="utf-8")
-    requires_boxed = "import xdist" in script and "--boxed" in script
-    supports_forked_fallback = "import pytest_forked" in script and "--forked" in script
-
-    assert requires_boxed or supports_forked_fallback, (
-        "Windows QML runner must require at least one pytest isolation mechanism "
-        "(xdist/--boxed or pytest-forked/--forked)."
-    )
-    assert "pytest isolation unavailable" in script
-
-    test_extra = _read_test_extra_entries(Path("pyproject.toml").read_text(encoding="utf-8"))
-    provides_xdist = any(dep.startswith("pytest-xdist") for dep in test_extra)
-    provides_forked = any(dep.startswith("pytest-forked") for dep in test_extra)
-
-    if requires_boxed:
-        assert provides_xdist, (
-            "project.optional-dependencies.test must include pytest-xdist for "
-            "scripts/run_qml_tests_windows.ps1 isolation preflight"
-        )
-    else:
-        assert supports_forked_fallback and provides_forked, (
-            "project.optional-dependencies.test must include pytest-forked when "
-            "Windows QML runner relies on --forked isolation"
-        )
+    assert "--boxed" not in script, "Windows QML runner must not pass unsupported --boxed flag."
+    assert "--forked" not in script, "Windows QML runner must not force pytest-forked isolation."
+    assert "import pytest_forked" not in script, "Windows QML runner must not require pytest-forked."


### PR DESCRIPTION
### Motivation
- The Windows QML test runner previously enforced pytest isolation via `pytest-xdist`/`--boxed` or `pytest-forked`/`--forked`, which is no longer desired and caused tight coupling with `pyproject` extras.
- The contract test was tightly coupled to TOML parsing and verifying project extras for isolation support and needed simplification to reflect the runner's new behavior.

### Description
- Removed the preflight detection and enforcement of `pytest-xdist`/`--boxed` and `pytest-forked`/`--forked` from `scripts/run_qml_tests_windows.ps1`.
- Preserved existing timeout and ProcDump handling while simplifying the pytest invocation argument construction.
- Simplified `tests/scripts/test_qml_windows_isolation_contract.py` by removing TOML parsing and `pyproject` checks, renaming the test, and asserting that the script does not use `--boxed`, `--forked`, or `import pytest_forked`.

### Testing
- Ran `pytest tests/scripts/test_qml_windows_isolation_contract.py` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e4e83440832a9f58e8563eef7599)