### PR TITLE
Snapshot opportunity runtime controls once per submit to ensure atomic mid-batch behavior

### DIFF
--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -2926,6 +2926,12 @@ class DecisionAwareSignalSink(StrategySignalSink):
         ai_shadow_persistence_error: str | None = None
         opportunity_ai_disabled_reason: str | None = None
 
+    @dataclass(slots=True, frozen=True)
+    class _BatchRuntimeControlSnapshot:
+        mode: "DecisionAwareSignalSink.OpportunityExecutionPolicyMode"
+        enabled: bool
+        manual_kill_switch: bool
+
     def __init__(
         self,
         *,
@@ -3127,6 +3133,7 @@ class DecisionAwareSignalSink(StrategySignalSink):
 
         accepted: list[StrategySignal] = []
         risk_snapshot = self._build_risk_snapshot(risk_profile)
+        batch_runtime_controls_snapshot = self._snapshot_runtime_controls_for_batch()
         for signal in signals:
             candidate, rejection_info = self._build_candidate(
                 strategy_name,
@@ -3198,6 +3205,7 @@ class DecisionAwareSignalSink(StrategySignalSink):
                 schedule_name=schedule_name,
                 risk_profile=risk_profile,
                 timestamp=timestamp,
+                batch_runtime_controls_snapshot=batch_runtime_controls_snapshot,
             )
             self._record_evaluation(
                 evaluation=evaluation,
@@ -3517,28 +3525,15 @@ class DecisionAwareSignalSink(StrategySignalSink):
         schedule_name: str,
         risk_profile: str,
         timestamp: datetime,
+        batch_runtime_controls_snapshot: "DecisionAwareSignalSink._BatchRuntimeControlSnapshot",
     ) -> "DecisionAwareSignalSink.OpportunityPolicyResolution":
         base_accepted = bool(getattr(evaluation, "accepted", False))
-        mode = self._opportunity_policy_mode
+        mode = batch_runtime_controls_snapshot.mode
         adapter = self._opportunity_shadow_adapter
-        enabled = self._opportunity_ai_enabled
-        runtime_manual_kill_switch = False
-        runtime_controls = self._opportunity_runtime_controls
-        if runtime_controls is not None and hasattr(runtime_controls, "snapshot"):
-            try:
-                runtime_snapshot = runtime_controls.snapshot()
-            except Exception:  # pragma: no cover - defensywne zabezpieczenie runtime bridge
-                runtime_snapshot = None
-            if runtime_snapshot is not None:
-                mode = self._parse_opportunity_policy_mode(
-                    getattr(runtime_snapshot, "policy_mode", mode.value)
-                )
-                enabled = bool(getattr(runtime_snapshot, "opportunity_ai_enabled", enabled))
-                runtime_manual_kill_switch = bool(
-                    getattr(runtime_snapshot, "manual_kill_switch", False)
-                )
-                if self._opportunity_shadow_adapter is not None:
-                    self._opportunity_shadow_adapter.mode = mode.value
+        enabled = batch_runtime_controls_snapshot.enabled
+        runtime_manual_kill_switch = batch_runtime_controls_snapshot.manual_kill_switch
+        if self._opportunity_shadow_adapter is not None:
+            self._opportunity_shadow_adapter.mode = mode.value
         disabled_reason: str | None = None
         manual_kill_switch = runtime_manual_kill_switch
         if self._opportunity_ai_enabled_override is not None:
@@ -3793,6 +3788,28 @@ class DecisionAwareSignalSink(StrategySignalSink):
                 "Nie udało się zapisać decision_evaluation (filtered)",
                 exc_info=True,
             )
+
+    def _snapshot_runtime_controls_for_batch(self) -> "DecisionAwareSignalSink._BatchRuntimeControlSnapshot":
+        mode = self._opportunity_policy_mode
+        enabled = self._opportunity_ai_enabled
+        manual_kill_switch = False
+        runtime_controls = self._opportunity_runtime_controls
+        if runtime_controls is not None and hasattr(runtime_controls, "snapshot"):
+            try:
+                runtime_snapshot = runtime_controls.snapshot()
+            except Exception:  # pragma: no cover - defensywne zabezpieczenie runtime bridge
+                runtime_snapshot = None
+            if runtime_snapshot is not None:
+                mode = self._parse_opportunity_policy_mode(
+                    getattr(runtime_snapshot, "policy_mode", mode.value)
+                )
+                enabled = bool(getattr(runtime_snapshot, "opportunity_ai_enabled", enabled))
+                manual_kill_switch = bool(getattr(runtime_snapshot, "manual_kill_switch", False))
+        return self._BatchRuntimeControlSnapshot(
+            mode=mode,
+            enabled=enabled,
+            manual_kill_switch=manual_kill_switch,
+        )
 
     def _build_risk_snapshot(self, risk_profile: str) -> Mapping[str, object]:
         loader = getattr(self._risk_engine, "snapshot_state", None)

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -22012,6 +22012,544 @@ def test_opportunity_autonomy_runtime_mode_hot_switch_applies_on_next_cycle_with
     assert first_cycle_events_after_switches == cycle_one_journal_snapshot
 
 
