### PR TITLE
Enhance autonomy enforcement metadata and restrict open-handoff to paper; add tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1750,20 +1750,47 @@ class TradingController:
                     )
                 )
                 if not contract_valid:
+                    metadata: dict[str, object] = {
+                        "environment": self.environment,
+                        "execution_permission": "blocked",
+                        "autonomy_mode": mode or "unknown",
+                        "autonomous_execution_allowed": False,
+                        "autonomy_primary_reason": blocking_reason,
+                        "blocking_reason": blocking_reason,
+                        "missing_contract_fields": ",".join(missing_fields),
+                    }
+                    metadata.update(
+                        self._extract_upstream_autonomy_governance_metadata(
+                            signal=signal,
+                            request=request,
+                        )
+                    )
+                    decision_payload = self._select_opportunity_autonomy_payload(signal, request)
+                    if decision_payload is not None:
+                        performance_guard_payload = decision_payload[0].get("performance_guard")
+                        if isinstance(performance_guard_payload, Mapping):
+                            guard_primary_reason = performance_guard_payload.get("primary_reason")
+                            if guard_primary_reason is not None:
+                                metadata["performance_guard_primary_reason"] = str(
+                                    guard_primary_reason
+                                )
+                            guard_effective_mode = performance_guard_payload.get("effective_mode")
+                            if guard_effective_mode is not None:
+                                metadata["performance_guard_effective_mode"] = str(
+                                    guard_effective_mode
+                                )
+                            guard_blocked = _as_bool(performance_guard_payload.get("blocked"))
+                            if guard_blocked:
+                                metadata["performance_guard_block_enforced"] = True
+                    self._attach_opportunity_autonomy_downgrade_chain_metadata(metadata)
+                    metadata["autonomy_decisive_stage"] = "fail_closed"
+                    metadata["autonomy_decisive_reason"] = blocking_reason
                     self._record_decision_event(
                         "opportunity_autonomy_enforcement",
                         signal=signal,
                         request=request,
                         status="blocked",
-                        metadata={
-                            "environment": self.environment,
-                            "execution_permission": "blocked",
-                            "autonomy_mode": mode or "unknown",
-                            "autonomous_execution_allowed": False,
-                            "autonomy_primary_reason": blocking_reason,
-                            "blocking_reason": blocking_reason,
-                            "missing_contract_fields": ",".join(missing_fields),
-                        },
+                        metadata=metadata,
                     )
                     self._metric_signals_total.inc(labels={**metric_labels, "status": "rejected"})
                     return None
@@ -2329,11 +2356,13 @@ class TradingController:
             "paper_autonomous",
             "live_autonomous",
         }
+        runtime_environment = str(self.environment).strip().lower()
         if (
             correlation_key
             and not has_handoff_decision_timestamp
             and has_performance_guard_payload
             and has_accepted_autonomous_handoff_intent
+            and runtime_environment == "paper"
         ):
             return True
         if correlation_key and has_handoff_decision_timestamp and has_performance_guard_payload:

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -21942,6 +21942,53 @@ def test_upstream_handoff_accepted_autonomous_open_with_incomplete_contract_is_f
     assert missing_fields == expected_missing
 
 
+def test_upstream_handoff_validator_complete_contract_scope_filter_path_is_valid_without_exception(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    controller, _execution, _journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _opportunity_autonomy_signal("paper_autonomous", include_decision_payload=True)
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_decision_timestamp": decision_timestamp.isoformat(),
+    }
+    request = controller._build_order_request(signal)
+
+    contract_valid, missing_fields, mode, blocking_reason = (
+        controller._validate_autonomous_open_handoff_contract(
+            signal=signal,
+            request=request,
+        )
+    )
+
+    assert contract_valid is True
+    assert missing_fields == ()
+    assert mode == "paper_autonomous"
+    assert blocking_reason == ""
+
+
 def test_upstream_handoff_incomplete_autonomous_contract_replay_is_stably_blocked_without_persistence_or_provenance_drift(
     tmp_path: Path,
 ) -> None:
@@ -22409,6 +22456,113 @@ def test_upstream_handoff_payload_only_effective_autonomous_mode_incomplete_cont
         event["blocking_reason"] == "accepted_autonomous_handoff_contract_incomplete"
         for event in enforcement_events
     )
