### PR TITLE
Fix arbitration bypass for autonomous OPEN candidates without shadow key

### DIFF
--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -3409,13 +3409,20 @@ class DecisionAwareSignalSink(StrategySignalSink):
             if len(records) == 1:
                 survivors.extend(records)
                 continue
-            correlation_keys = {
+            correlation_keys = [
                 str((record[0].metadata or {}).get("opportunity_shadow_record_key") or "").strip()
                 for record in records
-            }
-            if len(correlation_keys) <= 1:
-                survivors.extend(records)
-                continue
+            ]
+            non_empty_correlation_keys = {key for key in correlation_keys if key}
+            if len(non_empty_correlation_keys) == 1:
+                shared_key = next(iter(non_empty_correlation_keys))
+                if all(key == shared_key for key in correlation_keys):
+                    candidate_identities = {
+                        self._autonomous_open_candidate_identity_key(record) for record in records
+                    }
+                    if len(candidate_identities) == 1:
+                        survivors.extend(records)
+                        continue
             ranked = sorted(records, key=self._autonomous_open_candidate_rank_key)
             winner = ranked[0]
             survivors.append(winner)
@@ -3490,6 +3497,26 @@ class DecisionAwareSignalSink(StrategySignalSink):
             -(expected_probability if expected_probability is not None else float("-inf")),
             -(confidence if confidence is not None else float("-inf")),
             tiebreak,
+        )
+
+    def _autonomous_open_candidate_identity_key(
+        self,
+        record: tuple[
+            StrategySignal,
+            DecisionCandidate,
+            DecisionEvaluation,
+            OpportunityPolicyResolution,
+        ],
+    ) -> tuple[str, float | None, float | None, float | None, float | None, str]:
+        signal, candidate, _evaluation, _policy = record
+        metadata = signal.metadata if isinstance(signal.metadata, Mapping) else {}
+        return (
+            str(signal.side).strip().upper(),
+            self._coerce_float(getattr(candidate, "expected_return_bps", None)),
+            self._coerce_float(getattr(candidate, "expected_probability", None)),
+            self._coerce_float(getattr(signal, "confidence", None)),
+            self._coerce_float(getattr(signal, "quantity", None)),
+            str(metadata.get("opportunity_shadow_record_key") or "").strip(),
         )
 
     def export(self) -> Sequence[tuple[str, Sequence[StrategySignal]]]:

--- a/tests/runtime/test_streaming_feed.py
+++ b/tests/runtime/test_streaming_feed.py
@@ -1626,6 +1626,257 @@ def test_decision_aware_sink_arbitrates_same_scope_autonomous_open_candidates_de
     assert evaluation_events[0].metadata.get("expected_return_bps") == "9.0"
 
 
