### PR TITLE
tests: set decision timestamp in signal and add paper-scope shadow records in autonomy tests

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -1826,19 +1826,19 @@ def test_opportunity_autonomy_runtime_missing_repository_allows_payload_guard_on
     None
 ):
     controller, execution, journal = _build_autonomy_controller(environment="paper")
-
-    result = controller.process_signals(
-        [
-            _opportunity_autonomy_signal(
-                "live_autonomous",
-                include_decision_payload=True,
-                performance_guard_effective_mode="shadow_only",
-                performance_guard_primary_reason="payload_block_fallback",
-                performance_guard_hard_breach=True,
-                performance_guard_blocked=True,
-            )
-        ]
+    signal = _opportunity_autonomy_signal(
+        "live_autonomous",
+        include_decision_payload=True,
+        performance_guard_effective_mode="shadow_only",
+        performance_guard_primary_reason="payload_block_fallback",
+        performance_guard_hard_breach=True,
+        performance_guard_blocked=True,
     )
+    signal.metadata["opportunity_decision_timestamp"] = datetime(
+        2026, 1, 8, 12, 0, tzinfo=timezone.utc
+    ).isoformat()
+
+    result = controller.process_signals([signal])
 
     assert result == []
     assert execution.requests == []
@@ -9971,7 +9971,13 @@ def test_opportunity_autonomy_duplicate_open_guard_foreign_scope_restored_tracke
                     correlation_key=correlation_key, decision_timestamp=decision_timestamp
                 ),
                 context=OpportunityShadowContext(environment="live"),
-            )
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                context=OpportunityShadowContext(environment="paper"),
+            ),
         ]
     )
     repository.upsert_open_outcome(
@@ -10370,7 +10376,13 @@ def test_opportunity_autonomy_duplicate_open_guard_explicit_same_scope_tracker_w
                     correlation_key=correlation_key, decision_timestamp=decision_timestamp
                 ),
                 context=OpportunityShadowContext(environment="live"),
-            )
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                context=OpportunityShadowContext(environment="paper"),
+            ),
         ]
     )
     repository.upsert_open_outcome(


### PR DESCRIPTION
### Motivation

- Ensure autonomy tests provide an explicit ISO decision timestamp on the signal payload so fallback metadata is interpreted deterministically. 
- Ensure duplicate/foreign-scope shadow-record tests include both live and paper-scoped shadow records so scope-restoration and suppression logic are exercised correctly.

### Description

- In `test_opportunity_autonomy_runtime_missing_repository_allows_payload_guard_only_as_fallback_metadata` the signal is created as a local variable and `metadata["opportunity_decision_timestamp"]` is set with an ISO `datetime` string before calling `process_signals`.
- In two duplicate-open-shadow tests the repository's `append_shadow_records` call was extended to include an additional `replace(..., context=OpportunityShadowContext(environment="paper"))` record so both `live` and `paper` scoped shadow records exist for the same correlation key.
- Minor whitespace/formatting adjustments in the test file to accommodate the changes.

### Testing

- Ran `pytest tests/test_trading_controller.py` to exercise the modified tests and related autonomy scenarios, and the test module completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6782c4c0832ab00ad50a830df077)