### PR TITLE
Add runtime-service hot-switch contract test for shared OpportunityRuntimeControls

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -36,9 +36,13 @@ from bot_core.exchanges.base import AccountSnapshot, OrderRequest, OrderResult
 from bot_core.risk import RiskCheckResult, RiskEngine, RiskProfile
 from bot_core.runtime import TradingController
 from bot_core.runtime.journal import TradingDecisionEvent
-from bot_core.runtime.opportunity_runtime_controls import OpportunityRuntimeControls
+from bot_core.runtime.opportunity_runtime_controls import (
+    OpportunityRuntimeControls,
+    get_opportunity_runtime_controls,
+)
 from bot_core.runtime.pipeline import DecisionAwareSignalSink, InMemoryStrategySignalSink
 from bot_core.strategies import SignalLeg, StrategySignal
+from ui.backend.runtime_service import RuntimeService
 
 from tests._alert_channel_helpers import CollectingChannel
 
@@ -22161,6 +22165,131 @@ def test_opportunity_autonomy_runtime_mode_without_switch_has_no_regression() ->
     assert second_cycle["ai_required_for_execution"] == "false"
     assert second_cycle["final_decision_accepted"] == "true"
     assert adapter.modes_seen == ["assist", "assist"]
+
+
+def test_opportunity_autonomy_runtime_mode_hot_switch_via_runtime_service_updates_shared_controls() -> (
+    None
+):
+    class _AlwaysAcceptingOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+                cost_bps=2.0,
+                net_edge_bps=8.0,
+                model_name="runtime-hot-switch-model",
+                latency_ms=None,
+            )
+
+    class _RecordingPolicyAdapter:
+        def __init__(self) -> None:
+            self.mode = "shadow"
+            self.modes_seen: list[str] = []
+
+        def emit_shadow_proposal(self, **_kwargs):
+            self.modes_seen.append(str(self.mode))
+            return SimpleNamespace(
+                status="proposal",
+                decision_available=True,
+                accepted=True,
+                model_version="opportunity-v-hot-switch",
+                decision_source="opportunity_ai_shadow",
+                rejection_reason=None,
+                degraded_reason=None,
+                shadow_record_key=None,
+                shadow_persistence_status="disabled",
+                shadow_persistence_error=None,
+            )
+
+    runtime_controls = get_opportunity_runtime_controls()
+    initial_snapshot = runtime_controls.snapshot()
+    runtime_controls.update(
+        opportunity_ai_enabled=True,
+        manual_kill_switch=False,
+        policy_mode="live",
+    )
+
+    service = RuntimeService(decision_loader=lambda _limit: [])
+    adapter = _RecordingPolicyAdapter()
+    journal = CollectingDecisionJournal()
+    sink = DecisionAwareSignalSink(
+        base_sink=InMemoryStrategySignalSink(),
+        orchestrator=_AlwaysAcceptingOrchestrator(),
+        risk_engine=DummyRiskEngine(),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="BINANCE",
+        min_probability=0.4,
+        journal=journal,
+        opportunity_shadow_adapter=adapter,
+        opportunity_policy_mode="shadow",
+        opportunity_runtime_controls=get_opportunity_runtime_controls(),
+    )
+    signal = _opportunity_autonomy_signal("paper_autonomous")
+    signal.metadata = {
+        **dict(signal.metadata),
+        "expected_probability": 0.95,
+        "expected_return_bps": 16.0,
+    }
+
+    try:
+        sink.submit(
+            strategy_name="trend-d1",
+            schedule_name="trend-d1",
+            risk_profile="balanced",
+            timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+            signals=(signal,),
+        )
+
+        to_assist = service.applyOpportunityRuntimeSettings({"policyMode": "assist"})
+        assert to_assist["success"] is True
+        sink.submit(
+            strategy_name="trend-d1",
+            schedule_name="trend-d1",
+            risk_profile="balanced",
+            timestamp=datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+            signals=(signal,),
+        )
+
+        to_live = service.applyOpportunityRuntimeSettings({"policyMode": "live"})
+        assert to_live["success"] is True
+        sink.submit(
+            strategy_name="trend-d1",
+            schedule_name="trend-d1",
+            risk_profile="balanced",
+            timestamp=datetime(2026, 1, 1, 12, 2, tzinfo=timezone.utc),
+            signals=(signal,),
+        )
+    finally:
+        runtime_controls.update(
+            opportunity_ai_enabled=initial_snapshot.opportunity_ai_enabled,
+            manual_kill_switch=initial_snapshot.manual_kill_switch,
+            policy_mode=initial_snapshot.policy_mode,
+        )
+
+    decision_events = [
+        event for event in journal.export() if event.get("event") == "decision_evaluation"
+    ]
+    assert len(decision_events) == 3
+    first_cycle = decision_events[0]
+    second_cycle = decision_events[1]
+    third_cycle = decision_events[2]
+    assert first_cycle["opportunity_policy_mode"] == "live"
+    assert first_cycle["decision_authority"] == "shared_live_policy"
+    assert first_cycle["ai_required_for_execution"] == "true"
+    assert first_cycle["final_decision_accepted"] == "true"
+    assert second_cycle["opportunity_policy_mode"] == "assist"
+    assert second_cycle["decision_authority"] == "shared_assist_policy"
+    assert second_cycle["ai_required_for_execution"] == "false"
+    assert second_cycle["final_decision_accepted"] == "true"
+    assert third_cycle["opportunity_policy_mode"] == "live"
+    assert third_cycle["decision_authority"] == "shared_live_policy"
+    assert third_cycle["ai_required_for_execution"] == "true"
+    assert third_cycle["final_decision_accepted"] == "true"
+    assert adapter.modes_seen == ["live", "assist", "live"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- Audit of `ui/backend/runtime_service.py`, `bot_core/runtime/opportunity_runtime_controls.py` and `bot_core/runtime/pipeline.py` showed the backend hook already updates the shared `OpportunityRuntimeControls` and the sink reads a snapshot each cycle, leaving a gap only in automated proof.
- Provide a minimal, evidence-first contract test that exercising `RuntimeService.applyOpportunityRuntimeSettings` causes a running sink to pick up policy mode changes on the next cycle without any restart and preserves previous-cycle journaling.

### Description
- Added a focused contract test `test_opportunity_autonomy_runtime_mode_hot_switch_via_runtime_service_updates_shared_controls` in `tests/test_trading_controller.py` that exercises `RuntimeService.applyOpportunityRuntimeSettings` and validates `live -> assist -> live` transitions are observed by the running `DecisionAwareSignalSink` on subsequent cycles.
- Imported `get_opportunity_runtime_controls` and `RuntimeService` in the test and added restoration of the global controls snapshot in a `finally` block to avoid leaving global state mutated after the test.
- No production code changes were made; this is strictly a test-only PR to close the contract/evidence gap.

### Testing
- Set up dev deps with `python scripts/ci/pip_install.py -- .[dev]` (succeeded).
- Ran the focused test: `pytest -q tests/test_trading_controller.py -k "hot_switch_via_runtime_service_updates_shared_controls"` — `1 passed`.
- Ran the related autonomy/runtime test subset: `pytest -q tests/test_trading_controller.py -k "autonomy and runtime and mode"` — all selected tests passed (`12 passed`).
- Ran the wider regression subset: `pytest -q tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` and `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` — selected tests passed (all selected tests passed).
- Lint: `python -m ruff check tests/test_trading_controller.py` — all checks passed.
- Summary: all automated checks above completed and passed against this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13dce5ac0832a8149876d4973b13b)