+@pytest.mark.parametrize("reversed_input_order", [False, True])
+def test_decision_aware_sink_arbitrates_same_scope_autonomous_open_candidates_when_shadow_key_missing(
+    reversed_input_order: bool,
+) -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    journal = _DummyJournal()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=journal,
+    )
+    ts = datetime(2026, 4, 18, 12, 30, tzinfo=timezone.utc)
+    candidate_weaker = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.6,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 8.0,
+            "expected_probability": 0.7,
+        },
+    )
+    candidate_stronger = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.55,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 9.0,
+            "expected_probability": 0.65,
+            "arbitration_hint": "winner",
+        },
+    )
+    batch = (
+        (candidate_weaker, candidate_stronger)
+        if reversed_input_order
+        else (candidate_stronger, candidate_weaker)
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=batch,
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, exported_signals = records[0]
+    assert len(exported_signals) == 1
+    assert exported_signals[0].metadata.get("arbitration_hint") == "winner"
+    filtered_events = [event for event in journal.events if event.status == "filtered"]
+    assert len(filtered_events) == 1
+    assert (
+        filtered_events[0].metadata.get("decision_reason")
+        == "autonomous_open_candidate_arbitration_loser"
+    )
+    assert filtered_events[0].metadata.get("winner_shadow_record_key") in (None, "")
+
+
+@pytest.mark.parametrize("reversed_input_order", [False, True])
+def test_decision_aware_sink_missing_shadow_key_tie_uses_stable_technical_tiebreak(
+    reversed_input_order: bool,
+) -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=_DummyJournal(),
+    )
+
+    def _open_candidate_override(
+        self,
+        strategy_name: str,
+        risk_profile: str,
+        signal: StrategySignal,
+    ):
+        metadata = dict(signal.metadata or {})
+        metadata.setdefault("environment", self._environment)
+        metadata.setdefault("exchange", self._exchange)
+        metadata.setdefault("schedule", strategy_name)
+        return (
+            pipeline_module.DecisionCandidate(
+                strategy=strategy_name,
+                action="enter",
+                risk_profile=risk_profile,
+                symbol=signal.symbol,
+                notional=1_000.0,
+                expected_return_bps=float(metadata["expected_return_bps"]),
+                expected_probability=float(metadata["expected_probability"]),
+                cost_bps_override=None,
+                latency_ms=None,
+                metadata=metadata,
+            ),
+            None,
+        )
+
+    sink._build_candidate = MethodType(_open_candidate_override, sink)  # type: ignore[assignment]
+    ts = datetime(2026, 4, 18, 12, 45, tzinfo=timezone.utc)
+    candidate_alpha = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.8,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 10.0,
+            "expected_probability": 0.65,
+            "candidate_tag": "alpha",
+        },
+    )
+    candidate_beta = StrategySignal(
+        symbol="BTC/USDT",
+        side="SELL",
+        confidence=0.8,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 10.0,
+            "expected_probability": 0.65,
+            "candidate_tag": "beta",
+        },
+    )
+    batch = (
+        (candidate_beta, candidate_alpha)
+        if reversed_input_order
+        else (candidate_alpha, candidate_beta)
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=batch,
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    assert len(forwarded) == 1
+    assert forwarded[0].metadata.get("candidate_tag") == "alpha"
+
+
+def test_decision_aware_sink_single_key_duplicate_contract_requires_same_candidate_identity() -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=_DummyJournal(),
+    )
+    ts = datetime(2026, 4, 18, 12, 50, tzinfo=timezone.utc)
+    duplicate_one = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.7,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-duplicate",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 10.0,
+            "expected_probability": 0.6,
+        },
+    )
+    duplicate_two = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.7,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-duplicate",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 10.0,
+            "expected_probability": 0.6,
+        },
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=(duplicate_one, duplicate_two),
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    assert len(forwarded) == 2
+
+
 def test_decision_aware_sink_arbitration_does_not_mix_symbols_or_non_autonomous_or_close() -> None:
     base_sink = InMemoryStrategySignalSink()
 


### PR DESCRIPTION
### Motivation
- The arbitration seam in `DecisionAwareSignalSink` treated empty or missing `opportunity_shadow_record_key` as a single shared key and could skip arbitration when multiple autonomous OPEN candidates in the same scope lacked the key. 
- This allowed multiple autonomous OPEN candidates in the same scope to pass-through without resolving a single winner, which is a real runtime functional gap.
- The intent is to ensure missing/blank shadow keys do not disable arbitration while preserving the existing single-key duplicate bypass contract for true identical records.

### Description
- Tighten the arbitration guard in `DecisionAwareSignalSink._apply_autonomous_open_candidate_arbitration` so the single-key bypass is applied only when there is exactly one non-empty shared `opportunity_shadow_record_key` and all records have identical candidate identity. 
- Introduce `_autonomous_open_candidate_identity_key` helper (side + ranking metrics + quantity + key) used to confirm candidate identity equality for the bypass. 
- Leave the ranking policy unchanged (`expected_return_bps`, `expected_probability`, `confidence`, stable technical tie-break). 
- Add focused tests in `tests/runtime/test_streaming_feed.py` to cover missing/blank shadow key arbitration, tie-break determinism, and preserved true duplicate behavior.
- Files changed: `bot_core/runtime/pipeline.py`, `tests/runtime/test_streaming_feed.py`.

### Testing
- Installed dev deps with `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` which completed successfully. 
- Ran `PYENV_VERSION=3.11.14 pytest -q tests/runtime/test_streaming_feed.py -k "decision_aware_sink or filters or autonomy or arbitration"` and all relevant tests passed (`17 passed, 11 deselected`).
- Ran targeted new-test selector `PYENV_VERSION=3.11.14 pytest -q tests/runtime/test_streaming_feed.py -k "missing_shadow_key or single_key_duplicate_contract_requires_same_candidate_identity"` and the new tests passed (`3 passed, 25 deselected`).
- Ran controller and AI test selectors: `PYENV_VERSION=3.11.14 pytest -q tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source or duplicate or arbitration or filtered or signal_skipped"` (351 passed, 174 deselected) and `PYENV_VERSION=3.11.14 pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` (341 passed, 223 deselected). 
- Lint check `python -m ruff check bot_core/runtime/pipeline.py bot_core/runtime/controller.py tests/runtime/test_streaming_feed.py tests/test_trading_controller.py` passed with no findings. 
- Commit created containing the narrow changes to `bot_core/runtime/pipeline.py` and `tests/runtime/test_streaming_feed.py` (commit hash `3ada2be`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f28e31a4832a91c3b0e26544e539)