### PR TITLE
Make duplicate autonomous open guard scope-aware

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1033,6 +1033,72 @@ class TradingController:
             return False
         return False
 
+    def _matches_current_open_tracker_scope(
+        self,
+        *,
+        correlation_key: str,
+        symbol: str,
+        tracker: _OpportunityOpenOutcomeTracker,
+    ) -> bool:
+        scope_environment = str(self.environment or "").strip()
+        scope_portfolio = str(self.portfolio_id or "").strip()
+        tracker_environment = str(tracker.environment_scope or "").strip()
+        tracker_portfolio = str(tracker.portfolio_scope or "").strip()
+        if tracker_environment:
+            if scope_environment and tracker_environment != scope_environment:
+                return False
+        if tracker_portfolio:
+            if scope_portfolio and tracker_portfolio != scope_portfolio:
+                return False
+        if scope_portfolio and not tracker_portfolio:
+            return False
+        if tracker_environment and tracker_portfolio:
+            return True
+        repository = self._opportunity_shadow_repository
+        if repository is None:
+            return not (scope_environment and not tracker_environment) and not (
+                scope_portfolio and not tracker_portfolio
+            )
+        try:
+            shadow_records = repository.load_shadow_records()
+        except Exception:  # pragma: no cover - diagnostics only
+            return not (scope_environment and not tracker_environment) and not (
+                scope_portfolio and not tracker_portfolio
+            )
+        has_same_scope_shadow = False
+        has_foreign_scope_shadow = False
+        has_legacy_scope_shadow = False
+        for shadow_record in shadow_records:
+            if shadow_record.record_key != correlation_key:
+                continue
+            if str(getattr(shadow_record, "symbol", "")) != str(symbol):
+                continue
+            shadow_context = getattr(shadow_record, "context", None)
+            if isinstance(shadow_context, Mapping):
+                shadow_environment_raw = shadow_context.get("environment")
+            else:
+                shadow_environment_raw = getattr(shadow_context, "environment", None)
+            shadow_environment = (
+                str(shadow_environment_raw).strip() if shadow_environment_raw is not None else ""
+            )
+            shadow_environment_normalized = shadow_environment.lower()
+            if shadow_environment_normalized in {"", "shadow"}:
+                has_legacy_scope_shadow = True
+                continue
+            if scope_environment and shadow_environment == scope_environment:
+                has_same_scope_shadow = True
+                continue
+            has_foreign_scope_shadow = True
+        if has_same_scope_shadow:
+            return True
+        if has_foreign_scope_shadow:
+            return False
+        if has_legacy_scope_shadow:
+            return True
+        return not (scope_environment and not tracker_environment) and not (
+            scope_portfolio and not tracker_portfolio
+        )
+
     def _record_decision_event(
         self,
         event_type: str,
@@ -1619,6 +1685,11 @@ class TradingController:
             if (
                 duplicate_open_guard_enabled
                 and existing_open_tracker is not None
+                and self._matches_current_open_tracker_scope(
+                    correlation_key=correlation_key,
+                    symbol=str(request.symbol),
+                    tracker=existing_open_tracker,
+                )
                 and str(existing_open_tracker.symbol) == str(request.symbol)
                 and not self._is_closing_side(str(existing_open_tracker.side), str(request.side))
             ):

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -9347,6 +9347,467 @@ def test_opportunity_autonomy_duplicate_open_reentry_after_restart_is_suppressed
     assert skipped_events[-1]["proxy_correlation_key"] == correlation_key
 
 
+def test_opportunity_autonomy_duplicate_open_guard_foreign_scope_restored_tracker_does_not_suppress() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 13, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                context=OpportunityShadowContext(environment="live"),
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "restored_foreign_scope",
+                "environment": "live",
+                "portfolio": "live-1",
+            },
+        )
+    )
+
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=101.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="paper_autonomous",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                include_decision_payload=True,
+                decision_effective_mode="paper_autonomous",
+                decision_primary_reason="foreign_scope_open_should_execute",
+            )
+        ]
+    )
+
+    assert len(execution.requests) == 1
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert [
+        event
+        for event in skipped_events
+        if event.get("reason") == "duplicate_autonomous_open_reentry_suppressed"
+    ] == []
+
+
+@pytest.mark.parametrize("legacy_first", [True, False])
+def test_opportunity_autonomy_duplicate_open_guard_legacy_missing_scope_with_foreign_shadow_is_order_independent(
+    legacy_first: bool,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 8, 14, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    legacy_shadow = replace(
+        _shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp),
+        context=OpportunityShadowContext(environment="shadow"),
+    )
+    foreign_shadow = replace(
+        _shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp),
+        context=OpportunityShadowContext(environment="live"),
+    )
+    repository.append_shadow_records([legacy_shadow, foreign_shadow] if legacy_first else [foreign_shadow, legacy_shadow])
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={"source": "legacy_missing_scope"},
+        )
+    )
+
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=101.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="paper_autonomous",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                include_decision_payload=True,
+                decision_effective_mode="paper_autonomous",
+                decision_primary_reason="legacy_foreign_shadow_should_execute",
+            )
+        ]
+    )
+
+    assert len(execution.requests) == 1
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert [
+        event
+        for event in skipped_events
+        if event.get("reason") == "duplicate_autonomous_open_reentry_suppressed"
+    ] == []
+
+
+def test_opportunity_autonomy_duplicate_open_guard_legacy_missing_scope_with_same_scope_shadow_does_not_suppress_without_portfolio_proof() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 15, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                context=OpportunityShadowContext(environment="paper"),
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={"source": "legacy_missing_scope"},
+        )
+    )
+
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=101.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="paper_autonomous",
+                side="BUY",
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+                include_decision_payload=True,
+                decision_effective_mode="paper_autonomous",
+                decision_primary_reason="legacy_same_scope_without_portfolio_proof_should_execute",
+            )
+        ]
+    )
+
+    assert len(execution.requests) == 1
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert [
+        event
+        for event in skipped_events
+        if event.get("reason") == "duplicate_autonomous_open_reentry_suppressed"
+    ] == []
+
+
+def test_opportunity_autonomy_duplicate_open_guard_same_environment_foreign_portfolio_restored_tracker_does_not_suppress() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 16, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                context=OpportunityShadowContext(environment="paper"),
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "restored_foreign_portfolio",
+                "environment": "paper",
+                "portfolio": "paper-foreign",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=101.0)
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=CollectingDecisionJournal(),
+        opportunity_shadow_repository=repository,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="same_env_foreign_portfolio_should_execute",
+    )
+    controller.process_signals([signal])
+
+    assert len(execution.requests) == 1
+
+
+def test_opportunity_autonomy_duplicate_open_guard_legacy_missing_portfolio_same_environment_does_not_suppress_cross_portfolio() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 17, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                context=OpportunityShadowContext(environment="paper"),
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "legacy_missing_portfolio",
+                "environment": "paper",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=101.0)
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=CollectingDecisionJournal(),
+        opportunity_shadow_repository=repository,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="legacy_missing_portfolio_should_not_suppress",
+    )
+    controller.process_signals([signal])
+
+    assert len(execution.requests) == 1
+
+
+def test_opportunity_autonomy_duplicate_open_guard_explicit_foreign_tracker_scope_wins_over_same_scope_shadow() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 18, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                context=OpportunityShadowContext(environment="paper"),
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "explicit_foreign_tracker_scope",
+                "environment": "paper",
+                "portfolio": "paper-foreign",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=101.0)
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=CollectingDecisionJournal(),
+        opportunity_shadow_repository=repository,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="explicit_foreign_tracker_should_execute",
+    )
+    controller.process_signals([signal])
+
+    assert len(execution.requests) == 1
+
+
+def test_opportunity_autonomy_duplicate_open_guard_explicit_same_scope_tracker_wins_over_foreign_shadow() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 19, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                context=OpportunityShadowContext(environment="live"),
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "explicit_same_scope_tracker_scope",
+                "environment": "paper",
+                "portfolio": "paper-1",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=101.0)
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="explicit_same_scope_should_suppress",
+    )
+    controller.process_signals([signal])
+
+    assert len(execution.requests) == 0
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert skipped_events[-1]["reason"] == "duplicate_autonomous_open_reentry_suppressed"
+
+
 def test_opportunity_autonomy_duplicate_open_guard_does_not_suppress_legit_close() -> None:
     decision_timestamp = datetime(2026, 1, 9, 12, 0, tzinfo=timezone.utc)
     correlation_key = OpportunityShadowRecord.build_record_key(


### PR DESCRIPTION
### Motivation
- Duplicate autonomous open suppression needed to consider environment and portfolio scope so restored or cross-scope open trackers do not incorrectly block legitimate re-entries.
- Legacy shadow records (empty or "shadow" environment) must be handled specially while still preferring explicit scope information when available.

### Description
- Added a new helper `_matches_current_open_tracker_scope` on `TradingController` that compares the controller scope, an existing open tracker, and shadow repository records to determine whether the tracker is in the same operational scope (environment/portfolio) as the controller or represents a foreign/legacy scope.
- Integrated the new scope check into the duplicate-open guard flow so that suppression now only applies when the existing open tracker matches the controller scope according to repository and provenance rules.
- The scope matcher consults the `opportunity_shadow_repository` when available and falls back to conservative behavior when the repository is missing or errors, and it treats legacy scope markers (empty or "shadow") specially.

### Testing
- Added multiple unit tests in `tests/test_trading_controller.py` covering foreign scope restores, legacy-shadow ordering, same-environment/foreign-portfolio cases, explicit tracker scope precedence, and ensuring legitimate closes are not suppressed, and all new tests exercise the duplicate-open guard semantics.
- Ran the trading controller unit tests including the new parametrized and scope-specific tests in `tests/test_trading_controller.py`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9603138c4832aaa28a629153e2f6d)