### PR TITLE
style: fix formatter-only drift in tests/test_trading_controller.py

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -13312,7 +13312,9 @@ def test_opportunity_autonomy_duplicate_close_guard_legacy_shadow_missing_enviro
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-shadow-legacy-missing-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-shadow-legacy-missing-"))
+    )
     shadow_repo.append_shadow_records(
         [
             _shadow_record_for_key(
@@ -13417,7 +13419,9 @@ def test_opportunity_autonomy_duplicate_close_guard_legacy_shadow_environment_fa
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-shadow-legacy-blank-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-shadow-legacy-blank-"))
+    )
     shadow_repo.append_shadow_records(
         [
             OpportunityShadowRecord(
@@ -13507,7 +13511,9 @@ def test_opportunity_autonomy_duplicate_close_guard_mixed_legacy_and_same_scope_
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-shadow-legacy-mixed-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-shadow-legacy-mixed-"))
+    )
     legacy_missing_scope = OpportunityShadowRecord(
         record_key=correlation_key,
         symbol="BTC/USDT",
@@ -13530,7 +13536,9 @@ def test_opportunity_autonomy_duplicate_close_guard_mixed_legacy_and_same_scope_
         correlation_key=correlation_key,
         decision_timestamp=decision_timestamp,
     )
-    records = [legacy_missing_scope, same_scope] if legacy_first else [same_scope, legacy_missing_scope]
+    records = (
+        [legacy_missing_scope, same_scope] if legacy_first else [same_scope, legacy_missing_scope]
+    )
     shadow_repo.append_shadow_records(records)
     shadow_repo.append_outcome_labels(
         [
@@ -13599,7 +13607,9 @@ def test_opportunity_autonomy_duplicate_close_guard_foreign_plus_legacy_shadow_f
         model_version="opportunity-v1",
         rank=1,
     )
-    shadow_repo = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="duplicate-shadow-legacy-foreign-")))
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-shadow-legacy-foreign-"))
+    )
     legacy_missing_scope = OpportunityShadowRecord(
         record_key=correlation_key,
         symbol="BTC/USDT",
@@ -13636,7 +13646,11 @@ def test_opportunity_autonomy_duplicate_close_guard_foreign_plus_legacy_shadow_f
         snapshot={},
         context=OpportunityShadowContext(environment="live"),
     )
-    records = [legacy_missing_scope, foreign_scope] if legacy_first else [foreign_scope, legacy_missing_scope]
+    records = (
+        [legacy_missing_scope, foreign_scope]
+        if legacy_first
+        else [foreign_scope, legacy_missing_scope]
+    )
     shadow_repo.append_shadow_records(records)
     shadow_repo.append_outcome_labels(
         [


### PR DESCRIPTION
### Motivation
- Address formatter-only line-wrapping drift detected by the project's formatter to keep the test file consistent with style rules without altering behavior.

### Description
- Applied formatting-only changes in `tests/test_trading_controller.py`, breaking long expressions into multi-line calls for `OpportunityShadowRepository(...)` and wrapping ternary list expressions in parentheses to satisfy the formatter.
- Changes are strictly stylistic with no logic, API, naming, or behavioral modifications and touch only `tests/test_trading_controller.py`.

### Testing
- `python -m ruff format tests/test_trading_controller.py` ran and reported the file unchanged after the patch (success).
- `python -m pre_commit run --all-files --show-diff-on-failure` failed due to missing `pre_commit` module in the environment (environment error).
- `python -m pytest -q tests/test_trading_controller.py -xvv` failed during collection due to missing dependency `numpy` (environment error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9623d0884832aac974bfc16d72118)