### PR TITLE
Add parametric test for runtime hot-switch of opportunity AI shared controls (toggle + restore)

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -22328,6 +22328,174 @@ def test_opportunity_autonomy_runtime_mode_hot_switch_via_runtime_service_update
 
 
 @pytest.mark.parametrize(
+    ("toggle_payload", "restore_payload", "expected_disabled_reason", "expected_kill_switch_flag"),
+    (
+        (
+            {"opportunityAiEnabled": False},
+            {"opportunityAiEnabled": True},
+            "config_disabled",
+            "false",
+        ),
+        (
+            {"manualKillSwitch": True},
+            {"manualKillSwitch": False},
+            "manual_kill_switch:runtime_control_plane",
+            "true",
+        ),
+    ),
+)
+def test_opportunity_autonomy_runtime_hot_switch_shared_controls_toggle_ai_and_restore_without_restart(
+    toggle_payload: dict[str, bool],
+    restore_payload: dict[str, bool],
+    expected_disabled_reason: str,
+    expected_kill_switch_flag: str,
+) -> None:
+    class _AlwaysAcceptingOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+                cost_bps=2.0,
+                net_edge_bps=8.0,
+                model_name="runtime-hot-switch-model",
+                latency_ms=None,
+            )
+
+    class _AlwaysRejectingPolicyAdapter:
+        def __init__(self) -> None:
+            self.mode = "shadow"
+            self.modes_seen: list[str] = []
+
+        def emit_shadow_proposal(self, **_kwargs):
+            self.modes_seen.append(str(self.mode))
+            return SimpleNamespace(
+                status="proposal",
+                decision_available=True,
+                accepted=False,
+                model_version="opportunity-v-hot-switch",
+                decision_source="opportunity_ai_shadow",
+                rejection_reason="runtime_hot_switch_reject",
+                degraded_reason=None,
+                shadow_record_key=None,
+                shadow_persistence_status="disabled",
+                shadow_persistence_error=None,
+            )
+
+    runtime_controls = get_opportunity_runtime_controls()
+    initial_snapshot = runtime_controls.snapshot()
+    runtime_controls.update(
+        opportunity_ai_enabled=True,
+        manual_kill_switch=False,
+        policy_mode="live",
+    )
+
+    service = RuntimeService(decision_loader=lambda _limit: [])
+    adapter = _AlwaysRejectingPolicyAdapter()
+    journal = CollectingDecisionJournal()
+    base_sink = InMemoryStrategySignalSink()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_AlwaysAcceptingOrchestrator(),
+        risk_engine=DummyRiskEngine(),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="BINANCE",
+        min_probability=0.4,
+        journal=journal,
+        opportunity_shadow_adapter=adapter,
+        opportunity_policy_mode="shadow",
+        opportunity_runtime_controls=get_opportunity_runtime_controls(),
+    )
+    signal = _opportunity_autonomy_signal("paper_autonomous")
+    signal.metadata = {
+        **dict(signal.metadata),
+        "expected_probability": 0.95,
+        "expected_return_bps": 16.0,
+    }
+
+    try:
+        sink.submit(
+            strategy_name="trend-d1",
+            schedule_name="trend-d1",
+            risk_profile="balanced",
+            timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+            signals=(signal,),
+        )
+        cycle_one_journal_snapshot = tuple(journal.export())
+        cycle_one_forwarded_snapshot = tuple(base_sink.export())
+        assert cycle_one_forwarded_snapshot == ()
+
+        toggle_result = service.applyOpportunityRuntimeSettings(toggle_payload)
+        assert toggle_result["success"] is True
+        sink.submit(
+            strategy_name="trend-d1",
+            schedule_name="trend-d1",
+            risk_profile="balanced",
+            timestamp=datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+            signals=(signal,),
+        )
+        cycle_two_forwarded_snapshot = tuple(base_sink.export())
+
+        restore_result = service.applyOpportunityRuntimeSettings(restore_payload)
+        assert restore_result["success"] is True
+        sink.submit(
+            strategy_name="trend-d1",
+            schedule_name="trend-d1",
+            risk_profile="balanced",
+            timestamp=datetime(2026, 1, 1, 12, 2, tzinfo=timezone.utc),
+            signals=(signal,),
+        )
+    finally:
+        runtime_controls.update(
+            opportunity_ai_enabled=initial_snapshot.opportunity_ai_enabled,
+            manual_kill_switch=initial_snapshot.manual_kill_switch,
+            policy_mode=initial_snapshot.policy_mode,
+        )
+
+    decision_events = [
+        event for event in journal.export() if event.get("event") == "decision_evaluation"
+    ]
+    assert len(decision_events) == 3
+    first_cycle = decision_events[0]
+    second_cycle = decision_events[1]
+    third_cycle = decision_events[2]
+
+    assert first_cycle["opportunity_policy_mode"] == "live"
+    assert first_cycle["decision_authority"] == "opportunity_ai_live_policy"
+    assert first_cycle["ai_decision_available"] == "true"
+    assert first_cycle["opportunity_ai_enabled"] == "true"
+    assert first_cycle["final_decision_accepted"] == "false"
+
+    assert second_cycle["opportunity_policy_mode"] == "live"
+    assert second_cycle["decision_authority"] == "decision_orchestrator"
+    assert second_cycle["opportunity_ai_enabled"] == "false"
+    assert second_cycle["ai_decision_available"] == "false"
+    assert second_cycle["opportunity_ai_manual_kill_switch_active"] == expected_kill_switch_flag
+    assert second_cycle["opportunity_ai_disabled_reason"] == expected_disabled_reason
+    assert second_cycle["final_decision_accepted"] == "true"
+
+    assert third_cycle["opportunity_policy_mode"] == "live"
+    assert third_cycle["decision_authority"] == "opportunity_ai_live_policy"
+    assert third_cycle["ai_decision_available"] == "true"
+    assert third_cycle["opportunity_ai_enabled"] == "true"
+    assert third_cycle["opportunity_ai_manual_kill_switch_active"] == "false"
+    assert "opportunity_ai_disabled_reason" not in third_cycle
+    assert third_cycle["final_decision_accepted"] == "false"
+
+    assert len(cycle_two_forwarded_snapshot) == 1
+    assert cycle_two_forwarded_snapshot[0][0] == "trend-d1"
+    assert len(cycle_two_forwarded_snapshot[0][1]) == 1
+    forwarded_after_cycle_three = tuple(base_sink.export())
+    assert forwarded_after_cycle_three == cycle_two_forwarded_snapshot
+    first_cycle_events_after_switches = tuple(journal.export())[: len(cycle_one_journal_snapshot)]
+    assert first_cycle_events_after_switches == cycle_one_journal_snapshot
+    assert adapter.modes_seen == ["live", "live"]
+
+
+@pytest.mark.parametrize(
     ("missing_key", "missing_timestamp"),
     (
         (True, False),


### PR DESCRIPTION
### Motivation

- Verify that opportunity AI runtime controls (global enable and manual kill switch) can be toggled via the runtime service and restored without restarting the process while preserving correct decision-authority behavior and journaling.

### Description

- Add a new parametrized test `test_opportunity_autonomy_runtime_hot_switch_shared_controls_toggle_ai_and_restore_without_restart` covering two toggle scenarios: disabling via `opportunityAiEnabled` and disabling via `manualKillSwitch`.
- Introduce lightweight test helpers `_AlwaysAcceptingOrchestrator` and `_AlwaysRejectingPolicyAdapter` to simulate orchestrator and shadow-adapter behavior in the test.
- Use `RuntimeService.applyOpportunityRuntimeSettings` to toggle runtime controls and assert on decision journal fields such as `opportunity_policy_mode`, `decision_authority`, `ai_decision_available`, `opportunity_ai_enabled`, `opportunity_ai_manual_kill_switch_active`, and `opportunity_ai_disabled_reason` across three evaluation cycles.
- Assert forwarded signal behavior to the base sink and ensure runtime control state is restored to its initial snapshot in a `finally` block.

### Testing

- Ran the new parametrized test with both parameter combinations using `pytest tests/test_trading_controller.py::test_opportunity_autonomy_runtime_hot_switch_shared_controls_toggle_ai_and_restore_without_restart` and it passed.
- The test verifies three decision-evaluation cycles and the expected forwarded sink behavior for the toggled-and-restored scenarios, and these assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14bab6a34832abd0eb1659d58cd9c)