### PR TITLE
Suppress duplicate autonomous open re-entries across correlation keys and add deterministic selection logic

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1190,6 +1190,46 @@ class TradingController:
             scope_portfolio and not tracker_portfolio
         )
 
+    def _find_matching_active_open_tracker_for_autonomous_open(
+        self,
+        *,
+        symbol: str,
+        current_side: str,
+        exclude_correlation_key: str,
+    ) -> tuple[str, _OpportunityOpenOutcomeTracker] | None:
+        matching_trackers: list[tuple[str, _OpportunityOpenOutcomeTracker]] = []
+        for tracked_correlation_key, tracker in self._opportunity_open_outcomes.items():
+            if exclude_correlation_key and tracked_correlation_key == exclude_correlation_key:
+                continue
+            if str(tracker.symbol) != str(symbol):
+                continue
+            if self._is_closing_side(str(tracker.side), current_side):
+                continue
+            if not self._matches_current_open_tracker_scope(
+                correlation_key=tracked_correlation_key,
+                symbol=str(symbol),
+                tracker=tracker,
+            ):
+                continue
+            matching_trackers.append((tracked_correlation_key, tracker))
+        if not matching_trackers:
+            return None
+
+        def _tracker_order(
+            item: tuple[str, _OpportunityOpenOutcomeTracker],
+        ) -> tuple[datetime, str]:
+            tracked_correlation_key, tracker = item
+            decision_timestamp = tracker.decision_timestamp
+            if not isinstance(decision_timestamp, datetime):
+                normalized_timestamp = datetime.max.replace(tzinfo=timezone.utc)
+            elif decision_timestamp.tzinfo is None:
+                normalized_timestamp = decision_timestamp.replace(tzinfo=timezone.utc)
+            else:
+                normalized_timestamp = decision_timestamp.astimezone(timezone.utc)
+            return normalized_timestamp, tracked_correlation_key
+
+        return min(matching_trackers, key=_tracker_order)
+
     def _record_decision_event(
         self,
         event_type: str,
@@ -1922,20 +1962,30 @@ class TradingController:
                 "paper_autonomous",
                 "live_autonomous",
             }
