### PR TITLE
Harden controller-side autonomy enforcement runtime-lineage tests

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -25622,6 +25622,11 @@ def test_opportunity_autonomy_enforcement_event_uses_canonical_runtime_lineage_s
     assert enforcement_event["order_ai_decision_status"] == (
         "proposal" if expected_ai_enabled else "disabled"
     )
+    assert enforcement_event["order_ai_required_for_execution"] == (
+        "true" if expected_ai_enabled and expected_policy_mode == "live" else "false"
+    )
+    assert enforcement_event["order_live_gate_failed_closed"] == "false"
+    assert enforcement_event["order_final_decision_accepted"] == "true"
     assert enforcement_event["order_decision_authority"] == (
         "shared_assist_policy"
         if expected_ai_enabled and expected_policy_mode == "assist"
@@ -25629,8 +25634,10 @@ def test_opportunity_autonomy_enforcement_event_uses_canonical_runtime_lineage_s
     )
     if expected_disabled_reason is None:
         assert "order_opportunity_ai_disabled_reason" not in enforcement_event
+        assert enforcement_event["order_ai_decision_accepted"] == "true"
         assert enforcement_event["order_opportunity_policy_mode"] != "shadow"
     else:
+        assert "order_ai_decision_accepted" not in enforcement_event
         assert enforcement_event["order_opportunity_ai_disabled_reason"] == expected_disabled_reason
 
 
@@ -25708,6 +25715,9 @@ def test_opportunity_autonomy_enforcement_event_restore_cleans_disabled_lineage_
     )
     controller.process_signals(list(tuple(base_sink.export())[-1][1]))
     disabled_event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert disabled_event["order_ai_required_for_execution"] == "false"
+    assert disabled_event["order_live_gate_failed_closed"] == "false"
+    assert disabled_event["order_final_decision_accepted"] == "true"
     assert disabled_event["order_opportunity_ai_disabled_reason"] == "config_disabled"
     assert "order_ai_decision_accepted" not in disabled_event
 
@@ -25725,6 +25735,9 @@ def test_opportunity_autonomy_enforcement_event_restore_cleans_disabled_lineage_
     )
     controller.process_signals(list(tuple(base_sink.export())[-1][1]))
     restored_event = _last_event(journal, "opportunity_autonomy_enforcement")
+    assert restored_event["order_ai_required_for_execution"] == "true"
+    assert restored_event["order_live_gate_failed_closed"] == "false"
+    assert restored_event["order_final_decision_accepted"] == "true"
     assert "order_opportunity_ai_disabled_reason" not in restored_event
     assert restored_event["order_ai_decision_accepted"] == "true"
 


### PR DESCRIPTION
### Motivation
- Tests lacked final controller-side observability assertions for the `opportunity_autonomy_enforcement` event, leaving runtime-lineage contract risks unverified.
- The restore-case symmetry and presence/absence semantics (especially for `order_ai_decision_accepted` and `order_opportunity_ai_disabled_reason`) were not fully asserted, so the canonical-over-stale guarantees were incomplete.

### Description
- Added assertions in `test_opportunity_autonomy_enforcement_event_uses_canonical_runtime_lineage_snapshot` for `order_ai_required_for_execution`, `order_live_gate_failed_closed`, and `order_final_decision_accepted`, and tightened presence/absence rules for `order_ai_decision_accepted` across accepted vs disabled/manual-kill fallback paths.
- Added restore-case assertions in `test_opportunity_autonomy_enforcement_event_restore_cleans_disabled_lineage_markers` to enforce disabled→restore symmetry: disabled event checks (`order_ai_required_for_execution == "false"`, `order_live_gate_failed_closed == "false"`, `order_final_decision_accepted == "true"`, absence of `order_ai_decision_accepted`) and restored event checks (`order_ai_required_for_execution == "true"`, `order_live_gate_failed_closed == "false"`, `order_final_decision_accepted == "true"`, `order_ai_decision_accepted == "true"`, absence of `order_opportunity_ai_disabled_reason`).
- Change is test-only in `tests/test_trading_controller.py` and does not modify production code.

### Testing
- Ran dependency install with `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` and it completed successfully.
- Ran broad test selector with `PYENV_VERSION=3.11.14 pytest -q tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source or autonomy_enforcement or restored or signal_skipped"` and got `354 passed, 164 deselected`.
- Ran combined selector with `PYENV_VERSION=3.11.14 pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` and got `334 passed, 223 deselected`.
- Ran narrow selector for the two modified tests with `PYENV_VERSION=3.11.14 pytest -q tests/test_trading_controller.py -k "test_opportunity_autonomy_enforcement_event_uses_canonical_runtime_lineage_snapshot or test_opportunity_autonomy_enforcement_event_restore_cleans_disabled_lineage_markers"` and got `5 passed, 513 deselected`.
- Ran linting with `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` and it passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e4635ba0832aa743c2478f71d855)