### PR TITLE
Use decision payload `effective_mode` for autonomous handoff intent and simplify logic

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2318,21 +2318,17 @@ class TradingController:
         has_performance_guard_payload = isinstance(decision_payload, Mapping) and isinstance(
             decision_payload.get("performance_guard"), Mapping
         )
-        handoff_mode_candidates: list[str] = []
-        request_mode_raw = request_metadata.get("opportunity_autonomy_mode")
-        if request_mode_raw is not None:
-            request_mode = str(request_mode_raw).strip().lower()
-            if request_mode:
-                handoff_mode_candidates.append(request_mode)
+        payload_effective_mode: str | None = None
         if isinstance(decision_payload, Mapping):
             payload_mode_raw = decision_payload.get("effective_mode")
             if payload_mode_raw is not None:
                 payload_mode = str(payload_mode_raw).strip().lower()
                 if payload_mode:
-                    handoff_mode_candidates.append(payload_mode)
-        has_accepted_autonomous_handoff_intent = any(
-            mode in {"paper_autonomous", "live_autonomous"} for mode in handoff_mode_candidates
-        )
+                    payload_effective_mode = payload_mode
+        has_accepted_autonomous_handoff_intent = payload_effective_mode in {
+            "paper_autonomous",
+            "live_autonomous",
+        }
         if (
             correlation_key
             and not has_handoff_decision_timestamp


### PR DESCRIPTION
### Motivation

- Restrict autonomous handoff detection to the explicit decision payload `effective_mode` instead of mixing in a request-level `opportunity_autonomy_mode`, preventing ambiguous or stale mode interpretation.

### Description

- Replaced the ad-hoc `handoff_mode_candidates` list with a single `payload_effective_mode` variable extracted from `decision_payload["effective_mode"]` and normalized to lowercase.
- Determined `has_accepted_autonomous_handoff_intent` by checking membership of `payload_effective_mode` in `{"paper_autonomous","live_autonomous"}` instead of scanning multiple candidate sources.
- Removed handling of `opportunity_autonomy_mode` from the request metadata and simplified the boolean logic and typing for clarity.

### Testing

- Ran the test suite with `pytest -q`, and all tests passed.
- Ran static checks/linting (`flake8`/`mypy`) locally with no new errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daae57ea10832aad02a974882dad98)