### PR TITLE
Apply ruff-format line reflow in runtime controller

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2319,7 +2319,9 @@ class TradingController:
         scoped_candidates = []
         for candidate in timestamp_candidates:
             candidate_context = getattr(candidate, "context", None)
-            candidate_environment = str(getattr(candidate_context, "environment", "")).strip().lower()
+            candidate_environment = (
+                str(getattr(candidate_context, "environment", "")).strip().lower()
+            )
             if candidate_environment == "shadow":
                 candidate_environment = ""
             if (
@@ -2427,7 +2429,9 @@ class TradingController:
         scoped_candidates = []
         for candidate in symbol_candidates:
             candidate_context = getattr(candidate, "context", None)
-            candidate_environment = str(getattr(candidate_context, "environment", "")).strip().lower()
+            candidate_environment = (
+                str(getattr(candidate_context, "environment", "")).strip().lower()
+            )
             if candidate_environment == "shadow":
                 candidate_environment = ""
             if (


### PR DESCRIPTION
### Motivation
- Fix a formatting drift flagged by `ruff format` in `bot_core/runtime/controller.py` by reflowing two long `candidate_environment` assignment lines without changing any semantics or behavior.

### Description
- Wrapped the two `candidate_environment = str(getattr(candidate_context, "environment", "")).strip().lower()` assignments in parentheses inside the `timestamp_candidates` and `symbol_candidates` loops to satisfy `ruff-format` reflow rules.

### Testing
- Installed `pre-commit` as needed and ran `python -m pre_commit run --all-files --show-diff-on-failure`, which passed (hooks reported `ruff`, `ruff format`, and `mypy` as passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db666f1ff4832aaa6b311bc4385ebd)