### PR TITLE
Suppress conflicting autonomous-open candidates during batch signal processing

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1334,6 +1334,7 @@ class TradingController:
         """Przetwarza listę sygnałów strategii i zarządza alertami."""
         results: list[OrderResult] = []
         ai_blocked = self._update_ai_failover_state()
+        autonomous_open_conflicts = self._collect_autonomous_open_arbitration_conflicts(signals)
 
         prioritized: list[tuple[int, int, StrategySignal, str]] = []
         for index, signal in enumerate(signals):
@@ -1356,6 +1357,20 @@ class TradingController:
                     signal=signal,
                     status="skipped",
                     metadata={"reason": "ai_failover_active", "mode": mode},
+                )
+                continue
+            if self._is_autonomous_open_arbitration_conflict_signal(
+                signal=signal,
+                conflict_groups=autonomous_open_conflicts,
+            ):
+                self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+                self._record_decision_event(
+                    "signal_skipped",
+                    signal=signal,
+                    status="skipped",
+                    metadata={
+                        "reason": "autonomous_open_candidate_arbitration_conflict_fail_closed",
+                    },
                 )
                 continue
             priority = self._signal_mode_priorities.get(mode, self._default_signal_priority)
@@ -1395,6 +1410,80 @@ class TradingController:
 
         self.maybe_report_health()
         return results
