### PR TITLE
Apply ruff-format reflow in trading controller tests

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -22528,8 +22528,9 @@ def test_upstream_handoff_early_fail_closed_event_metadata_contract_is_stable(
     assert str(event["performance_guard_block_enforced"]).strip().lower() == "true"
 
 
-def test_upstream_handoff_live_missing_timestamp_with_performance_guard_keeps_fail_closed_local_guard_precedence(
-) -> None:
+def test_upstream_handoff_live_missing_timestamp_with_performance_guard_keeps_fail_closed_local_guard_precedence() -> (
+    None
+):
     controller, execution, journal = _build_autonomy_controller(environment="live")
     signal = _opportunity_autonomy_signal(
         "live_autonomous",
@@ -22562,7 +22563,6 @@ def test_upstream_handoff_live_missing_timestamp_with_performance_guard_keeps_fa
         )
         assert event["autonomy_primary_reason"] == event["blocking_reason"]
     assert event.get("missing_contract_fields", "") == ""
-
 
 
 def test_upstream_handoff_open_validator_does_not_block_legal_autonomous_close_or_close_replay(


### PR DESCRIPTION
### Motivation
- Fix a formatter drift in `tests/test_trading_controller.py` so the repository passes the configured `ruff-format` pre-commit hook without any behavioral changes.

### Description
- Reflowed the long test function signature `test_upstream_handoff_live_missing_timestamp_with_performance_guard_keeps_fail_closed_local_guard_precedence` to match `ruff-format` wrapping and removed one redundant blank line before the next test; no logic, assertions, names, messages, contracts or test ordering were changed.

### Testing
- Ran `python -m pre_commit run --all-files --show-diff-on-failure` (initial run failed due to missing `pre-commit`), then installed with `python -m pip install pre-commit`, re-ran `python -m pre_commit run --all-files --show-diff-on-failure` which showed `ruff-format` modified the file, and finally re-ran `python -m pre_commit run --all-files --show-diff-on-failure` which completed with all hooks passing (`ruff` Passed, `ruff format` Passed, `mypy` Passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dadae7f408832aad79030ef7a42832)