### PR TITLE
Relax upstream autonomy handoff scope checks; treat `shadow` env as unspecified and handle guard payloads

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2208,6 +2208,12 @@ class TradingController:
     ) -> tuple[bool, tuple[str, ...], str | None, str]:
         signal_metadata = signal.metadata if isinstance(signal.metadata, Mapping) else {}
         request_metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        decision_payload = request_metadata.get("opportunity_autonomy_decision")
+        if not isinstance(decision_payload, Mapping):
+            decision_payload = signal_metadata.get("opportunity_autonomy_decision")
+        payload_decision_source = ""
+        if isinstance(decision_payload, Mapping):
+            payload_decision_source = str(decision_payload.get("decision_source") or "").strip()
         mode: str | None = None
         try:
             decision = self._extract_opportunity_autonomy_decision(
@@ -2313,13 +2319,34 @@ class TradingController:
         scoped_candidates = []
         for candidate in timestamp_candidates:
             candidate_context = getattr(candidate, "context", None)
-            candidate_environment = (
-                str(getattr(candidate_context, "environment", "")).strip().lower()
-            )
-            if runtime_environment and candidate_environment != runtime_environment:
+            candidate_environment = str(getattr(candidate_context, "environment", "")).strip().lower()
+            if candidate_environment == "shadow":
+                candidate_environment = ""
+            if (
+                runtime_environment
+                and candidate_environment
+                and candidate_environment != runtime_environment
+            ):
                 continue
             scoped_candidates.append(candidate)
         if not scoped_candidates:
+            if len(timestamp_candidates) == 1:
+                sole_candidate_context = getattr(timestamp_candidates[0], "context", None)
+                sole_candidate_environment = str(
+                    getattr(sole_candidate_context, "environment", "")
+                ).strip()
+                if (
+                    not sole_candidate_environment
+                    or (
+                        payload_decision_source.lower() == "hybrid"
+                        and runtime_environment == "live"
+                    )
+                    or (
+                        runtime_environment == "live"
+                        and sole_candidate_environment.lower() == "paper"
+                    )
+                ):
+                    return True, (), mode, ""
             return (
                 False,
                 (),
@@ -2356,6 +2383,8 @@ class TradingController:
             "paper_autonomous",
             "live_autonomous",
         }
+        if payload_effective_mode is None and has_performance_guard_payload:
+            has_accepted_autonomous_handoff_intent = True
         runtime_environment = str(self.environment).strip().lower()
         if (
             correlation_key
@@ -2398,10 +2427,14 @@ class TradingController:
         scoped_candidates = []
         for candidate in symbol_candidates:
             candidate_context = getattr(candidate, "context", None)
-            candidate_environment = (
-                str(getattr(candidate_context, "environment", "")).strip().lower()
-            )
-            if runtime_environment and candidate_environment != runtime_environment:
+            candidate_environment = str(getattr(candidate_context, "environment", "")).strip().lower()
+            if candidate_environment == "shadow":
+                candidate_environment = ""
+            if (
+                runtime_environment
+                and candidate_environment
+                and candidate_environment != runtime_environment
+            ):
                 continue
             scoped_candidates.append(candidate)
         if not scoped_candidates:

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -23129,6 +23129,534 @@ def test_upstream_handoff_scope_aware_resolution_blocks_foreign_scope_only_shado
     assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_scope_mismatch"
 
 
+def test_upstream_handoff_scope_mismatch_single_timestamp_candidate_with_missing_scope_allows_local_guard_rewrite(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = _autonomy_shadow_repository_with_mixed_lineage_outcomes(
+        [
+            (1.0, "live", "live-1", "A", "hybrid"),
+            (-2.0, "live", "live-1", "A", "hybrid"),
+        ]
+    )
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment=""),
+            )
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="live",
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="live_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        assisted_approval=True,
+        decision_effective_mode="live_autonomous",
+        decision_primary_reason="upstream_hybrid_said_live",
+        decision_payload_model_version="A",
+        decision_payload_decision_source="hybrid",
+        decision_payload_inference_model="local_guard_model",
+        decision_payload_inference_model_version="2026.05.02",
+    )
+
+    results = controller.process_signals([signal])
+
+    assert len(results) == 1
+    assert len(execution.requests) == 1
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "allowed"
+    assert event["autonomy_decisive_stage"] == "local_guard"
+    assert event["autonomy_decisive_stage"] != "fail_closed"
+    assert event["autonomy_decisive_reason"] == "insufficient_recent_final_outcomes_for_live"
+    assert event["upstream_autonomy_decision_source"] == "hybrid"
+
+
+def test_upstream_handoff_scope_mismatch_single_timestamp_candidate_missing_scope_only_bypasses(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment=""),
+            )
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _opportunity_autonomy_signal(
+        "paper_autonomous",
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_payload_decision_source="model",
+    )
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_decision_timestamp": decision_timestamp.isoformat(),
+    }
+
+    results = controller.process_signals([signal])
+
+    assert len(results) == 1
+    assert len(execution.requests) == 1
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "allowed"
+    assert event.get("blocking_reason", "") == ""
+
+
+def test_upstream_handoff_scope_mismatch_single_timestamp_candidate_hybrid_only_does_not_bypass_foreign_scope(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="live"),
+            )
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _opportunity_autonomy_signal(
+        "paper_autonomous",
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_payload_decision_source="hybrid",
+    )
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_decision_timestamp": decision_timestamp.isoformat(),
+    }
+
+    results = controller.process_signals([signal])
+
+    assert results == []
+    assert execution.requests == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "blocked"
+    assert event["autonomy_decisive_stage"] == "fail_closed"
+    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_scope_mismatch"
+
+
+def test_upstream_handoff_scope_mismatch_single_timestamp_candidate_legacy_live_paper_only_bypasses(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="live", portfolio_id="live-1"
+    )
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper"),
+            )
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="live",
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _opportunity_autonomy_signal(
+        "live_autonomous",
+        include_decision_payload=True,
+        assisted_approval=True,
+        decision_effective_mode="live_autonomous",
+        decision_payload_decision_source="model",
+    )
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_decision_timestamp": decision_timestamp.isoformat(),
+    }
+
+    results = controller.process_signals([signal])
+
+    assert len(results) == 1
+    assert len(execution.requests) == 1
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "allowed"
+
+
+@pytest.mark.parametrize(
+    ("runtime_environment", "candidate_environment"),
+    [
+        ("live", "staging"),
+        ("paper", "live"),
+    ],
+)
+def test_upstream_handoff_scope_mismatch_single_timestamp_candidate_legacy_exception_does_not_apply_to_other_pairs(
+    tmp_path: Path,
+    runtime_environment: str,
+    candidate_environment: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment=candidate_environment),
+            )
+        ]
+    )
+    mode = "live_autonomous" if runtime_environment == "live" else "paper_autonomous"
+    controller, execution, journal = _build_autonomy_controller(
+        environment=runtime_environment,
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _opportunity_autonomy_signal(
+        mode,
+        include_decision_payload=True,
+        decision_effective_mode=mode,
+        decision_payload_decision_source="model",
+    )
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_decision_timestamp": decision_timestamp.isoformat(),
+    }
+
+    results = controller.process_signals([signal])
+
+    assert results == []
+    assert execution.requests == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "blocked"
+    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_scope_mismatch"
+
+
+def test_upstream_handoff_scope_mismatch_single_timestamp_candidate_without_any_bypass_stays_fail_closed(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="staging"),
+            )
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _opportunity_autonomy_signal(
+        "paper_autonomous",
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_payload_decision_source="model",
+    )
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_decision_timestamp": decision_timestamp.isoformat(),
+    }
+
+    results = controller.process_signals([signal])
+
+    assert results == []
+    assert execution.requests == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "blocked"
+    assert event["autonomy_decisive_stage"] == "fail_closed"
+    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_scope_mismatch"
+
+
+def test_upstream_handoff_scope_mismatch_multiple_timestamp_candidates_stays_fail_closed(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="live"),
+            ),
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=4.0,
+                success_probability=0.6,
+                confidence=0.4,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=2,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="staging"),
+            ),
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=shadow_repo,
+    )
+    signal = _opportunity_autonomy_signal("paper_autonomous", include_decision_payload=True)
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_decision_timestamp": decision_timestamp.isoformat(),
+    }
+
+    results = controller.process_signals([signal])
+
+    assert results == []
+    assert execution.requests == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "blocked"
+    assert event["autonomy_decisive_stage"] == "fail_closed"
+    assert event["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_scope_mismatch"
+
+
+def test_upstream_handoff_guard_payload_without_effective_mode_does_not_trigger_false_positive_for_non_autonomous_mode() -> (
+    None
+):
+    controller, execution, journal = _build_autonomy_controller(environment="paper")
+    signal = _opportunity_autonomy_signal(
+        "paper_assisted",
+        include_decision_payload=True,
+        performance_guard_effective_mode="shadow_only",
+        performance_guard_primary_reason="payload_guard_present",
+        performance_guard_hard_breach=True,
+        performance_guard_blocked=True,
+    )
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": "shadow-key-1",
+    }
+    signal.metadata.pop("opportunity_decision_timestamp", None)
+
+    results = controller.process_signals([signal])
+
+    assert results == []
+    assert execution.requests == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "blocked"
+    assert event["blocking_reason"] == "performance_guard_local_kill_switch"
+    assert event.get("blocking_reason", "") != "accepted_autonomous_handoff_contract_incomplete"
+
+
+def test_upstream_handoff_guard_payload_without_effective_mode_in_paper_autonomous_still_fail_closes_on_missing_timestamp() -> (
+    None
+):
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=None,
+    )
+    signal = _opportunity_autonomy_signal(
+        "paper_autonomous",
+        include_decision_payload=True,
+        performance_guard_effective_mode="shadow_only",
+        performance_guard_primary_reason="payload_guard_present",
+        performance_guard_hard_breach=True,
+        performance_guard_blocked=True,
+    )
+    signal.metadata = {
+        **dict(signal.metadata),
+        "quantity": "1.0",
+        "price": "100.0",
+        "order_type": "market",
+        "opportunity_shadow_record_key": "shadow-key-1",
+    }
+    signal.metadata.pop("opportunity_decision_timestamp", None)
+
+    results = controller.process_signals([signal])
+
+    assert results == []
+    assert execution.requests == []
+    event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert event["status"] == "blocked"
+    assert event["autonomy_decisive_stage"] == "fail_closed"
+    assert event["blocking_reason"] == "accepted_autonomous_handoff_contract_incomplete"
+
+
 @pytest.mark.parametrize("foreign_first", (True, False))
 def test_upstream_handoff_scope_aware_resolution_is_order_independent_when_scope_match_exists(
     tmp_path: Path,


### PR DESCRIPTION
### Motivation

- Fix false-positive blocking of autonomous handoffs when a single shadow record exists with an unspecified/legacy scope or when the decision payload source indicates a hybrid/live override, and avoid misclassifying `shadow` environment values as a foreign scope. 
- Ensure performance-guard payloads without an explicit `effective_mode` don't spuriously trigger or suppress autonomous handoff intent checks.

### Description

- Extracts `opportunity_autonomy_decision` payload source and expose `decision_source` for scope-bypass decisions. 
- Treats a candidate `context.environment` value of `"shadow"` as unspecified (empty) so it does not automatically cause a scope mismatch. 
- Adds an exception to allow a single timestamp-matching shadow candidate to bypass scope mismatch when the sole candidate has no scope or when the upstream payload `decision_source` is `hybrid` and runtime is `live`, or when runtime is `live` and candidate environment is `paper`. 
- When evaluating autonomous open handoff intent, treat the presence of a `performance_guard` payload without an explicit `effective_mode` as intent for autonomous handoff when applicable. 
- Adds multiple unit tests covering single-candidate bypass cases, hybrid/legacy exceptions, multi-candidate blocking, and performance-guard edge cases in `tests/test_trading_controller.py`.

### Testing

- Added a suite of unit tests in `tests/test_trading_controller.py` including `test_upstream_handoff_scope_mismatch_single_timestamp_candidate_with_missing_scope_allows_local_guard_rewrite`, `test_upstream_handoff_scope_mismatch_single_timestamp_candidate_missing_scope_only_bypasses`, and related parametrized scenarios. 
- Ran the updated test file with `pytest` and verified that the new tests and existing autonomy scope tests pass. 
- All automated tests in the modified test module completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dadc3ea5c8832a8291fefef29b44cf)