### PR TITLE
Add autonomous open-candidate arbitration and deterministic ranking to DecisionAwareSignalSink

### DIFF
--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -3134,6 +3134,14 @@ class DecisionAwareSignalSink(StrategySignalSink):
             return
 
         accepted: list[StrategySignal] = []
+        pending_accepted: list[
+            tuple[
+                StrategySignal,
+                DecisionCandidate,
+                DecisionEvaluation,
+                DecisionAwareSignalSink.OpportunityPolicyResolution,
+            ]
+        ] = []
         risk_snapshot = self._build_risk_snapshot(risk_profile)
         batch_runtime_controls_snapshot = self._snapshot_runtime_controls_for_batch()
         for signal in signals:
@@ -3209,6 +3217,34 @@ class DecisionAwareSignalSink(StrategySignalSink):
                 timestamp=timestamp,
                 batch_runtime_controls_snapshot=batch_runtime_controls_snapshot,
             )
+            if policy_resolution.final_accepted:
+                pending_accepted.append((signal, candidate, evaluation, policy_resolution))
+            else:
+                self._record_evaluation(
+                    evaluation=evaluation,
+                    candidate=candidate,
+                    signal=signal,
+                    strategy_name=strategy_name,
+                    schedule_name=schedule_name,
+                    risk_profile=risk_profile,
+                    timestamp=timestamp,
+                    policy_resolution=policy_resolution,
+                )
+                self._logger.debug(
+                    "DecisionOrchestrator odrzucił sygnał %s/%s: %s",
+                    strategy_name,
+                    signal.symbol,
+                    ", ".join(evaluation.reasons) or "brak powodów",
+                )
+
+        pending_accepted = self._apply_autonomous_open_candidate_arbitration(
+            pending_accepted=pending_accepted,
+            strategy_name=strategy_name,
+            schedule_name=schedule_name,
+            risk_profile=risk_profile,
+            timestamp=timestamp,
+        )
+        for signal, candidate, evaluation, policy_resolution in pending_accepted:
             self._record_evaluation(
                 evaluation=evaluation,
                 candidate=candidate,
@@ -3219,82 +3255,13 @@ class DecisionAwareSignalSink(StrategySignalSink):
                 timestamp=timestamp,
                 policy_resolution=policy_resolution,
             )