+def test_opportunity_autonomy_runtime_controls_mid_batch_policy_mode_is_atomic_per_submit() -> (
+    None
+):
+    class _AlwaysAcceptingOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+                cost_bps=2.0,
+                net_edge_bps=8.0,
+                model_name="runtime-hot-switch-model",
+                latency_ms=None,
+            )
+
+    class _ModeFlipOnFirstProbeAdapter:
+        def __init__(self, controls: OpportunityRuntimeControls) -> None:
+            self.mode = "shadow"
+            self._controls = controls
+            self._calls = 0
+
+        def emit_shadow_proposal(self, **_kwargs):
+            self._calls += 1
+            if self._calls == 1:
+                self._controls.update(policy_mode="assist")
+            return SimpleNamespace(
+                status="degraded",
+                decision_available=False,
+                accepted=False,
+                model_version="opportunity-v-hot-switch",
+                decision_source="opportunity_ai_shadow",
+                rejection_reason=None,
+                degraded_reason="runtime_hot_switch_probe_unavailable",
+                shadow_record_key=None,
+                shadow_persistence_status="disabled",
+                shadow_persistence_error=None,
+            )
+
+    runtime_controls = OpportunityRuntimeControls(policy_mode="live")
+    journal = CollectingDecisionJournal()
+    base_sink = InMemoryStrategySignalSink()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_AlwaysAcceptingOrchestrator(),
+        risk_engine=DummyRiskEngine(),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="BINANCE",
+        min_probability=0.4,
+        journal=journal,
+        opportunity_shadow_adapter=_ModeFlipOnFirstProbeAdapter(runtime_controls),
+        opportunity_policy_mode="shadow",
+        opportunity_runtime_controls=runtime_controls,
+    )
+    first_signal = _opportunity_autonomy_signal("paper_autonomous")
+    second_signal = _opportunity_autonomy_signal("paper_autonomous")
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+        signals=(first_signal, second_signal),
+    )
+    first_submit_snapshot = tuple(journal.export())
+    assert tuple(base_sink.export()) == ()
+
+    first_submit_decisions = [
+        event
+        for event in first_submit_snapshot
+        if event.get("event") == "decision_evaluation"
+    ]
+    assert len(first_submit_decisions) == 2
+    assert [event["opportunity_policy_mode"] for event in first_submit_decisions] == ["live", "live"]
+    assert [event["final_decision_accepted"] for event in first_submit_decisions] == ["false", "false"]
+    assert [event["decision_authority"] for event in first_submit_decisions] == [
+        "opportunity_ai_live_fail_closed",
+        "opportunity_ai_live_fail_closed",
+    ]
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+        signals=(first_signal, second_signal),
+    )
+    forwarded_after_second_submit = tuple(base_sink.export())
+    assert len(forwarded_after_second_submit) == 1
+    assert len(forwarded_after_second_submit[0][1]) == 2
+    first_submit_events_after_second_submit = tuple(journal.export())[: len(first_submit_snapshot)]
+    assert first_submit_events_after_second_submit == first_submit_snapshot
+
+    all_decisions = [event for event in journal.export() if event.get("event") == "decision_evaluation"]
+    second_submit_decisions = all_decisions[2:]
+    assert len(second_submit_decisions) == 2
+    assert [event["opportunity_policy_mode"] for event in second_submit_decisions] == ["assist", "assist"]
+    assert [event["final_decision_accepted"] for event in second_submit_decisions] == ["true", "true"]
+    assert [event["decision_authority"] for event in second_submit_decisions] == [
+        "decision_orchestrator",
+        "decision_orchestrator",
+    ]
+
+
+def test_opportunity_autonomy_runtime_controls_mid_batch_policy_mode_restore_is_atomic_per_submit() -> (
+    None
+):
+    class _AlwaysAcceptingOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+                cost_bps=2.0,
+                net_edge_bps=8.0,
+                model_name="runtime-hot-switch-model",
+                latency_ms=None,
+            )
+
+    class _ModeRestoreOnFirstProbeAdapter:
+        def __init__(self, controls: OpportunityRuntimeControls) -> None:
+            self.mode = "shadow"
+            self._controls = controls
+            self._calls = 0
+
+        def emit_shadow_proposal(self, **_kwargs):
+            self._calls += 1
+            if self._calls == 1:
+                self._controls.update(policy_mode="live")
+            return SimpleNamespace(
+                status="degraded",
+                decision_available=False,
+                accepted=False,
+                model_version="opportunity-v-hot-switch",
+                decision_source="opportunity_ai_shadow",
+                rejection_reason=None,
+                degraded_reason="runtime_hot_switch_probe_unavailable",
+                shadow_record_key=None,
+                shadow_persistence_status="disabled",
+                shadow_persistence_error=None,
+            )
+
+    runtime_controls = OpportunityRuntimeControls(policy_mode="assist")
+    journal = CollectingDecisionJournal()
+    base_sink = InMemoryStrategySignalSink()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_AlwaysAcceptingOrchestrator(),
+        risk_engine=DummyRiskEngine(),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="BINANCE",
+        min_probability=0.4,
+        journal=journal,
+        opportunity_shadow_adapter=_ModeRestoreOnFirstProbeAdapter(runtime_controls),
+        opportunity_policy_mode="shadow",
+        opportunity_runtime_controls=runtime_controls,
+    )
+    first_signal = _opportunity_autonomy_signal("paper_autonomous")
+    second_signal = _opportunity_autonomy_signal("paper_autonomous")
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+        signals=(first_signal, second_signal),
+    )
+    first_submit_snapshot = tuple(journal.export())
+    forwarded_after_first_submit = tuple(base_sink.export())
+    assert len(forwarded_after_first_submit) == 1
+    assert len(forwarded_after_first_submit[0][1]) == 2
+
+    first_submit_decisions = [
+        event
+        for event in first_submit_snapshot
+        if event.get("event") == "decision_evaluation"
+    ]
+    assert len(first_submit_decisions) == 2
+    assert [event["opportunity_policy_mode"] for event in first_submit_decisions] == ["assist", "assist"]
+    assert [event["final_decision_accepted"] for event in first_submit_decisions] == ["true", "true"]
+    assert [event["decision_authority"] for event in first_submit_decisions] == [
+        "decision_orchestrator",
+        "decision_orchestrator",
+    ]
+    assert [event["ai_required_for_execution"] for event in first_submit_decisions] == [
+        "false",
+        "false",
+    ]
+    assert [event["ai_decision_available"] for event in first_submit_decisions] == ["false", "false"]
+    assert [event["ai_decision_status"] for event in first_submit_decisions] == ["degraded", "degraded"]
+    assert [event["live_gate_failed_closed"] for event in first_submit_decisions] == ["false", "false"]
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+        signals=(first_signal, second_signal),
+    )
+    forwarded_after_second_submit = tuple(base_sink.export())
+    assert forwarded_after_second_submit == forwarded_after_first_submit
+    first_submit_events_after_second_submit = tuple(journal.export())[: len(first_submit_snapshot)]
+    assert first_submit_events_after_second_submit == first_submit_snapshot
+
+    all_decisions = [event for event in journal.export() if event.get("event") == "decision_evaluation"]
+    second_submit_decisions = all_decisions[2:]
+    assert len(second_submit_decisions) == 2
+    assert [event["opportunity_policy_mode"] for event in second_submit_decisions] == ["live", "live"]
+    assert [event["final_decision_accepted"] for event in second_submit_decisions] == ["false", "false"]
+    assert [event["decision_authority"] for event in second_submit_decisions] == [
+        "opportunity_ai_live_fail_closed",
+        "opportunity_ai_live_fail_closed",
+    ]
+    assert [event["ai_required_for_execution"] for event in second_submit_decisions] == [
+        "true",
+        "true",
+    ]
+    assert [event["ai_decision_available"] for event in second_submit_decisions] == ["false", "false"]
+    assert [event["ai_decision_status"] for event in second_submit_decisions] == ["degraded", "degraded"]
+    assert [event["live_gate_failed_closed"] for event in second_submit_decisions] == ["true", "true"]
+
+
+@pytest.mark.parametrize(
+    ("toggle_payload", "expected_disabled_reason", "expected_manual_kill_switch_flag"),
+    (
+        (
+            {"opportunity_ai_enabled": False},
+            "config_disabled",
+            "false",
+        ),
+        (
+            {"manual_kill_switch": True},
+            "manual_kill_switch:runtime_control_plane",
+            "true",
+        ),
+    ),
+)
+def test_opportunity_autonomy_runtime_controls_mid_batch_flags_are_atomic_per_submit(
+    toggle_payload: dict[str, object],
+    expected_disabled_reason: str,
+    expected_manual_kill_switch_flag: str,
+) -> None:
+    class _AlwaysAcceptingOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+                cost_bps=2.0,
+                net_edge_bps=8.0,
+                model_name="runtime-hot-switch-model",
+                latency_ms=None,
+            )
+
+    class _RejectingAndFlippingAdapter:
+        def __init__(
+            self,
+            controls: OpportunityRuntimeControls,
+            *,
+            toggle_payload: Mapping[str, object],
+        ) -> None:
+            self.mode = "shadow"
+            self._controls = controls
+            self._toggle_payload = dict(toggle_payload)
+            self._calls = 0
+
+        def emit_shadow_proposal(self, **_kwargs):
+            self._calls += 1
+            if self._calls == 1:
+                self._controls.update(**self._toggle_payload)
+            return SimpleNamespace(
+                status="proposal",
+                decision_available=True,
+                accepted=False,
+                model_version="opportunity-v-hot-switch",
+                decision_source="opportunity_ai_shadow",
+                rejection_reason="runtime_hot_switch_reject",
+                degraded_reason=None,
+                shadow_record_key=None,
+                shadow_persistence_status="disabled",
+                shadow_persistence_error=None,
+            )
+
+    runtime_controls = OpportunityRuntimeControls(
+        policy_mode="live",
+        opportunity_ai_enabled=True,
+        manual_kill_switch=False,
+    )
+    journal = CollectingDecisionJournal()
+    base_sink = InMemoryStrategySignalSink()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_AlwaysAcceptingOrchestrator(),
+        risk_engine=DummyRiskEngine(),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="BINANCE",
+        min_probability=0.4,
+        journal=journal,
+        opportunity_shadow_adapter=_RejectingAndFlippingAdapter(
+            runtime_controls,
+            toggle_payload=toggle_payload,
+        ),
+        opportunity_policy_mode="shadow",
+        opportunity_runtime_controls=runtime_controls,
+    )
+    first_signal = _opportunity_autonomy_signal("paper_autonomous")
+    second_signal = _opportunity_autonomy_signal("paper_autonomous")
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+        signals=(first_signal, second_signal),
+    )
+    first_submit_snapshot = tuple(journal.export())
+    assert tuple(base_sink.export()) == ()
+
+    first_submit_decisions = [
+        event
+        for event in first_submit_snapshot
+        if event.get("event") == "decision_evaluation"
+    ]
+    assert len(first_submit_decisions) == 2
+    assert [event["opportunity_ai_enabled"] for event in first_submit_decisions] == ["true", "true"]
+    assert [
+        event["opportunity_ai_manual_kill_switch_active"] for event in first_submit_decisions
+    ] == ["false", "false"]
+    assert [event["final_decision_accepted"] for event in first_submit_decisions] == ["false", "false"]
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+        signals=(first_signal, second_signal),
+    )
+    forwarded_after_second_submit = tuple(base_sink.export())
+    assert len(forwarded_after_second_submit) == 1
+    assert len(forwarded_after_second_submit[0][1]) == 2
+    first_submit_events_after_second_submit = tuple(journal.export())[: len(first_submit_snapshot)]
+    assert first_submit_events_after_second_submit == first_submit_snapshot
+
+    all_decisions = [event for event in journal.export() if event.get("event") == "decision_evaluation"]
+    second_submit_decisions = all_decisions[2:]
+    assert len(second_submit_decisions) == 2
+    assert [event["opportunity_ai_enabled"] for event in second_submit_decisions] == ["false", "false"]
+    assert [
+        event["opportunity_ai_manual_kill_switch_active"] for event in second_submit_decisions
+    ] == [expected_manual_kill_switch_flag, expected_manual_kill_switch_flag]
+    assert [event["final_decision_accepted"] for event in second_submit_decisions] == ["true", "true"]
+    assert [
+        event["opportunity_ai_disabled_reason"] for event in second_submit_decisions
+    ] == [expected_disabled_reason, expected_disabled_reason]
+
+
+@pytest.mark.parametrize(
+    ("initial_controls", "restore_payload"),
+    (
+        (
+            {"opportunity_ai_enabled": False, "manual_kill_switch": False},
+            {"opportunity_ai_enabled": True},
+        ),
+        (
+            {"opportunity_ai_enabled": True, "manual_kill_switch": True},
+            {"manual_kill_switch": False},
+        ),
+    ),
+)
+def test_opportunity_autonomy_runtime_controls_mid_batch_restore_flags_are_atomic_per_submit(
+    initial_controls: Mapping[str, bool],
+    restore_payload: Mapping[str, bool],
+) -> None:
+    expected_first_submit_disabled_reason = (
+        "manual_kill_switch:runtime_control_plane"
+        if initial_controls["manual_kill_switch"]
+        else "config_disabled"
+    )
+    expected_first_submit_kill_switch_flag = "true" if initial_controls["manual_kill_switch"] else "false"
+
+    class _RestoringOrchestrator:
+        def __init__(
+            self,
+            controls: OpportunityRuntimeControls,
+            *,
+            restore_payload: Mapping[str, bool],
+        ) -> None:
+            self._controls = controls
+            self._restore_payload = dict(restore_payload)
+            self._calls = 0
+
+        def evaluate_candidate(self, candidate, _context):
+            self._calls += 1
+            if self._calls == 1:
+                self._controls.update(**self._restore_payload)
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+                cost_bps=2.0,
+                net_edge_bps=8.0,
+                model_name="runtime-hot-switch-model",
+                latency_ms=None,
+            )
+
+    class _AlwaysRejectingAdapter:
+        def __init__(self) -> None:
+            self.mode = "shadow"
+
+        def emit_shadow_proposal(self, **_kwargs):
+            return SimpleNamespace(
+                status="proposal",
+                decision_available=True,
+                accepted=False,
+                model_version="opportunity-v-hot-switch",
+                decision_source="opportunity_ai_shadow",
+                rejection_reason="runtime_hot_switch_reject",
+                degraded_reason=None,
+                shadow_record_key=None,
+                shadow_persistence_status="disabled",
+                shadow_persistence_error=None,
+            )
+
+    runtime_controls = OpportunityRuntimeControls(
+        policy_mode="live",
+        opportunity_ai_enabled=initial_controls["opportunity_ai_enabled"],
+        manual_kill_switch=initial_controls["manual_kill_switch"],
+    )
+    journal = CollectingDecisionJournal()
+    base_sink = InMemoryStrategySignalSink()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_RestoringOrchestrator(
+            runtime_controls,
+            restore_payload=restore_payload,
+        ),
+        risk_engine=DummyRiskEngine(),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="BINANCE",
+        min_probability=0.4,
+        journal=journal,
+        opportunity_shadow_adapter=_AlwaysRejectingAdapter(),
+        opportunity_policy_mode="shadow",
+        opportunity_runtime_controls=runtime_controls,
+    )
+    first_signal = _opportunity_autonomy_signal("paper_autonomous")
+    second_signal = _opportunity_autonomy_signal("paper_autonomous")
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+        signals=(first_signal, second_signal),
+    )
+    first_submit_snapshot = tuple(journal.export())
+    forwarded_after_first_submit = tuple(base_sink.export())
+    assert len(forwarded_after_first_submit) == 1
+    assert len(forwarded_after_first_submit[0][1]) == 2
+
+    first_submit_decisions = [
+        event
+        for event in first_submit_snapshot
+        if event.get("event") == "decision_evaluation"
+    ]
+    assert len(first_submit_decisions) == 2
+    assert [event["opportunity_ai_enabled"] for event in first_submit_decisions] == ["false", "false"]
+    assert [event["opportunity_policy_mode"] for event in first_submit_decisions] == ["live", "live"]
+    assert [
+        event["opportunity_ai_manual_kill_switch_active"] for event in first_submit_decisions
+    ] == [expected_first_submit_kill_switch_flag, expected_first_submit_kill_switch_flag]
+    assert [event["opportunity_ai_disabled_reason"] for event in first_submit_decisions] == [
+        expected_first_submit_disabled_reason,
+        expected_first_submit_disabled_reason,
+    ]
+    assert [event["ai_decision_status"] for event in first_submit_decisions] == ["disabled", "disabled"]
+    assert [event["ai_decision_available"] for event in first_submit_decisions] == ["false", "false"]
+    assert [event["ai_required_for_execution"] for event in first_submit_decisions] == [
+        "false",
+        "false",
+    ]
+    assert [event["live_gate_failed_closed"] for event in first_submit_decisions] == ["false", "false"]
+    assert [event["final_decision_accepted"] for event in first_submit_decisions] == ["true", "true"]
+    assert [event["decision_authority"] for event in first_submit_decisions] == [
+        "decision_orchestrator",
+        "decision_orchestrator",
+    ]
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+        signals=(first_signal, second_signal),
+    )
+    forwarded_after_second_submit = tuple(base_sink.export())
+    assert forwarded_after_second_submit == forwarded_after_first_submit
+    first_submit_events_after_second_submit = tuple(journal.export())[: len(first_submit_snapshot)]
+    assert first_submit_events_after_second_submit == first_submit_snapshot
+
+    all_decisions = [event for event in journal.export() if event.get("event") == "decision_evaluation"]
+    second_submit_decisions = all_decisions[2:]
+    assert len(second_submit_decisions) == 2
+    assert [event["opportunity_ai_enabled"] for event in second_submit_decisions] == ["true", "true"]
+    assert [event["opportunity_policy_mode"] for event in second_submit_decisions] == ["live", "live"]
+    assert [event["opportunity_ai_manual_kill_switch_active"] for event in second_submit_decisions] == [
+        "false",
+        "false",
+    ]
+    assert [event["ai_decision_status"] for event in second_submit_decisions] == ["proposal", "proposal"]
+    assert [event["ai_decision_available"] for event in second_submit_decisions] == ["true", "true"]
+    assert [event["ai_decision_accepted"] for event in second_submit_decisions] == ["false", "false"]
+    assert [event["ai_required_for_execution"] for event in second_submit_decisions] == [
+        "true",
+        "true",
+    ]
+    assert [event["live_gate_failed_closed"] for event in second_submit_decisions] == ["false", "false"]
+    assert [event["decision_authority"] for event in second_submit_decisions] == [
+        "opportunity_ai_live_policy",
+        "opportunity_ai_live_policy",
+    ]
+    assert [event["final_decision_accepted"] for event in second_submit_decisions] == ["false", "false"]
+    assert [
+        "opportunity_ai_disabled_reason" in event for event in second_submit_decisions
+    ] == [False, False]
+
+
 def test_opportunity_autonomy_runtime_mode_hot_switch_preserves_prior_cycle_journal_lineage() -> (
     None
 ):


