### PR TITLE
Clamp autonomous restored tracker close requests to remaining quantity and validate tracker quantities

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -938,6 +938,23 @@ class TradingController:
         }
         return bool(autonomy_modes & {"paper_autonomous", "live_autonomous"})
 
+    @staticmethod
+    def _remaining_quantity_for_tracker(
+        tracker: _OpportunityOpenOutcomeTracker | None,
+    ) -> float | None:
+        if tracker is None:
+            return None
+        try:
+            entry_quantity = float(tracker.entry_quantity)
+            closed_quantity = float(tracker.closed_quantity)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(entry_quantity) or not math.isfinite(closed_quantity):
+            return None
+        if entry_quantity < 0.0 or closed_quantity < 0.0:
+            return None
+        return max(0.0, entry_quantity - closed_quantity)
+
     def _is_duplicate_autonomous_close_replay(
         self,
         *,
@@ -1755,6 +1772,48 @@ class TradingController:
                         },
                     )
                     return None
+        if (
+            existing_open_tracker is not None
+            and self._is_closing_side(str(existing_open_tracker.side), str(request.side))
+            and self._is_autonomous_restored_tracker_contract(existing_open_tracker)
+        ):
+            remaining_quantity = self._remaining_quantity_for_tracker(existing_open_tracker)
+            if remaining_quantity is None:
+                self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+                self._record_decision_event(
+                    "signal_skipped",
+                    signal=signal,
+                    request=request,
+                    status="skipped",
+                    metadata={
+                        "reason": "restored_tracker_remaining_quantity_invalid_suppressed",
+                        "proxy_correlation_key": correlation_key,
+                    },
+                )
+                return None
+            if remaining_quantity <= 1e-12:
+                self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+                self._record_decision_event(
+                    "signal_skipped",
+                    signal=signal,
+                    request=request,
+                    status="skipped",
+                    metadata={
+                        "reason": "restored_tracker_remaining_quantity_exhausted_suppressed",
+                        "proxy_correlation_key": correlation_key,
+                    },
+                )
+                return None
+            if request.quantity > remaining_quantity + 1e-12:
+                request = replace(
+                    request,
+                    quantity=remaining_quantity,
+                    metadata={
+                        **dict(request.metadata or {}),
+                        "restored_tracker_remaining_quantity": remaining_quantity,
+                        "restored_tracker_quantity_clamped": True,
+                    },
+                )
         if self._is_duplicate_autonomous_close_replay(
             request=request,
             correlation_key=correlation_key,

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -10371,6 +10371,243 @@ def test_opportunity_autonomy_duplicate_close_replay_after_restart_prunes_stale_
     assert skipped_events[-1]["proxy_correlation_key"] == correlation_key
 
 
+def test_opportunity_autonomy_restored_tracker_partial_close_clamps_to_remaining_quantity() -> None:
+    decision_timestamp = datetime(2026, 1, 11, 13, 30, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.4,
+            provenance={
+                "source": "restored_partial_tracker",
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", avg_price=111.0)
+    controller, _journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=False,
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "quantity": "0.8"}
+    controller.process_signals([close_signal])
+
+    assert len(execution.requests) == 1
+    assert execution.requests[0].quantity == pytest.approx(0.6, rel=1e-6)
+    request_metadata = execution.requests[0].metadata or {}
+    assert request_metadata.get("restored_tracker_remaining_quantity") == pytest.approx(0.6, rel=1e-6)
+    assert request_metadata.get("restored_tracker_quantity_clamped") is True
+    assert repository.load_open_outcomes() == []
+
+
+def test_opportunity_autonomy_restored_tracker_partial_close_allows_exact_remaining_quantity() -> None:
+    decision_timestamp = datetime(2026, 1, 11, 13, 40, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.4,
+            provenance={
+                "source": "restored_partial_tracker",
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", avg_price=111.0)
+    controller, _journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=False,
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "quantity": "0.6"}
+    controller.process_signals([close_signal])
+
+    assert len(execution.requests) == 1
+    assert execution.requests[0].quantity == pytest.approx(0.6, rel=1e-6)
+    assert repository.load_open_outcomes() == []
+
+
+def test_opportunity_autonomy_restored_tracker_inconsistent_closed_quantity_fail_closed_skip() -> None:
+    decision_timestamp = datetime(2026, 1, 11, 13, 50, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=1.5,
+            provenance={
+                "source": "restored_inconsistent_tracker",
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", avg_price=111.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=False,
+    )
+    controller.process_signals([close_signal])
+
+    assert execution.requests == []
+    skipped_events = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and event.get("reason") == "restored_tracker_remaining_quantity_exhausted_suppressed"
+    ]
+    assert skipped_events
+    assert skipped_events[-1]["proxy_correlation_key"] == correlation_key
+
+
+def test_opportunity_autonomy_restored_tracker_negative_closed_quantity_invalid_fail_closed_skip() -> None:
+    decision_timestamp = datetime(2026, 1, 11, 13, 55, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=-0.1,
+            provenance={
+                "source": "restored_invalid_tracker",
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", avg_price=111.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=False,
+    )
+    controller.process_signals([close_signal])
+
+    assert execution.requests == []
+    skipped_events = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and event.get("reason") == "restored_tracker_remaining_quantity_invalid_suppressed"
+    ]
+    assert skipped_events
+    assert skipped_events[-1]["proxy_correlation_key"] == correlation_key
+
+
 def test_opportunity_autonomy_restored_tracker_runtime_position_absent_suppresses_close_execution_after_restart() -> (
     None
 ):


### PR DESCRIPTION
### Motivation

- Prevent execution of duplicate or invalid close orders after controller restart by validating restored open-outcome trackers and ensuring closed requests do not exceed remaining quantity.

### Description

- Add `_remaining_quantity_for_tracker` helper to compute a validated remaining quantity from `entry_quantity` and `closed_quantity`, returning `None` on invalid inputs and clamped non-negative remainder otherwise.
- Before duplicate-replay checks, detect autonomous restored open trackers when processing a closing-side request and skip the signal if the remaining quantity is invalid or exhausted, recording metrics and decision events for diagnostics.
- Clamp the `OrderRequest.quantity` to the remaining quantity when a requested close exceeds the remaining amount and annotate the request `metadata` with `restored_tracker_remaining_quantity` and `restored_tracker_quantity_clamped`.
- Add unit tests that exercise partial clamps, exact-remaining closes, and invalid/exhausted restored-tracker scenarios.

### Testing

- Added and ran `pytest` tests: `test_opportunity_autonomy_restored_tracker_partial_close_clamps_to_remaining_quantity`, `test_opportunity_autonomy_restored_tracker_partial_close_allows_exact_remaining_quantity`, `test_opportunity_autonomy_restored_tracker_inconsistent_closed_quantity_fail_closed_skip`, and `test_opportunity_autonomy_restored_tracker_negative_closed_quantity_invalid_fail_closed_skip`, and they passed.
- Existing autonomy replay/duplicate-close tests were exercised and remained passing with the new checks in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d973b4e854832ab04d907cb80eab9f)