### PR TITLE
style: fix formatter drift in trading controller files

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1012,7 +1012,9 @@ class TradingController:
             if scope_environment and shadow_environment != scope_environment:
                 continue
             matching_shadow_scope_candidate_exists = True
-            proposed_direction = str(getattr(shadow_record, "proposed_direction", "")).strip().lower()
+            proposed_direction = (
+                str(getattr(shadow_record, "proposed_direction", "")).strip().lower()
+            )
             expected_open_side = (
                 "BUY"
                 if proposed_direction in {"long", "buy"}

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -12566,7 +12566,9 @@ def test_opportunity_autonomy_duplicate_close_guard_prefers_later_same_scope_aut
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-order-a-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-order-a-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -12652,7 +12654,9 @@ def test_opportunity_autonomy_duplicate_close_guard_prefers_same_scope_autonomou
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-order-b-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-order-b-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -12738,7 +12742,9 @@ def test_opportunity_autonomy_duplicate_close_guard_ignores_same_scope_non_auton
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-order-c-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-order-c-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -12824,7 +12830,9 @@ def test_opportunity_autonomy_duplicate_close_guard_does_not_suppress_when_no_sa
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-order-d-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-order-d-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -12910,7 +12918,9 @@ def test_opportunity_autonomy_duplicate_close_guard_does_not_suppress_when_auton
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-a-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-a-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -12980,7 +12990,9 @@ def test_opportunity_autonomy_duplicate_close_guard_does_not_suppress_when_auton
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-b-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-b-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -13050,7 +13062,9 @@ def test_opportunity_autonomy_duplicate_close_guard_ignores_scope_incomplete_lab
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-c-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-c-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -13135,7 +13149,9 @@ def test_opportunity_autonomy_duplicate_close_guard_ignores_scope_incomplete_lab
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-d-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-d-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -13220,7 +13236,9 @@ def test_opportunity_autonomy_duplicate_close_guard_full_same_scope_autonomous_s
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-e-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-scope-incomplete-e-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -13294,7 +13312,9 @@ def test_opportunity_autonomy_duplicate_close_guard_prefers_same_scope_shadow_re
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-shadow-scope-a-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-shadow-scope-a-"))
+    )
     shadow_repo.append_shadow_records(
         [
             OpportunityShadowRecord(
@@ -13386,7 +13406,9 @@ def test_opportunity_autonomy_duplicate_close_guard_prefers_same_scope_shadow_re
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-shadow-scope-b-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-shadow-scope-b-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -13478,7 +13500,9 @@ def test_opportunity_autonomy_duplicate_close_guard_does_not_suppress_when_only_
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-shadow-scope-c-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-shadow-scope-c-"))
+    )
     shadow_repo.append_shadow_records(
         [
             OpportunityShadowRecord(
@@ -13569,7 +13593,9 @@ def test_opportunity_autonomy_duplicate_close_guard_shadow_record_direction_orde
     )
 
     def _run_case(records: list[OpportunityShadowRecord]) -> list[dict[str, str]]:
-        shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-shadow-scope-d-")))
+        shadow_repo = OpportunityShadowRepository(
+            Path(tempfile.mkdtemp(prefix="duplicate-shadow-scope-d-"))
+        )
         shadow_repo.append_shadow_records(records)
         shadow_repo.append_outcome_labels(
             [


### PR DESCRIPTION
### Motivation
- Resolve formatter-only drift reported by pre-commit/ruff by applying line-wrapping changes without altering runtime behavior or semantics.
- Keep the scope strictly to the two files that showed formatting differences to avoid unintended changes.

### Description
- Wrapped the long `proposed_direction` assignment in `bot_core/runtime/controller.py` to satisfy the formatter without changing logic. 
- Reflowed multiple `OpportunityShadowRepository(Path(tempfile.mkdtemp(...)))` constructor calls in `tests/test_trading_controller.py` into multi-line form to match the formatter. 
- No functional code, names, messages, or contracts were modified and all edits are formatter-only. 
- Changes were limited exclusively to `bot_core/runtime/controller.py` and `tests/test_trading_controller.py`.

### Testing
- Ran `python -m ruff format bot_core/runtime/controller.py tests/test_trading_controller.py` which reported the files left unchanged after applying the formatter patch. 
- Ran `python -m pre_commit run --all-files --show-diff-on-failure` and the pre-commit hooks passed. 
- Ran `python -m pytest -q tests/test_trading_controller.py -xvv` which failed during collection due to missing runtime dependencies in the test environment (`jsonschema` and other packages), preventing full test collection (collection error reported). 
- Verified `git diff -- bot_core/runtime/controller.py tests/test_trading_controller.py` shows only the formatter-only diff and `git status --short` indicated the working tree was committed, final commit hash `d0c5d27`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95c76bb04832abde23988b25fa1b1)