### PR DESCRIPTION
### Motivation

- Prevent inconsistent decision behavior when `OpportunityRuntimeControls` are updated while processing a batch of signals by making control values stable for the whole `submit()` call.  
- Ensure the opportunity shadow adapter and decision resolution logic observe a single coherent policy mode, enabled flag and manual kill-switch state per submit.  

### Description

- Added a frozen dataclass `_BatchRuntimeControlSnapshot` and a helper method `_snapshot_runtime_controls_for_batch()` on `DecisionAwareSignalSink` to capture `policy_mode`, `opportunity_ai_enabled`, and `manual_kill_switch` once at the start of `submit()`.  
- Modified `submit()` to take a `batch_runtime_controls_snapshot` and pass it into `_resolve_opportunity_policy()`.  
- Updated `_resolve_opportunity_policy()` to use the batch snapshot instead of querying runtime controls per-signal and to set the `opportunity_shadow_adapter.mode` from the snapshot.  
- Added comprehensive unit tests in `tests/test_trading_controller.py` to validate atomic mid-batch behavior for mode flips, restores, enable/disable toggles, and manual kill-switch changes.  

### Testing

- Added multiple new tests under `tests/test_trading_controller.py` (e.g. `test_opportunity_autonomy_runtime_controls_mid_batch_policy_mode_is_atomic_per_submit` and related parametrized cases) that exercise mid-batch control flips and restores.  
- Ran the test file with `pytest tests/test_trading_controller.py -q` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15225656c832a82a87d953d051f20)