### PR TITLE
Sanitize autonomy mode to fail-safe on _extract_opportunity_autonomy_decision exception

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2190,10 +2190,7 @@ class TradingController:
             )
             mode = decision.mode.value
         except Exception:
-            mode_raw = request_metadata.get("opportunity_autonomy_mode")
-            if mode_raw is None:
-                mode_raw = signal_metadata.get("opportunity_autonomy_mode")
-            mode = str(mode_raw or "").strip().lower() or None
+            mode = "unavailable"
         if mode not in {"paper_autonomous", "live_autonomous"}:
             return True, (), None, ""
         missing_fields: list[str] = []


### PR DESCRIPTION
### Motivation
- Prevent raw `opportunity_autonomy_mode` from leaking into downstream diagnostics when `_extract_opportunity_autonomy_decision(...)` raises, preserving the fail-closed / fail-safe contract (no execution, empty result, `autonomy_mode` => `unavailable`).

### Description
- Changed `_validate_autonomous_open_handoff_contract(...)` in `bot_core/runtime/controller.py` so the exception branch sets `mode = "unavailable"` instead of falling back to raw `opportunity_autonomy_mode` from signal/request metadata, keeping the failure-path sanitized and minimal.

### Testing
- Ran `pytest -q tests/test_trading_controller.py::test_opportunity_autonomy_exception_contract_extract_failure_keeps_fail_safe_chain_consistent` and it passed (`1 passed`).
- Ran `pytest -q tests/test_trading_controller.py -k "opportunity_autonomy and exception"` and it passed (`3 passed, 453 deselected`).
- Ran `pytest -q tests/test_trading_controller.py -k "opportunity_autonomy_enforcement_contract_keys_present_for_fail_closed_guard_paths or exception_contract"` and it passed (`4 passed, 452 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa98c51d0832a9e32c8bff67276a7)