### PR TITLE
Apply formatter-only reflow fixes in controller and tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1465,17 +1465,25 @@ class TradingController:
             except Exception:  # pragma: no cover - diagnostics only
                 shadow_records = ()
             shadow_record = next(
-                (row for row in shadow_records if str(getattr(row, "record_key", "")) == correlation_key),
+                (
+                    row
+                    for row in shadow_records
+                    if str(getattr(row, "record_key", "")) == correlation_key
+                ),
                 None,
             )
             if shadow_record is not None:
-                proposed_direction = str(getattr(shadow_record, "proposed_direction", "")).strip().lower()
+                proposed_direction = (
+                    str(getattr(shadow_record, "proposed_direction", "")).strip().lower()
+                )
                 expected_open_side = (
                     "BUY"
                     if proposed_direction in {"long", "buy"}
                     else ("SELL" if proposed_direction in {"short", "sell"} else "")
                 )
-                if expected_open_side and self._is_closing_side(expected_open_side, normalized_side):
+                if expected_open_side and self._is_closing_side(
+                    expected_open_side, normalized_side
+                ):
                     return None
         group_key = (
             str(signal.symbol).strip(),

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -9517,9 +9517,9 @@ def test_opportunity_autonomy_batch_multiple_open_candidates_fail_closed_determi
     assert repository.load_open_outcomes() == []
     skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
     assert len(skipped_events) == 2
-    assert {
-        event.get("reason") for event in skipped_events
-    } == {"autonomous_open_candidate_arbitration_conflict_fail_closed"}
+    assert {event.get("reason") for event in skipped_events} == {
+        "autonomous_open_candidate_arbitration_conflict_fail_closed"
+    }
 
 
 def test_opportunity_autonomy_batch_multiple_open_candidates_replay_stays_fail_closed_without_provenance_mutation() -> (
@@ -9587,9 +9587,9 @@ def test_opportunity_autonomy_batch_multiple_open_candidates_replay_stays_fail_c
     assert repository.load_outcome_labels() == labels_before
     skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
     assert len(skipped_events) == 4
-    assert {
-        event.get("reason") for event in skipped_events
-    } == {"autonomous_open_candidate_arbitration_conflict_fail_closed"}
+    assert {event.get("reason") for event in skipped_events} == {
+        "autonomous_open_candidate_arbitration_conflict_fail_closed"
+    }
 
 
 def test_opportunity_autonomy_batch_mixed_buy_sell_does_not_trigger_open_arbitration_conflict() -> (


### PR DESCRIPTION
### Motivation
- Fix formatter drift detected by pre-commit/ruff in two files without changing any runtime logic or behavior.

### Description
- Applied only whitespace/line-wrap reflows: expanded the generator expression and parenthesized long `str(...)` call and `if` condition in `bot_core/runtime/controller.py`, and reflowed two set-comprehension assertions in `tests/test_trading_controller.py`, touching only those two files.

### Testing
- Ran `python -m ruff format bot_core/runtime/controller.py tests/test_trading_controller.py` which passed, then `python -m pre_commit run --all-files --show-diff-on-failure` which passed after installing tooling, and attempted `python -m pytest -q tests/test_trading_controller.py -xvv` which failed during collection due to a missing runtime dependency (`pydantic`) even after installing `numpy`, `pandas`, and `cryptography`; the formatting changes themselves do not affect tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3e7f3d94832ab2b0872cfc87b6d5)