### PR TITLE
Accept ruff-format drift in runtime pipeline and trading controller tests

### DIFF
--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -3240,7 +3240,9 @@ class DecisionAwareSignalSink(StrategySignalSink):
                 enriched_signal_metadata["live_gate_failed_closed"] = (
                     "true" if policy_resolution.live_gate_failed_closed else "false"
                 )
-                enriched_signal_metadata["decision_authority"] = policy_resolution.decision_authority
+                enriched_signal_metadata["decision_authority"] = (
+                    policy_resolution.decision_authority
+                )
                 enriched_signal_metadata["final_decision_accepted"] = (
                     "true" if policy_resolution.final_accepted else "false"
                 )

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -24131,7 +24131,8 @@ def test_opportunity_autonomy_runtime_lineage_sink_snapshot_propagates_downstrea
             "opportunity_ai_manual_kill_switch_active": (
                 str(metadata.get("opportunity_ai_manual_kill_switch_active") or "") or None
             ),
-            "ai_required_for_execution": str(metadata.get("ai_required_for_execution") or "") or None,
+            "ai_required_for_execution": str(metadata.get("ai_required_for_execution") or "")
+            or None,
             "decision_authority": str(metadata.get("decision_authority") or "") or None,
             "ai_decision_status": str(metadata.get("ai_decision_status") or "") or None,
             "ai_decision_available": str(metadata.get("ai_decision_available") or "") or None,
@@ -24228,7 +24229,9 @@ def test_opportunity_autonomy_runtime_lineage_sink_snapshot_propagates_downstrea
         "final_decision_accepted": "true",
         "opportunity_ai_disabled_reason": None,
     }
-    assert live_snapshot == _snapshot_from_request_metadata(dict(execution.requests[0].metadata or {}))
+    assert live_snapshot == _snapshot_from_request_metadata(
+        dict(execution.requests[0].metadata or {})
+    )
 
     # C. AI OFF snapshot z fallbackiem jest widoczny downstream.
     runtime_controls.update(policy_mode="live", opportunity_ai_enabled=False)
@@ -24255,7 +24258,9 @@ def test_opportunity_autonomy_runtime_lineage_sink_snapshot_propagates_downstrea
     }
 
     # D. restore usuwa disabled markers i wraca do normalnego live behavior.
-    runtime_controls.update(opportunity_ai_enabled=True, manual_kill_switch=False, policy_mode="live")
+    runtime_controls.update(
+        opportunity_ai_enabled=True, manual_kill_switch=False, policy_mode="live"
+    )
     sink.submit(
         strategy_name="trend-d1",
         schedule_name="trend-d1",
@@ -24286,7 +24291,9 @@ def test_opportunity_autonomy_runtime_lineage_sink_snapshot_propagates_downstrea
     exported_after_block = tuple(base_sink.export())
     assert len(exported_after_block) == 4
     assert len(execution.requests) == request_count_before_block
-    assert _snapshot_from_request_metadata(dict(execution.requests[0].metadata or {})) == live_snapshot
+    assert (
+        _snapshot_from_request_metadata(dict(execution.requests[0].metadata or {})) == live_snapshot
+    )
     sink_decision_events = [
         event for event in sink_journal.export() if event.get("event") == "decision_evaluation"
     ]
@@ -24496,7 +24503,9 @@ def test_opportunity_autonomy_runtime_lineage_restore_cleans_disabled_markers_on
     assert disabled_request_metadata["opportunity_ai_disabled_reason"] == "config_disabled"
 
     # restore cycle
-    runtime_controls.update(opportunity_ai_enabled=True, manual_kill_switch=False, policy_mode="live")
+    runtime_controls.update(
+        opportunity_ai_enabled=True, manual_kill_switch=False, policy_mode="live"
+    )
     sink.submit(
         strategy_name="trend-d1",
         schedule_name="trend-d1",
@@ -24608,7 +24617,9 @@ def test_opportunity_autonomy_runtime_lineage_restore_cleans_disabled_markers_on
     )
 
     # restore cycle
-    runtime_controls.update(manual_kill_switch=False, opportunity_ai_enabled=True, policy_mode="live")
+    runtime_controls.update(
+        manual_kill_switch=False, opportunity_ai_enabled=True, policy_mode="live"
+    )
     sink.submit(
         strategy_name="trend-d1",
         schedule_name="trend-d1",
@@ -24723,7 +24734,9 @@ def test_opportunity_autonomy_runtime_lineage_ai_decision_accepted_re_materializ
     assert disabled_request_metadata["opportunity_ai_disabled_reason"] == "config_disabled"
 
     # B. restore/live accepted cycle
-    runtime_controls.update(opportunity_ai_enabled=True, manual_kill_switch=False, policy_mode="live")
+    runtime_controls.update(
+        opportunity_ai_enabled=True, manual_kill_switch=False, policy_mode="live"
+    )
     sink.submit(
         strategy_name="trend-d1",
         schedule_name="trend-d1",


### PR DESCRIPTION
### Motivation
- Accept ruff-format-only formatter drift in two files to restore pre-commit/CI green while keeping all semantics and assertions identical.

### Description
- Wrap `decision_authority` assignment in `bot_core/runtime/pipeline.py` to the multi-line form required by the formatter and apply ruff-induced reflow in `tests/test_trading_controller.py` for a few long assertions and several `runtime_controls.update(...)` calls, with no changes to logic, contracts, assertion content, names, or messages.

### Testing
- Ran `python -m pre_commit run --all-files --show-diff-on-failure` which passed (including `ruff`, `ruff format`, and `mypy`), and ran `python -m pytest -q tests/test_trading_controller.py -k "runtime_lineage_sink_snapshot or runtime_lineage_restore or runtime_lineage_ai_decision_accepted" -xvv` which reported `4 passed, 493 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a222a968832aa0f41e4da74d025b)