+            duplicate_open_tracker_key = correlation_key
+            duplicate_open_tracker = existing_open_tracker
+            if duplicate_open_guard_enabled and duplicate_open_tracker is None:
+                matching_tracker = self._find_matching_active_open_tracker_for_autonomous_open(
+                    symbol=str(request.symbol),
+                    current_side=str(request.side),
+                    exclude_correlation_key=correlation_key,
+                )
+                if matching_tracker is not None:
+                    duplicate_open_tracker_key, duplicate_open_tracker = matching_tracker
             if (
                 duplicate_open_guard_enabled
-                and existing_open_tracker is not None
+                and duplicate_open_tracker is not None
                 and self._matches_current_open_tracker_scope(
-                    correlation_key=correlation_key,
+                    correlation_key=duplicate_open_tracker_key,
                     symbol=str(request.symbol),
-                    tracker=existing_open_tracker,
+                    tracker=duplicate_open_tracker,
                 )
-                and str(existing_open_tracker.symbol) == str(request.symbol)
-                and not self._is_closing_side(str(existing_open_tracker.side), str(request.side))
+                and str(duplicate_open_tracker.symbol) == str(request.symbol)
+                and not self._is_closing_side(str(duplicate_open_tracker.side), str(request.side))
             ):
                 request = self._apply_restored_runtime_lineage_to_request_metadata(
                     request=request,
-                    tracker=existing_open_tracker,
+                    tracker=duplicate_open_tracker,
                 )
                 self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
                 self._record_decision_event(
@@ -1946,7 +1996,8 @@ class TradingController:
                     metadata={
                         "reason": "duplicate_autonomous_open_reentry_suppressed",
                         "proxy_correlation_key": correlation_key,
-                        "existing_open_side": str(existing_open_tracker.side),
+                        "existing_open_side": str(duplicate_open_tracker.side),
+                        "existing_open_correlation_key": duplicate_open_tracker_key,
                     },
                 )
                 return None

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -9776,6 +9776,523 @@ def test_opportunity_autonomy_duplicate_open_reentry_same_runtime_is_suppressed(
     assert skipped_events[-1]["proxy_correlation_key"] == correlation_key
 
 
+def test_opportunity_autonomy_duplicate_open_reentry_cross_correlation_same_scope_is_suppressed() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 7, 12, 30, tzinfo=timezone.utc)
+    primary_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    replay_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=primary_correlation_key, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_correlation_key, decision_timestamp=decision_timestamp
+            ),
+        ]
+    )
+    controller, execution, journal = _build_autonomy_controller(
+        environment="paper",
+        opportunity_shadow_repository=repository,
+    )
+    primary_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=primary_correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="primary_open",
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="cross_correlation_reentry",
+    )
+
+    controller.process_signals([primary_open_signal])
+    open_rows_before_replay = repository.load_open_outcomes()
+    labels_before_replay = repository.load_outcome_labels()
+    controller.process_signals([replay_open_signal])
+
+    assert len(execution.requests) == 1
+    assert repository.load_open_outcomes() == open_rows_before_replay
+    assert repository.load_outcome_labels() == labels_before_replay
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert skipped_events
+    assert skipped_events[-1]["reason"] == "duplicate_autonomous_open_reentry_suppressed"
+    assert skipped_events[-1]["proxy_correlation_key"] == replay_correlation_key
+    assert skipped_events[-1]["existing_open_correlation_key"] == primary_correlation_key
+
+
+def test_opportunity_autonomy_duplicate_open_reentry_cross_correlation_after_restart_is_suppressed() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 12, 45, tzinfo=timezone.utc)
+    restored_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v2",
+        rank=1,
+    )
+    replay_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v2",
+        rank=2,
+    )
+    repository = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="dup-open-cross-key-")))
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=restored_correlation_key, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_correlation_key, decision_timestamp=decision_timestamp
+            ),
+        ]
+    )
+    restored_runtime_lineage = {
+        "opportunity_policy_mode": "live",
+        "opportunity_ai_enabled": "false",
+        "opportunity_ai_manual_kill_switch_active": "true",
+        "ai_required_for_execution": "false",
+        "ai_decision_available": "false",
+        "ai_decision_status": "disabled",
+        "live_gate_failed_closed": "false",
+        "decision_authority": "decision_orchestrator",
+        "final_decision_accepted": "true",
+        "opportunity_ai_disabled_reason": "manual_kill_switch:runtime_control_plane",
+    }
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=restored_correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "cross_correlation_restored_tracker",
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_requested_mode": "paper_autonomous",
+                "autonomy_upstream_effective_mode": "paper_autonomous",
+                "autonomy_local_guard_effective_mode": "paper_autonomous",
+                "autonomy_final_mode": "paper_autonomous",
+                **restored_runtime_lineage,
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=100.0)
+    controller, replay_journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    replay_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=True,
+    )
+    replay_signal.metadata = {
+        **dict(replay_signal.metadata),
+        "opportunity_policy_mode": "paper",
+        "decision_authority": "shared_live_policy",
+    }
+    open_rows_before = repository.load_open_outcomes()
+    labels_before = repository.load_outcome_labels()
+
+    controller.process_signals([replay_signal])
+
+    assert len(execution.requests) == 0
+    assert repository.load_open_outcomes() == open_rows_before
+    assert repository.load_outcome_labels() == labels_before
+    skipped_events = [
+        event for event in replay_journal.export() if event["event"] == "signal_skipped"
+    ]
+    assert skipped_events
+    event = skipped_events[-1]
+    assert event["reason"] == "duplicate_autonomous_open_reentry_suppressed"
+    assert event["proxy_correlation_key"] == replay_correlation_key
+    assert event["existing_open_correlation_key"] == restored_correlation_key
+    assert event["order_opportunity_policy_mode"] == "paper"
+    assert event["order_decision_authority"] == "shared_live_policy"
+    assert "order_opportunity_ai_enabled" not in event
+
+
+@pytest.mark.parametrize("newer_inserted_first", [True, False])
+def test_opportunity_autonomy_duplicate_open_reentry_cross_correlation_multi_tracker_selection_is_order_independent(
+    newer_inserted_first: bool,
+) -> None:
+    older_timestamp = datetime(2026, 1, 8, 12, 46, tzinfo=timezone.utc)
+    newer_timestamp = datetime(2026, 1, 8, 12, 47, tzinfo=timezone.utc)
+    older_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=older_timestamp,
+        model_version="opportunity-v2",
+        rank=1,
+    )
+    newer_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=newer_timestamp,
+        model_version="opportunity-v2",
+        rank=2,
+    )
+    replay_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=newer_timestamp,
+        model_version="opportunity-v2",
+        rank=3,
+    )
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="dup-open-cross-key-multi-"))
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=older_correlation_key, decision_timestamp=older_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=newer_correlation_key, decision_timestamp=newer_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_correlation_key, decision_timestamp=newer_timestamp
+            ),
+        ]
+    )
+    older_tracker = repository.OpenOutcomeState(
+        correlation_key=older_correlation_key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=older_timestamp,
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        provenance={
+            "source": "oldest_tracker_should_win",
+            "environment": "paper",
+            "portfolio": "paper-1",
+            "autonomy_requested_mode": "paper_autonomous",
+            "autonomy_upstream_effective_mode": "paper_autonomous",
+            "autonomy_local_guard_effective_mode": "paper_autonomous",
+            "autonomy_final_mode": "paper_autonomous",
+            "opportunity_policy_mode": "live",
+            "decision_authority": "oldest_tracker_authority",
+        },
+    )
+    newer_tracker = repository.OpenOutcomeState(
+        correlation_key=newer_correlation_key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=101.0,
+        decision_timestamp=newer_timestamp,
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        provenance={
+            "source": "newer_tracker_should_lose",
+            "environment": "paper",
+            "portfolio": "paper-1",
+            "autonomy_requested_mode": "paper_autonomous",
+            "autonomy_upstream_effective_mode": "paper_autonomous",
+            "autonomy_local_guard_effective_mode": "paper_autonomous",
+            "autonomy_final_mode": "paper_autonomous",
+            "opportunity_policy_mode": "live",
+            "decision_authority": "newer_tracker_authority",
+        },
+    )
+    if newer_inserted_first:
+        repository.upsert_open_outcome(newer_tracker)
+        repository.upsert_open_outcome(older_tracker)
+    else:
+        repository.upsert_open_outcome(older_tracker)
+        repository.upsert_open_outcome(newer_tracker)
+
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=100.0)
+    controller, replay_journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    replay_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_correlation_key,
+        decision_timestamp=newer_timestamp,
+        include_mode=True,
+    )
+    controller.process_signals([replay_signal])
+
+    assert len(execution.requests) == 0
+    skipped_events = [
+        event for event in replay_journal.export() if event["event"] == "signal_skipped"
+    ]
+    assert skipped_events
+    event = skipped_events[-1]
+    assert event["reason"] == "duplicate_autonomous_open_reentry_suppressed"
+    assert event["proxy_correlation_key"] == replay_correlation_key
+    assert event["existing_open_correlation_key"] == older_correlation_key
+    assert event["order_decision_authority"] == "oldest_tracker_authority"
+
+
+def test_opportunity_autonomy_duplicate_open_reentry_cross_correlation_multi_tracker_tie_uses_lexicographically_smallest_correlation_key() -> (
+    None
+):
+    shared_timestamp = datetime(2026, 1, 8, 12, 48, tzinfo=timezone.utc)
+    smaller_correlation_key = "aaa-cross-key"
+    larger_correlation_key = "zzz-cross-key"
+    replay_correlation_key = "mmm-cross-key"
+    repository = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="dup-open-cross-key-tie-")))
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=smaller_correlation_key,
+                    decision_timestamp=shared_timestamp,
+                ),
+                record_key=smaller_correlation_key,
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=larger_correlation_key,
+                    decision_timestamp=shared_timestamp,
+                ),
+                record_key=larger_correlation_key,
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=replay_correlation_key,
+                    decision_timestamp=shared_timestamp,
+                ),
+                record_key=replay_correlation_key,
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=larger_correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=shared_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+            },
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=smaller_correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=shared_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+            },
+        )
+    )
+
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=100.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    replay_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_correlation_key,
+        decision_timestamp=shared_timestamp,
+        include_mode=True,
+    )
+    controller.process_signals([replay_signal])
+
+    assert len(execution.requests) == 0
+    skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
+    assert skipped_events
+    assert skipped_events[-1]["existing_open_correlation_key"] == smaller_correlation_key
+
+
+def test_opportunity_autonomy_duplicate_open_reentry_cross_correlation_foreign_scope_does_not_suppress() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 13, 15, tzinfo=timezone.utc)
+    restored_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v3",
+        rank=1,
+    )
+    replay_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v3",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=restored_correlation_key, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_correlation_key, decision_timestamp=decision_timestamp
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=restored_correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "foreign_scope_tracker",
+                "environment": "paper",
+                "portfolio": "paper-foreign",
+            },
+        )
+    )
+
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=100.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    replay_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+        decision_primary_reason="foreign_scope_replay_should_execute",
+    )
+
+    controller.process_signals([replay_signal])
+
+    assert len(execution.requests) == 1
+    suppressed_events = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and event.get("reason") == "duplicate_autonomous_open_reentry_suppressed"
+    ]
+    assert suppressed_events == []
+
+
+def test_opportunity_autonomy_duplicate_open_reentry_cross_correlation_does_not_block_close_or_non_autonomous() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 8, 13, 45, tzinfo=timezone.utc)
+    primary_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v4",
+        rank=1,
+    )
+    close_correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v4",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0, 5.0, 4.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=primary_correlation_key, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=close_correlation_key, decision_timestamp=decision_timestamp
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 104.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 106.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="paper_autonomous",
+                side="BUY",
+                correlation_key=primary_correlation_key,
+                decision_timestamp=decision_timestamp,
+                include_decision_payload=True,
+                decision_effective_mode="paper_autonomous",
+                decision_primary_reason="open_before_close",
+            )
+        ]
+    )
+    controller.process_signals(
+        [
+            _autonomy_signal_with_correlation(
+                mode="paper_autonomous",
+                side="SELL",
+                correlation_key=close_correlation_key,
+                decision_timestamp=decision_timestamp,
+                include_mode=False,
+            )
+        ]
+    )
+    controller.process_signals([_signal("BUY")])
+
+    assert len(execution.requests) == 3
+    suppressed_events = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and event.get("reason") == "duplicate_autonomous_open_reentry_suppressed"
+        and event.get("proxy_correlation_key") == close_correlation_key
+    ]
+    assert suppressed_events == []
+
+
 @pytest.mark.parametrize("reversed_input_order", [False, True])
 def test_opportunity_autonomy_batch_multiple_open_candidates_fail_closed_deterministically(
     reversed_input_order: bool,


### PR DESCRIPTION
### Motivation
- Prevent autonomous open signals from causing duplicate executions when multiple shadow records/correlation keys represent the same effective open, while preserving scope and closing-side semantics.
- Ensure deterministic selection of an existing active open tracker to compare against replays by ordering candidates by decision timestamp and correlation key.

### Description
- Added `_find_matching_active_open_tracker_for_autonomous_open` to locate active open trackers matching symbol/side/scope while excluding a given correlation key and returning the earliest `decision_timestamp` (with UTC normalization) and lexicographically smallest key as a tie-breaker.
- Updated the autonomous-open handling path to consult the new helper when duplicate-open guard is enabled, and to use the selected tracker (key and tracker object) for scope matching and lineage restoration when suppressing duplicate re-entries.
- Preserved existing behavior for closing-side signals and foreign-scope trackers so they do not suppress the incoming request, and ensured metadata fields written in the skipped event include `existing_open_correlation_key` and `proxy_correlation_key` for traceability.
- Added comprehensive unit tests in `tests/test_trading_controller.py` covering same-runtime suppression, cross-correlation suppression, restored tracker suppression after restart, order-independence of candidate selection, tie-breaking by lexicographic key, foreign-scope exemption, and ensuring close/non-autonomous flows are not blocked.

### Testing
- Ran the controller unit tests including the modified/added tests in `tests/test_trading_controller.py` using `pytest` and verified the new tests for duplicate-autonomy suppression pass.
- Verified that existing related tests in the same suite remained green after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f55e6cc8832aa71d322330762f65)