-            if policy_resolution.final_accepted:
-                enriched_signal_metadata = dict(signal.metadata or {})
-                enriched_signal_metadata["opportunity_policy_mode"] = policy_resolution.mode.value
-                enriched_signal_metadata["opportunity_ai_enabled"] = (
-                    "true" if policy_resolution.opportunity_ai_enabled else "false"
+            accepted.append(
+                self._build_enriched_forward_signal(
+                    signal=signal,
+                    policy_resolution=policy_resolution,
+                    timestamp=timestamp,
                 )
-                enriched_signal_metadata["opportunity_ai_manual_kill_switch_active"] = (
-                    "true"
-                    if policy_resolution.opportunity_ai_manual_kill_switch_active
-                    else "false"
-                )
-                enriched_signal_metadata["ai_required_for_execution"] = (
-                    "true" if policy_resolution.ai_required_for_execution else "false"
-                )
-                enriched_signal_metadata["ai_decision_available"] = (
-                    "true" if policy_resolution.ai_decision_available else "false"
-                )
-                enriched_signal_metadata["ai_decision_status"] = policy_resolution.ai_status
-                enriched_signal_metadata["live_gate_failed_closed"] = (
-                    "true" if policy_resolution.live_gate_failed_closed else "false"
-                )
-                enriched_signal_metadata["decision_authority"] = (
-                    policy_resolution.decision_authority
-                )
-                enriched_signal_metadata["final_decision_accepted"] = (
-                    "true" if policy_resolution.final_accepted else "false"
-                )
-                if policy_resolution.ai_decision_accepted is not None:
-                    enriched_signal_metadata["ai_decision_accepted"] = (
-                        "true" if policy_resolution.ai_decision_accepted else "false"
-                    )
-                else:
-                    enriched_signal_metadata.pop("ai_decision_accepted", None)
-                if policy_resolution.opportunity_ai_disabled_reason:
-                    enriched_signal_metadata["opportunity_ai_disabled_reason"] = (
-                        policy_resolution.opportunity_ai_disabled_reason
-                    )
-                else:
-                    enriched_signal_metadata.pop("opportunity_ai_disabled_reason", None)
-                if policy_resolution.ai_shadow_record_key:
-                    enriched_signal_metadata.setdefault(
-                        "opportunity_shadow_record_key",
-                        policy_resolution.ai_shadow_record_key,
-                    )
-                    enriched_signal_metadata.setdefault(
-                        "opportunity_decision_timestamp",
-                        timestamp.isoformat(),
-                    )
-                if policy_resolution.ai_model_version:
-                    enriched_signal_metadata.setdefault(
-                        "opportunity_model_version",
-                        policy_resolution.ai_model_version,
-                    )
-                if policy_resolution.ai_decision_source:
-                    enriched_signal_metadata.setdefault(
-                        "opportunity_decision_source",
-                        policy_resolution.ai_decision_source,
-                    )
-                accepted.append(
-                    StrategySignal(
-                        symbol=signal.symbol,
-                        side=signal.side,
-                        confidence=signal.confidence,
-                        quantity=signal.quantity,
-                        intent=signal.intent,
-                        legs=signal.legs,
-                        metadata=enriched_signal_metadata,
-                    )
-                )
-            else:
-                self._logger.debug(
-                    "DecisionOrchestrator odrzucił sygnał %s/%s: %s",
-                    strategy_name,
-                    signal.symbol,
-                    ", ".join(evaluation.reasons) or "brak powodów",
-                )
+            )
 
         if not accepted:
             return
@@ -3305,6 +3272,224 @@ class DecisionAwareSignalSink(StrategySignalSink):
             risk_profile=risk_profile,
             timestamp=timestamp,
             signals=tuple(accepted),
+        )
+
+    def _build_enriched_forward_signal(
+        self,
+        *,
+        signal: StrategySignal,
+        policy_resolution: "DecisionAwareSignalSink.OpportunityPolicyResolution",
+        timestamp: datetime,
+    ) -> StrategySignal:
+        enriched_signal_metadata = dict(signal.metadata or {})
+        enriched_signal_metadata["opportunity_policy_mode"] = policy_resolution.mode.value
+        enriched_signal_metadata["opportunity_ai_enabled"] = (
+            "true" if policy_resolution.opportunity_ai_enabled else "false"
+        )
+        enriched_signal_metadata["opportunity_ai_manual_kill_switch_active"] = (
+            "true" if policy_resolution.opportunity_ai_manual_kill_switch_active else "false"
+        )
+        enriched_signal_metadata["ai_required_for_execution"] = (
+            "true" if policy_resolution.ai_required_for_execution else "false"
+        )
+        enriched_signal_metadata["ai_decision_available"] = (
+            "true" if policy_resolution.ai_decision_available else "false"
+        )
+        enriched_signal_metadata["ai_decision_status"] = policy_resolution.ai_status
+        enriched_signal_metadata["live_gate_failed_closed"] = (
+            "true" if policy_resolution.live_gate_failed_closed else "false"
+        )
+        enriched_signal_metadata["decision_authority"] = policy_resolution.decision_authority
+        enriched_signal_metadata["final_decision_accepted"] = (
+            "true" if policy_resolution.final_accepted else "false"
+        )
+        if policy_resolution.ai_decision_accepted is not None:
+            enriched_signal_metadata["ai_decision_accepted"] = (
+                "true" if policy_resolution.ai_decision_accepted else "false"
+            )
+        else:
+            enriched_signal_metadata.pop("ai_decision_accepted", None)
+        if policy_resolution.opportunity_ai_disabled_reason:
+            enriched_signal_metadata["opportunity_ai_disabled_reason"] = (
+                policy_resolution.opportunity_ai_disabled_reason
+            )
+        else:
+            enriched_signal_metadata.pop("opportunity_ai_disabled_reason", None)
+        if policy_resolution.ai_shadow_record_key:
+            enriched_signal_metadata.setdefault(
+                "opportunity_shadow_record_key",
+                policy_resolution.ai_shadow_record_key,
+            )
+            enriched_signal_metadata.setdefault(
+                "opportunity_decision_timestamp",
+                timestamp.isoformat(),
+            )
+        if policy_resolution.ai_model_version:
+            enriched_signal_metadata.setdefault(
+                "opportunity_model_version",
+                policy_resolution.ai_model_version,
+            )
+        if policy_resolution.ai_decision_source:
+            enriched_signal_metadata.setdefault(
+                "opportunity_decision_source",
+                policy_resolution.ai_decision_source,
+            )
+        return StrategySignal(
+            symbol=signal.symbol,
+            side=signal.side,
+            confidence=signal.confidence,
+            quantity=signal.quantity,
+            intent=signal.intent,
+            legs=signal.legs,
+            metadata=enriched_signal_metadata,
+        )
+
+    def _apply_autonomous_open_candidate_arbitration(
+        self,
+        *,
+        pending_accepted: list[
+            tuple[
+                StrategySignal,
+                DecisionCandidate,
+                DecisionEvaluation,
+                OpportunityPolicyResolution,
+            ]
+        ],
+        strategy_name: str,
+        schedule_name: str,
+        risk_profile: str,
+        timestamp: datetime,
+    ) -> list[
+        tuple[
+            StrategySignal,
+            DecisionCandidate,
+            DecisionEvaluation,
+            OpportunityPolicyResolution,
+        ]
+    ]:
+        if len(pending_accepted) < 2:
+            return pending_accepted
+
+        grouped: dict[
+            tuple[str, str, str, str],
+            list[
+                tuple[
+                    StrategySignal,
+                    DecisionCandidate,
+                    DecisionEvaluation,
+                    "DecisionAwareSignalSink.OpportunityPolicyResolution",
+                ]
+            ],
+        ] = {}
+        passthrough: list[
+            tuple[
+                StrategySignal,
+                DecisionCandidate,
+                DecisionEvaluation,
+                "DecisionAwareSignalSink.OpportunityPolicyResolution",
+            ]
+        ] = []
+        for record in pending_accepted:
+            signal, candidate, _evaluation, _policy = record
+            scope_key = self._autonomous_open_arbitration_scope_key(signal=signal, candidate=candidate)
+            if scope_key is None:
+                passthrough.append(record)
+                continue
+            grouped.setdefault(scope_key, []).append(record)
+
+        survivors: list[
+            tuple[
+                StrategySignal,
+                DecisionCandidate,
+                DecisionEvaluation,
+                "DecisionAwareSignalSink.OpportunityPolicyResolution",
+            ]
+        ] = list(passthrough)
+        for scope_key, records in grouped.items():
+            if len(records) == 1:
+                survivors.extend(records)
+                continue
+            correlation_keys = {
+                str((record[0].metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+                for record in records
+            }
+            if len(correlation_keys) <= 1:
+                survivors.extend(records)
+                continue
+            ranked = sorted(records, key=self._autonomous_open_candidate_rank_key)
+            winner = ranked[0]
+            survivors.append(winner)
+            winner_signal = winner[0]
+            winner_correlation_key = str(
+                (winner_signal.metadata or {}).get("opportunity_shadow_record_key") or ""
+            )
+            for loser in ranked[1:]:
+                loser_signal = loser[0]
+                self._record_filtered_signal(
+                    signal=loser_signal,
+                    strategy_name=strategy_name,
+                    schedule_name=schedule_name,
+                    risk_profile=risk_profile,
+                    timestamp=timestamp,
+                    rejection_info={
+                        "reason": "autonomous_open_candidate_arbitration_loser",
+                        "winner_shadow_record_key": winner_correlation_key,
+                        "arbitration_scope": "|".join(scope_key),
+                    },
+                )
+        return survivors
+
+    def _autonomous_open_arbitration_scope_key(
+        self,
+        *,
+        signal: StrategySignal,
+        candidate: DecisionCandidate,
+    ) -> tuple[str, str, str, str] | None:
+        if str(getattr(candidate, "action", "")).strip().lower() != "enter":
+            return None
+        metadata = signal.metadata if isinstance(signal.metadata, Mapping) else {}
+        autonomy_mode = str(metadata.get("opportunity_autonomy_mode") or "").strip().lower()
+        if autonomy_mode not in {"paper_autonomous", "live_autonomous"}:
+            return None
+        portfolio_scope = str(metadata.get("portfolio_id") or metadata.get("portfolio") or "").strip()
+        if not portfolio_scope:
+            portfolio_scope = self._portfolio or self._environment
+        return (
+            str(candidate.symbol).strip(),
+            str(self._environment).strip(),
+            str(portfolio_scope).strip(),
+            autonomy_mode,
+        )
+
+    def _autonomous_open_candidate_rank_key(
+        self,
+        record: tuple[
+            StrategySignal,
+            DecisionCandidate,
+            DecisionEvaluation,
+            OpportunityPolicyResolution,
+        ],
+    ) -> tuple[float, float, float, str]:
+        signal, candidate, _evaluation, _policy = record
+        expected_return_bps = self._coerce_float(getattr(candidate, "expected_return_bps", None))
+        expected_probability = self._coerce_float(getattr(candidate, "expected_probability", None))
+        confidence = self._coerce_float(getattr(signal, "confidence", None))
+        metadata = signal.metadata if isinstance(signal.metadata, Mapping) else {}
+        tiebreak = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if not tiebreak:
+            try:
+                metadata_key = json.dumps(dict(metadata), ensure_ascii=False, sort_keys=True)
+            except (TypeError, ValueError):
+                metadata_key = repr(metadata)
+            tiebreak = (
+                f"{signal.symbol}|{signal.side}|{metadata_key}|"
+                f"{self._coerce_float(getattr(signal, 'quantity', None))}"
+            )
+        return (
+            -(expected_return_bps if expected_return_bps is not None else float("-inf")),
+            -(expected_probability if expected_probability is not None else float("-inf")),
+            -(confidence if confidence is not None else float("-inf")),
+            tiebreak,
         )
 
     def export(self) -> Sequence[tuple[str, Sequence[StrategySignal]]]:
@@ -3767,12 +3952,18 @@ class DecisionAwareSignalSink(StrategySignalSink):
         min_probability: float | None = None
         error_detail: str | None = None
         evaluation_type: str | None = None
+        winner_shadow_record_key: str | None = None
+        arbitration_scope: str | None = None
         if rejection_info:
             reason = str(rejection_info.get("reason") or "") or None
             raw_probability = rejection_info.get("probability")
             raw_min_probability = rejection_info.get("min_probability")
             error_detail = str(rejection_info.get("error") or "") or None
             evaluation_type = str(rejection_info.get("evaluation_type") or "") or None
+            winner_shadow_record_key = (
+                str(rejection_info.get("winner_shadow_record_key") or "") or None
+            )
+            arbitration_scope = str(rejection_info.get("arbitration_scope") or "") or None
             try:
                 probability = float(raw_probability) if raw_probability is not None else None
             except (TypeError, ValueError):  # pragma: no cover - defensywnie
@@ -3794,6 +3985,10 @@ class DecisionAwareSignalSink(StrategySignalSink):
             metadata.setdefault("decision_error", error_detail)
         if evaluation_type:
             metadata.setdefault("evaluation_type", evaluation_type)
+        if winner_shadow_record_key:
+            metadata.setdefault("winner_shadow_record_key", winner_shadow_record_key)
+        if arbitration_scope:
+            metadata.setdefault("arbitration_scope", arbitration_scope)
 
         metadata.setdefault("environment", self._environment)
         metadata.setdefault("exchange", self._exchange)

--- a/tests/runtime/test_streaming_feed.py
+++ b/tests/runtime/test_streaming_feed.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 import json
 import asyncio
 import time
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from contextlib import suppress
 from typing import Sequence
 
@@ -503,17 +503,18 @@ def test_decision_aware_sink_filters_signals() -> None:
     assert forwarded.metadata["final_decision_accepted"] == "true"
     assert len(orchestrator.invocations) == 1
     assert orchestrator.invocations[0].symbol == "BTC/USDT"
-    assert [event.status for event in journal.events] == ["accepted", "filtered"]
+    assert [event.status for event in journal.events] == ["filtered", "accepted"]
     assert all(event.portfolio == "paper-01" for event in journal.events)
-    accepted_event = journal.events[0]
+    accepted_event = next(event for event in journal.events if event.status == "accepted")
     thresholds_payload = json.loads(accepted_event.metadata["decision_thresholds"])
     assert thresholds_payload["max_cost_bps"] == pytest.approx(12.0)
     selection_payload = json.loads(accepted_event.metadata["model_selection"])
     assert selection_payload["selected"] == "gbm_v1"
     assert accepted_event.metadata["model_name"] == "gbm_v1"
     assert accepted_event.metadata["model_success_probability"] == "0.700000"
-    assert journal.events[1].metadata.get("decision_reason") == "probability_below_threshold"
-    assert journal.events[1].metadata.get("decision_status") == "filtered"
+    filtered_event = next(event for event in journal.events if event.status == "filtered")
+    assert filtered_event.metadata.get("decision_reason") == "probability_below_threshold"
+    assert filtered_event.metadata.get("decision_status") == "filtered"
 
 
 def test_decision_aware_sink_handles_missing_metadata() -> None:
@@ -1536,3 +1537,385 @@ def test_consume_stream_async_respects_async_stop_condition() -> None:
     assert processed[0].events[0]["close"] == pytest.approx(100.0)
     assert stream.aclose_calls == 1
     assert stream.next_calls == 1
+
+
+@pytest.mark.parametrize("reversed_input_order", [False, True])
+def test_decision_aware_sink_arbitrates_same_scope_autonomous_open_candidates_deterministically(
+    reversed_input_order: bool,
+) -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    journal = _DummyJournal()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=journal,
+    )
+    ts = datetime(2026, 4, 18, 12, 0, tzinfo=timezone.utc)
+    candidate_weaker = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.6,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-b",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 8.0,
+            "expected_probability": 0.7,
+        },
+    )
+    candidate_stronger = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.55,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-a",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 9.0,
+            "expected_probability": 0.65,
+        },
+    )
+    batch = (
+        (candidate_weaker, candidate_stronger)
+        if reversed_input_order
+        else (candidate_stronger, candidate_weaker)
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=batch,
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, exported_signals = records[0]
+    assert len(exported_signals) == 1
+    assert exported_signals[0].metadata["opportunity_shadow_record_key"] == "shadow-a"
+    filtered_events = [event for event in journal.events if event.status == "filtered"]
+    assert len(filtered_events) == 1
+    assert (
+        filtered_events[0].metadata.get("decision_reason")
+        == "autonomous_open_candidate_arbitration_loser"
+    )
+    assert filtered_events[0].metadata.get("winner_shadow_record_key") == "shadow-a"
+    evaluation_events = [event for event in journal.events if event.status == "accepted"]
+    assert len(evaluation_events) == 1
+    assert evaluation_events[0].metadata.get("decision_status") == "accepted"
+    assert evaluation_events[0].metadata.get("expected_return_bps") == "9.0"
+
+
+def test_decision_aware_sink_arbitration_does_not_mix_symbols_or_non_autonomous_or_close() -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    journal = _DummyJournal()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=journal,
+    )
+    ts = datetime(2026, 4, 18, 13, 0, tzinfo=timezone.utc)
+    signals = (
+        StrategySignal(
+            symbol="BTC/USDT",
+            side="BUY",
+            confidence=0.6,
+            metadata={
+                "opportunity_autonomy_mode": "paper_autonomous",
+                "opportunity_shadow_record_key": "shadow-btc-1",
+                "opportunity_decision_timestamp": ts.isoformat(),
+                "expected_return_bps": 9.0,
+                "expected_probability": 0.7,
+            },
+        ),
+        StrategySignal(
+            symbol="ETH/USDT",
+            side="BUY",
+            confidence=0.7,
+            metadata={
+                "opportunity_autonomy_mode": "paper_autonomous",
+                "opportunity_shadow_record_key": "shadow-eth-1",
+                "opportunity_decision_timestamp": ts.isoformat(),
+                "expected_return_bps": 8.0,
+                "expected_probability": 0.7,
+            },
+        ),
+        StrategySignal(
+            symbol="BTC/USDT",
+            side="SELL",
+            confidence=0.4,
+            metadata={
+                "opportunity_autonomy_mode": "paper_autonomous",
+                "opportunity_shadow_record_key": "shadow-btc-close",
+                "opportunity_decision_timestamp": ts.isoformat(),
+                "expected_return_bps": 7.0,
+                "expected_probability": 0.7,
+            },
+        ),
+        StrategySignal(
+            symbol="BTC/USDT",
+            side="BUY",
+            confidence=0.3,
+            metadata={
+                "opportunity_shadow_record_key": "shadow-non-autonomous",
+                "opportunity_decision_timestamp": ts.isoformat(),
+                "expected_return_bps": 6.0,
+                "expected_probability": 0.7,
+            },
+        ),
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=signals,
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    assert len(forwarded) == 4
+    assert [event for event in journal.events if event.status == "filtered"] == []
+
+
+@pytest.mark.parametrize("reversed_input_order", [False, True])
+def test_decision_aware_sink_arbitrates_opposite_side_autonomous_open_candidates_in_same_scope(
+    reversed_input_order: bool,
+) -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    journal = _DummyJournal()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=journal,
+    )
+
+    def _open_candidate_override(
+        self,
+        strategy_name: str,
+        risk_profile: str,
+        signal: StrategySignal,
+    ):
+        metadata = dict(signal.metadata or {})
+        metadata.setdefault("environment", self._environment)
+        metadata.setdefault("exchange", self._exchange)
+        metadata.setdefault("schedule", strategy_name)
+        return (
+            pipeline_module.DecisionCandidate(
+                strategy=strategy_name,
+                action="enter",
+                risk_profile=risk_profile,
+                symbol=signal.symbol,
+                notional=1_000.0,
+                expected_return_bps=float(metadata["expected_return_bps"]),
+                expected_probability=float(metadata["expected_probability"]),
+                cost_bps_override=None,
+                latency_ms=None,
+                metadata=metadata,
+            ),
+            None,
+        )
+
+    sink._build_candidate = MethodType(_open_candidate_override, sink)  # type: ignore[assignment]
+    ts = datetime(2026, 4, 18, 14, 0, tzinfo=timezone.utc)
+    buy_open = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.6,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-buy",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 9.0,
+            "expected_probability": 0.7,
+        },
+    )
+    sell_open = StrategySignal(
+        symbol="BTC/USDT",
+        side="SELL",
+        confidence=0.7,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-sell",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 8.0,
+            "expected_probability": 0.7,
+        },
+    )
+    batch = (sell_open, buy_open) if reversed_input_order else (buy_open, sell_open)
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=batch,
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    assert len(forwarded) == 1
+    assert forwarded[0].metadata["opportunity_shadow_record_key"] == "shadow-buy"
+    filtered_events = [event for event in journal.events if event.status == "filtered"]
+    assert len(filtered_events) == 1
+    assert (
+        filtered_events[0].metadata.get("decision_reason")
+        == "autonomous_open_candidate_arbitration_loser"
+    )
+    assert filtered_events[0].metadata.get("winner_shadow_record_key") == "shadow-buy"
+
+
+def test_decision_aware_sink_opposite_side_open_arbitration_tie_uses_stable_technical_tiebreak() -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=_DummyJournal(),
+    )
+
+    def _open_candidate_override(
+        self,
+        strategy_name: str,
+        risk_profile: str,
+        signal: StrategySignal,
+    ):
+        metadata = dict(signal.metadata or {})
+        metadata.setdefault("environment", self._environment)
+        metadata.setdefault("exchange", self._exchange)
+        metadata.setdefault("schedule", strategy_name)
+        return (
+            pipeline_module.DecisionCandidate(
+                strategy=strategy_name,
+                action="enter",
+                risk_profile=risk_profile,
+                symbol=signal.symbol,
+                notional=1_000.0,
+                expected_return_bps=10.0,
+                expected_probability=0.65,
+                cost_bps_override=None,
+                latency_ms=None,
+                metadata=metadata,
+            ),
+            None,
+        )
+
+    sink._build_candidate = MethodType(_open_candidate_override, sink)  # type: ignore[assignment]
+    ts = datetime(2026, 4, 18, 15, 0, tzinfo=timezone.utc)
+    buy_open = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.8,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-a",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 10.0,
+            "expected_probability": 0.65,
+        },
+    )
+    sell_open = StrategySignal(
+        symbol="BTC/USDT",
+        side="SELL",
+        confidence=0.8,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-b",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 10.0,
+            "expected_probability": 0.65,
+        },
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=(sell_open, buy_open),
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    assert len(forwarded) == 1
+    assert forwarded[0].metadata["opportunity_shadow_record_key"] == "shadow-a"


