### PR TITLE
style: fix formatter drift in QML Windows isolation contract test

### DIFF
--- a/tests/scripts/test_qml_windows_isolation_contract.py
+++ b/tests/scripts/test_qml_windows_isolation_contract.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+
 def test_windows_qml_runner_isolation_contract() -> None:
     script = Path("scripts/run_qml_tests_windows.ps1").read_text(encoding="utf-8")
     assert "--boxed" not in script, "Windows QML runner must not pass unsupported --boxed flag."
     assert "--forked" not in script, "Windows QML runner must not force pytest-forked isolation."
-    assert "import pytest_forked" not in script, "Windows QML runner must not require pytest-forked."
+    assert "import pytest_forked" not in script, (
+        "Windows QML runner must not require pytest-forked."
+    )


### PR DESCRIPTION
### Motivation
- Fix a formatter-only drift in `tests/scripts/test_qml_windows_isolation_contract.py` to satisfy project formatting rules without changing test logic or behavior.

### Description
- Apply the exact formatter-only edits: add a blank line after imports and reformat the final assertion into a parenthesized multi-line form in `tests/scripts/test_qml_windows_isolation_contract.py`, with no semantic or runtime changes.

### Testing
- Ran `python -m ruff format tests/scripts/test_qml_windows_isolation_contract.py` (file left unchanged after patch), `python -m pre_commit run --all-files --show-diff-on-failure` (failed in this environment due to missing `pre_commit`), and `python -m pytest -q tests/scripts/test_qml_windows_isolation_contract.py -xvv` (1 passed), and committed the formatter-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d912aab124832a94b96c2a7ef51261)