### PR TITLE
Formatter-only: wrap long lines in controller and trading tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1743,9 +1743,11 @@ class TradingController:
         request = self._build_order_request(signal, extra_metadata=decision_metadata)
         if self._is_opportunity_autonomy_enforced(signal, request):
             if self._is_autonomous_open_handoff_path(request):
-                contract_valid, missing_fields, mode, blocking_reason = self._validate_autonomous_open_handoff_contract(
-                    signal=signal,
-                    request=request,
+                contract_valid, missing_fields, mode, blocking_reason = (
+                    self._validate_autonomous_open_handoff_contract(
+                        signal=signal,
+                        request=request,
+                    )
                 )
                 if not contract_valid:
                     self._record_decision_event(
@@ -2198,7 +2200,9 @@ class TradingController:
         correlation_key = str(request_metadata.get("opportunity_shadow_record_key") or "").strip()
         if not correlation_key:
             missing_fields.append("opportunity_shadow_record_key")
-        decision_timestamp = str(request_metadata.get("opportunity_decision_timestamp") or "").strip()
+        decision_timestamp = str(
+            request_metadata.get("opportunity_decision_timestamp") or ""
+        ).strip()
         if not decision_timestamp:
             missing_fields.append("opportunity_decision_timestamp")
         if missing_fields:
@@ -2285,7 +2289,9 @@ class TradingController:
         scoped_candidates = []
         for candidate in timestamp_candidates:
             candidate_context = getattr(candidate, "context", None)
-            candidate_environment = str(getattr(candidate_context, "environment", "")).strip().lower()
+            candidate_environment = (
+                str(getattr(candidate_context, "environment", "")).strip().lower()
+            )
             if runtime_environment and candidate_environment != runtime_environment:
                 continue
             scoped_candidates.append(candidate)
@@ -2339,14 +2345,18 @@ class TradingController:
         scoped_candidates = []
         for candidate in symbol_candidates:
             candidate_context = getattr(candidate, "context", None)
-            candidate_environment = str(getattr(candidate_context, "environment", "")).strip().lower()
+            candidate_environment = (
+                str(getattr(candidate_context, "environment", "")).strip().lower()
+            )
             if runtime_environment and candidate_environment != runtime_environment:
                 continue
             scoped_candidates.append(candidate)
         if len(scoped_candidates) != 1:
             return True
         scoped_shadow_record = scoped_candidates[0]
-        proposed_direction = str(getattr(scoped_shadow_record, "proposed_direction", "")).strip().lower()
+        proposed_direction = (
+            str(getattr(scoped_shadow_record, "proposed_direction", "")).strip().lower()
+        )
         expected_open_side = (
             "BUY"
             if proposed_direction in {"long", "buy"}

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -22161,7 +22161,8 @@ def test_upstream_handoff_open_validator_does_not_block_legal_autonomous_close_o
     blocked_events = [
         event
         for event in journal.export()
-        if event.get("event") == "opportunity_autonomy_enforcement" and event.get("status") == "blocked"
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and event.get("status") == "blocked"
     ]
     assert blocked_events == []
 
@@ -22257,7 +22258,9 @@ def test_upstream_handoff_complete_contract_but_symbol_mismatch_shadow_record_is
     assert shadow_repo.load_outcome_labels() == []
     event = _last_event(journal, "opportunity_autonomy_enforcement")
     assert event["status"] == "blocked"
-    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_symbol_mismatch"
+    assert (
+        event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_symbol_mismatch"
+    )
 
 
 def test_upstream_handoff_complete_contract_but_dangling_shadow_reference_replay_is_stably_blocked(
@@ -22348,7 +22351,10 @@ def test_upstream_handoff_complete_contract_but_timestamp_mismatch_is_fail_close
     assert shadow_repo.load_outcome_labels() == []
     event = _last_event(journal, "opportunity_autonomy_enforcement")
     assert event["status"] == "blocked"
-    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    assert (
+        event["blocking_reason"]
+        == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    )
 
 
 def test_upstream_handoff_complete_contract_timestamp_mismatch_replay_is_stably_blocked(
@@ -22401,7 +22407,8 @@ def test_upstream_handoff_complete_contract_timestamp_mismatch_replay_is_stably_
     assert len(enforcement_events) == 2
     assert all(event["status"] == "blocked" for event in enforcement_events)
     assert all(
-        event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+        event["blocking_reason"]
+        == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
         for event in enforcement_events
     )
 
@@ -22492,7 +22499,10 @@ def test_upstream_handoff_payload_only_effective_mode_timestamp_mismatch_is_fail
     assert shadow_repo.load_outcome_labels() == []
     event = _last_event(journal, "opportunity_autonomy_enforcement")
     assert event["status"] == "blocked"
-    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    assert (
+        event["blocking_reason"]
+        == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    )
 
 
 def test_upstream_handoff_timestamp_mismatch_validator_does_not_block_legal_close_or_replay_close(
@@ -22543,7 +22553,9 @@ def test_upstream_handoff_timestamp_mismatch_validator_does_not_block_legal_clos
         "opportunity_shadow_record_key": correlation_key,
         "opportunity_decision_timestamp": shadow_timestamp.isoformat(),
     }
-    close_signal = _opportunity_autonomy_signal("paper_autonomous", side="SELL", include_decision_payload=True)
+    close_signal = _opportunity_autonomy_signal(
+        "paper_autonomous", side="SELL", include_decision_payload=True
+    )
     close_signal.metadata = {
         **dict(close_signal.metadata),
         "quantity": "1.0",
@@ -22567,7 +22579,8 @@ def test_upstream_handoff_timestamp_mismatch_validator_does_not_block_legal_clos
     blocked_events = [
         event
         for event in journal.export()
-        if event.get("event") == "opportunity_autonomy_enforcement" and event.get("status") == "blocked"
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and event.get("status") == "blocked"
     ]
     assert blocked_events == []
 
@@ -22678,7 +22691,9 @@ def test_upstream_handoff_scope_aware_resolution_is_order_independent_when_scope
         snapshot={},
         context=OpportunityShadowContext(environment="paper"),
     )
-    first, second = (foreign_record, scoped_record) if foreign_first else (scoped_record, foreign_record)
+    first, second = (
+        (foreign_record, scoped_record) if foreign_first else (scoped_record, foreign_record)
+    )
     shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
     shadow_repo.append_shadow_records([first, second])
     controller, execution, _journal = _build_autonomy_controller(
@@ -22833,7 +22848,9 @@ def test_upstream_handoff_scope_aware_resolution_blocks_ambiguous_same_scope_sha
     assert shadow_repo.load_open_outcomes() == []
     event = _last_event(journal, "opportunity_autonomy_enforcement")
     assert event["status"] == "blocked"
-    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_scope_ambiguous"
+    assert (
+        event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_scope_ambiguous"
+    )
 
 
 @pytest.mark.parametrize("foreign_first", (True, False))
@@ -22908,7 +22925,10 @@ def test_upstream_handoff_open_close_classifier_is_order_independent_for_actual_
     assert execution.requests == []
     event = _last_event(journal, "opportunity_autonomy_enforcement")
     assert event["status"] == "blocked"
-    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    assert (
+        event["blocking_reason"]
+        == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    )
 
 
 @pytest.mark.parametrize("foreign_first", (True, False))
@@ -22980,7 +23000,9 @@ def test_upstream_handoff_open_close_classifier_is_order_independent_for_legal_c
         decision_journal=journal,
         opportunity_shadow_repository=shadow_repo,
     )
-    close_signal = _opportunity_autonomy_signal("paper_autonomous", side="SELL", include_decision_payload=True)
+    close_signal = _opportunity_autonomy_signal(
+        "paper_autonomous", side="SELL", include_decision_payload=True
+    )
     close_signal.metadata = {
         **dict(close_signal.metadata),
         "quantity": "1.0",
@@ -22996,7 +23018,8 @@ def test_upstream_handoff_open_close_classifier_is_order_independent_for_legal_c
     blocked_events = [
         event
         for event in journal.export()
-        if event.get("event") == "opportunity_autonomy_enforcement" and event.get("status") == "blocked"
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and event.get("status") == "blocked"
     ]
     assert blocked_events == []
 
@@ -23074,7 +23097,10 @@ def test_upstream_handoff_payload_only_effective_mode_open_close_classifier_uses
     assert execution.requests == []
     event = _last_event(journal, "opportunity_autonomy_enforcement")
     assert event["status"] == "blocked"
-    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    assert (
+        event["blocking_reason"]
+        == "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    )
 
 
 def test_upstream_handoff_mixed_batch_e2e_contract_is_identical_in_controller_and_persistence_regardless_of_order() -> (


### PR DESCRIPTION
### Motivation
- Fix formatter drift reported by project linters by adjusting line wraps only in the two affected files without changing behavior.

### Description
- Applied purely stylistic line-wrapping changes in `bot_core/runtime/controller.py` to break long assignments and expressions into multiple lines without altering logic.
- Applied equivalent stylistic line-wrapping changes in `tests/test_trading_controller.py` for long conditions, assertions, and helper calls without changing test semantics.
- Changes are confined to exactly those two files and do not modify names, messages, control flow, or contracts.

### Testing
- Ran `python -m ruff format bot_core/runtime/controller.py tests/test_trading_controller.py` which completed with the two files left unchanged after formatting.
- Ran `python -m pre_commit run --all-files --show-diff-on-failure` which failed due to missing `pre_commit` module in the environment (`No module named pre_commit`).
- Ran `python -m pytest -q tests/test_trading_controller.py -xvv` which failed during collection due to a missing runtime dependency (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da74166cd4832abb16ffbcd06c81cd)