+
+    def _collect_autonomous_open_arbitration_conflicts(
+        self,
+        signals: Sequence[StrategySignal],
+    ) -> set[tuple[str, str, str, str]]:
+        grouped_keys: dict[tuple[str, str, str, str], set[str]] = {}
+        for signal in signals:
+            candidate = self._autonomous_open_arbitration_candidate(signal)
+            if candidate is None:
+                continue
+            group_key, correlation_key = candidate
+            grouped_keys.setdefault(group_key, set()).add(correlation_key)
+        return {group_key for group_key, keys in grouped_keys.items() if len(keys) > 1}
+
+    def _is_autonomous_open_arbitration_conflict_signal(
+        self,
+        *,
+        signal: StrategySignal,
+        conflict_groups: set[tuple[str, str, str, str]],
+    ) -> bool:
+        candidate = self._autonomous_open_arbitration_candidate(signal)
+        if candidate is None:
+            return False
+        group_key, _correlation_key = candidate
+        return group_key in conflict_groups
+
+    def _autonomous_open_arbitration_candidate(
+        self,
+        signal: StrategySignal,
+    ) -> tuple[tuple[str, str, str, str], str] | None:
+        metadata = signal.metadata if isinstance(signal.metadata, Mapping) else {}
+        mode_raw = metadata.get("opportunity_autonomy_mode")
+        mode = str(mode_raw or "").strip().lower()
+        if mode not in {"paper_autonomous", "live_autonomous"}:
+            return None
+
+        correlation_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if not correlation_key:
+            return None
+        if self._opportunity_open_outcomes.get(correlation_key) is not None:
+            return None
+
+        decision_timestamp = str(metadata.get("opportunity_decision_timestamp") or "").strip()
+        if not decision_timestamp:
+            return None
+        normalized_side = _normalize_trade_side(signal.side)
+        if normalized_side is None:
+            return None
+        repository = self._opportunity_shadow_repository
+        if repository is not None:
+            try:
+                shadow_records = repository.load_shadow_records()
+            except Exception:  # pragma: no cover - diagnostics only
+                shadow_records = ()
+            shadow_record = next(
+                (row for row in shadow_records if str(getattr(row, "record_key", "")) == correlation_key),
+                None,
+            )
+            if shadow_record is not None:
+                proposed_direction = str(getattr(shadow_record, "proposed_direction", "")).strip().lower()
+                expected_open_side = (
+                    "BUY"
+                    if proposed_direction in {"long", "buy"}
+                    else ("SELL" if proposed_direction in {"short", "sell"} else "")
+                )
+                if expected_open_side and self._is_closing_side(expected_open_side, normalized_side):
+                    return None
+        group_key = (
+            str(signal.symbol).strip(),
+            decision_timestamp,
+            mode,
+            normalized_side,
+        )
+        return group_key, correlation_key
 
     def maybe_report_health(self, *, force: bool = False) -> None:
         """Publikuje raport health-check, gdy minął interwał lub wymusimy wysyłkę."""

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -9449,6 +9449,353 @@ def test_opportunity_autonomy_duplicate_open_reentry_same_runtime_is_suppressed(
     assert skipped_events[-1]["proxy_correlation_key"] == correlation_key
 
 
+@pytest.mark.parametrize("reversed_input_order", [False, True])
+def test_opportunity_autonomy_batch_multiple_open_candidates_fail_closed_deterministically(
+    reversed_input_order: bool,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 11, 12, 0, tzinfo=timezone.utc)
+    correlation_key_a = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    correlation_key_b = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key_a, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=correlation_key_b, decision_timestamp=decision_timestamp
+            ),
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=repository,
+    )
+    candidate_a = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key_a,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="candidate_a",
+    )
+    candidate_b = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key_b,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="candidate_b",
+    )
+    batch = [candidate_b, candidate_a] if reversed_input_order else [candidate_a, candidate_b]
+
+    results = controller.process_signals(batch)
+
+    assert results == []
+    assert len(execution.requests) == 0
+    assert repository.load_open_outcomes() == []
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert len(skipped_events) == 2
+    assert {
+        event.get("reason") for event in skipped_events
+    } == {"autonomous_open_candidate_arbitration_conflict_fail_closed"}
+
+
+def test_opportunity_autonomy_batch_multiple_open_candidates_replay_stays_fail_closed_without_provenance_mutation() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 11, 13, 0, tzinfo=timezone.utc)
+    correlation_key_a = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v2",
+        rank=1,
+    )
+    correlation_key_b = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v2",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key_a, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=correlation_key_b, decision_timestamp=decision_timestamp
+            ),
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=repository,
+    )
+    batch = [
+        _autonomy_signal_with_correlation(
+            mode="paper_autonomous",
+            side="BUY",
+            correlation_key=correlation_key_a,
+            decision_timestamp=decision_timestamp,
+            include_decision_payload=True,
+            decision_effective_mode="paper_autonomous",
+            decision_primary_reason="candidate_a",
+        ),
+        _autonomy_signal_with_correlation(
+            mode="paper_autonomous",
+            side="BUY",
+            correlation_key=correlation_key_b,
+            decision_timestamp=decision_timestamp,
+            include_decision_payload=True,
+            decision_effective_mode="paper_autonomous",
+            decision_primary_reason="candidate_b",
+        ),
+    ]
+    labels_before = repository.load_outcome_labels()
+
+    first = controller.process_signals(batch)
+    second = controller.process_signals(list(reversed(batch)))
+
+    assert first == []
+    assert second == []
+    assert len(execution.requests) == 0
+    assert repository.load_open_outcomes() == []
+    assert repository.load_outcome_labels() == labels_before
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert len(skipped_events) == 4
+    assert {
+        event.get("reason") for event in skipped_events
+    } == {"autonomous_open_candidate_arbitration_conflict_fail_closed"}
+
+
+def test_opportunity_autonomy_batch_mixed_buy_sell_does_not_trigger_open_arbitration_conflict() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 11, 14, 0, tzinfo=timezone.utc)
+    correlation_key_buy = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v3",
+        rank=1,
+    )
+    correlation_key_sell = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v3",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key_buy, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=correlation_key_sell, decision_timestamp=decision_timestamp
+            ),
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=repository,
+    )
+    buy_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key_buy,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="mixed_batch_buy",
+    )
+    sell_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key_sell,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="mixed_batch_sell",
+    )
+
+    results = controller.process_signals([buy_signal, sell_signal])
+
+    assert len(results) == 2
+    assert len(execution.requests) == 2
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert [
+        event
+        for event in skipped_events
+        if event.get("reason") == "autonomous_open_candidate_arbitration_conflict_fail_closed"
+    ] == []
+
+
+def test_opportunity_autonomy_close_signal_is_not_captured_by_open_arbitration_conflict_prescan() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 11, 15, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v4",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={"source": "existing_open_for_close_path"},
+        )
+    )
+
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=99.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="close_path_should_not_conflict",
+    )
+
+    results = controller.process_signals([close_signal])
+
+    assert len(results) == 1
+    assert len(execution.requests) == 1
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert [
+        event
+        for event in skipped_events
+        if event.get("reason") == "autonomous_open_candidate_arbitration_conflict_fail_closed"
+    ] == []
+
+
+def test_opportunity_autonomy_no_tracker_close_replay_batch_is_not_classified_as_open_conflict() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 11, 16, 0, tzinfo=timezone.utc)
+    correlation_key_a = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=1,
+    )
+    correlation_key_b = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key_a, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=correlation_key_b, decision_timestamp=decision_timestamp
+            ),
+        ]
+    )
+    _append_autonomous_final_label_for_correlation(
+        repository,
+        correlation_key=correlation_key_a,
+        decision_timestamp=decision_timestamp,
+        environment="paper",
+        portfolio_id="paper-1",
+    )
+    _append_autonomous_final_label_for_correlation(
+        repository,
+        correlation_key=correlation_key_b,
+        decision_timestamp=decision_timestamp,
+        environment="paper",
+        portfolio_id="paper-1",
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=99.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    close_a = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key_a,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="close_replay_a",
+    )
+    close_b = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key_b,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="close_replay_b",
+    )
+
+    results = controller.process_signals([close_a, close_b])
+
+    assert results == []
+    assert len(execution.requests) == 0
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert [
+        event
+        for event in skipped_events
+        if event.get("reason") == "autonomous_open_candidate_arbitration_conflict_fail_closed"
+    ] == []
+    replay_events = [
+        event
+        for event in skipped_events
+        if event.get("reason") == "duplicate_autonomous_close_replay_suppressed"
+    ]
+    assert len(replay_events) == 2
+
+
 def test_opportunity_autonomy_duplicate_open_reentry_after_restart_is_suppressed_and_contract_stable() -> (
     None
 ):