+
+
+def test_upstream_handoff_early_fail_closed_event_metadata_contract_is_stable(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _opportunity_autonomy_signal(
+        "paper_autonomous",
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="upstream_primary_reason",
+        performance_guard_effective_mode="paper_autonomous",
+        performance_guard_primary_reason="payload_guard_reason",
+        performance_guard_hard_breach=True,
+        performance_guard_blocked=True,
+    )
+    decision_payload = dict(signal.metadata.get("opportunity_autonomy_decision", {}))
+    decision_payload["requested_mode"] = "paper_autonomous"
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_autonomy_decision": decision_payload,
+    }
+    signal.metadata.pop("opportunity_decision_timestamp", None)
+
+    results = controller.process_signals([signal])
+
+    assert results == []
+    assert execution.requests == []
+    assert shadow_repo.load_open_outcomes() == []
+    assert shadow_repo.load_outcome_labels() == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["event"] == "opportunity_autonomy_enforcement"
+    assert event["status"] == "blocked"
+    assert event["execution_permission"] == "blocked"
+    assert event["blocking_reason"] == "accepted_autonomous_handoff_contract_incomplete"
+    assert event.get("missing_contract_fields") == "opportunity_decision_timestamp"
+    assert event["autonomy_primary_reason"] == event["blocking_reason"]
+    assert event["autonomy_decisive_stage"] == "fail_closed"
+    assert event["autonomy_decisive_reason"] == event["blocking_reason"]
+    assert event["autonomy_mode"] == "paper_autonomous"
+    assert event["autonomy_requested_mode"] == "paper_autonomous"
+    assert event["autonomy_upstream_effective_mode"] == "paper_autonomous"
+    assert event["autonomy_final_mode"] == "paper_autonomous"
+    assert event["upstream_autonomy_effective_mode"] == "paper_autonomous"
+    assert event["performance_guard_primary_reason"] == "payload_guard_reason"
+    assert event["performance_guard_effective_mode"] == "paper_autonomous"
+    assert str(event["performance_guard_block_enforced"]).strip().lower() == "true"
+
+
+def test_upstream_handoff_live_missing_timestamp_with_performance_guard_keeps_fail_closed_local_guard_precedence(
+) -> None:
+    controller, execution, journal = _build_autonomy_controller(environment="live")
+    signal = _opportunity_autonomy_signal(
+        "live_autonomous",
+        assisted_approval=True,
+        include_decision_payload=True,
+        decision_effective_mode="live_autonomous",
+        decision_primary_reason="upstream_primary_should_not_override_fail_closed",
+        performance_guard_effective_mode="live_autonomous",
+        performance_guard_primary_reason="payload_guard_reason_should_not_override_fail_closed",
+        performance_guard_hard_breach=True,
+        performance_guard_blocked=True,
+    )
+    signal.metadata.pop("opportunity_decision_timestamp", None)
+
+    result = controller.process_signals([signal])
+
+    assert result == []
+    assert execution.requests == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "blocked"
+    assert event["blocking_reason"] == "performance_guard_snapshot_source_unavailable"
+    assert event["blocking_reason"] != "accepted_autonomous_handoff_contract_incomplete"
+    assert event["autonomy_primary_reason"] == event["blocking_reason"]
+    assert event["autonomy_decisive_stage"] == "fail_closed"
+    assert event["autonomy_decisive_reason"] == "performance_guard_snapshot_source_unavailable"
+    if "performance_guard_primary_reason" in event:
+        assert (
+            event["performance_guard_primary_reason"]
+            == "payload_guard_reason_should_not_override_fail_closed"
+        )
+        assert event["autonomy_primary_reason"] == event["blocking_reason"]
+    assert event.get("missing_contract_fields", "") == ""
+
 
 
 def test_upstream_handoff_open_validator_does_not_block_legal_autonomous_close_or_close_replay(


### PR DESCRIPTION
### Motivation

- Provide richer, stable metadata on opportunity autonomy enforcement failures (especially early `fail_closed` cases) so diagnostics, provenance and downstream consumers can rely on consistent fields and performance-guard context. 
- Ensure that the autonomous open-handoff path is only taken in the `paper` runtime to avoid unintended autonomous handoffs in other environments. 
- Add unit tests that validate contract validation, event metadata stability, and precedence between local guards and upstream payloads.

### Description

- Reworked the blocked-path metadata construction in `TradingController` to build a `metadata` dict, update it with upstream autonomy governance via `_extract_upstream_autonomy_governance_metadata`, and include `execution_permission`, `autonomy_mode`, `autonomous_execution_allowed`, `missing_contract_fields`, and other diagnostic keys. 
- Extracted `performance_guard` details from the selected opportunity autonomy payload (when present) and surface `performance_guard_primary_reason`, `performance_guard_effective_mode`, and `performance_guard_block_enforced` in the event metadata. 
- Attached downgrade-chain metadata via `_attach_opportunity_autonomy_downgrade_chain_metadata` and set `autonomy_decisive_stage` to `fail_closed` and `autonomy_decisive_reason` to the blocking reason for blocked enforcements. 
- Replaced the inline metadata literal with the assembled `metadata` variable when recording the `opportunity_autonomy_enforcement` event. 
- Tightened `_is_autonomous_open_handoff_path` to require the controller `environment` to be `paper` for the early open-handoff path when a performance-guard payload indicates an accepted autonomous intent. 
- Added unit tests `test_upstream_handoff_validator_complete_contract_scope_filter_path_is_valid_without_exception`, `test_upstream_handoff_early_fail_closed_event_metadata_contract_is_stable`, and `test_upstream_handoff_live_missing_timestamp_with_performance_guard_keeps_fail_closed_local_guard_precedence` to validate contract validation behavior, metadata stability, and guard precedence.

### Testing

- Ran the autonomy-related unit tests in `tests/test_trading_controller.py` using `pytest`, and the new tests (`test_upstream_handoff_validator_complete_contract_scope_filter_path_is_valid_without_exception`, `test_upstream_handoff_early_fail_closed_event_metadata_contract_is_stable`, and `test_upstream_handoff_live_missing_timestamp_with_performance_guard_keeps_fail_closed_local_guard_precedence`) passed. 
- Existing enforcement/replay tests in the same file were executed and remained green after the changes. 
- No regressions were observed in the autonomy enforcement scenarios covered by the test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabe28f260832a84ab02ea38393504)