### PR DESCRIPTION
### Motivation
- Prevent multiple autonomous "open" candidates from the same scope being forwarded simultaneously by selecting a single winner deterministically. 
- Provide stable, explainable arbitration and surface arbitration metadata to the decision journal for debugging and auditing. 
- Keep forwarding logic and metadata enrichment consistent while deferring final forwarding until arbitration is applied. 

### Description
- Stage accepted evaluations into a `pending_accepted` list in `DecisionAwareSignalSink.submit` and defer forwarding until arbitration is applied. 
- Add `_apply_autonomous_open_candidate_arbitration` to group pending candidates by a scope key and pick a single winner per scope using a deterministic rank computed by `_autonomous_open_candidate_rank_key`. 
- Add `_autonomous_open_arbitration_scope_key` to detect applicable "enter" autonomous candidates and return the arbitration scope tuple. 
- Extract signal enrichment into `_build_enriched_forward_signal` and record arbitration metadata (`winner_shadow_record_key` and `arbitration_scope`) on filtered events via `_record_filtered_signal`. 
- Adjust submit flow to record evaluations for non-finalized candidates immediately, apply arbitration for `final_accepted` candidates, and then forward the enriched survivors to the base sink. 
- Minor test/import updates: add `MethodType` import and update `tests/runtime/test_streaming_feed.py` with multiple new tests exercising arbitration behavior and adjust an assertion order in an existing test. 

### Testing
- Ran the unit tests in `tests/runtime/test_streaming_feed.py` which include the updated assertion and the new arbitration tests; all tests in that module passed. 
- Executed parametrized scenarios covering deterministic selection, symbol/scope separation, opposite-side arbitration, and stable tiebreak behavior; all scenarios passed. 
- Existing behavior for non-arbitrated flows and metadata enrichment was validated by the adjusted tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ec95d334832a9b23613a788f9e9a)