### PR TITLE
Accept ruff-format signature reflow in trading controller test

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -21978,7 +21978,9 @@ def test_opportunity_autonomy_runtime_mode_hot_switch_applies_on_next_cycle_with
     assert adapter.modes_seen == ["live", "assist"]
 
 
-def test_opportunity_autonomy_runtime_mode_hot_switch_preserves_prior_cycle_journal_lineage() -> None:
+def test_opportunity_autonomy_runtime_mode_hot_switch_preserves_prior_cycle_journal_lineage() -> (
+    None
+):
     class _AlwaysAcceptingOrchestrator:
         def evaluate_candidate(self, candidate, _context):
             return SimpleNamespace(


### PR DESCRIPTION
### Motivation
- Accept a formatter-only drift: `ruff-format` reflowed the return annotation of one test in `tests/test_trading_controller.py` and this change preserves semantics without touching logic or assertions.

### Description
- Update `tests/test_trading_controller.py` to reflow the signature of `test_opportunity_autonomy_runtime_mode_hot_switch_preserves_prior_cycle_journal_lineage` from `-> None` to a multi-line `-> (\n    None\n):` and make no other changes.

### Testing
- Ran `python -m pre_commit run --all-files --show-diff-on-failure` and the hooks passed (ruff, ruff format, mypy reported green).
- Ran `python -m pytest -q tests/test_trading_controller.py -k "runtime_mode_hot_switch_preserves_prior_cycle_journal_lineage" -xvv` and test collection failed due to missing runtime dependencies (`ModuleNotFoundError: No module named 'pydantic'`), unrelated to the formatting change; earlier missing packages (`numpy`, `pandas`, `cryptography`) were installed during investigation but `pydantic` remains required for full collection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13effa580832a910ee0eda9537223)