### PR DESCRIPTION
### Motivation

- Prevent multiple autonomous-open candidates for the same opportunity from being executed concurrently when they share the same symbol, decision timestamp, autonomy mode and trade side, which could cause duplicate opens or nondeterministic behavior.

### Description

- Added a pre-scan in `process_signals` to collect conflict groups via `_autonomous_open_arbitration_candidate_` and `_collect_autonomous_open_arbitration_conflicts_` and skip signals that belong to multi-candidate conflict groups.
- Implemented helper methods `_collect_autonomous_open_arbitration_conflicts_`, `_is_autonomous_open_arbitration_conflict_signal_`, and `_autonomous_open_arbitration_candidate_` to classify candidates based on `signal.metadata` keys (`opportunity_autonomy_mode`, `opportunity_shadow_record_key`, `opportunity_decision_timestamp`) and current `_opportunity_open_outcomes_` and shadow repository state.
- Ensured closing-side candidates (determined from shadow records or existing open outcomes) are not treated as open conflicts, and recorded skipped signals with the reason `autonomous_open_candidate_arbitration_conflict_fail_closed` while incrementing metrics accordingly.

### Testing

- Added multiple unit tests in `tests/test_trading_controller.py` including `test_opportunity_autonomy_batch_multiple_open_candidates_fail_closed_deterministically`, replay/ordering tests, mixed buy/sell behavior, close-signal exemptions, and no-tracker replay checks, which assert signals are skipped and repository/execution remain unchanged.
- All updated and new tests were run as part of the test suite and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da1dd22728832a917acc7024e05da3)