### PR TITLE
Limit autonomous-open winners per batch in DecisionAwareSignalSink

### DIFF
--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -2953,6 +2953,7 @@ class DecisionAwareSignalSink(StrategySignalSink):
         opportunity_ai_enabled_override: bool | None = None,
         opportunity_ai_kill_switch_override: bool | None = None,
         opportunity_runtime_controls: object | None = None,
+        max_autonomous_open_winners_per_batch: int | None = None,
     ) -> None:
         self._base_sink = base_sink
         self._orchestrator = orchestrator
@@ -2973,6 +2974,11 @@ class DecisionAwareSignalSink(StrategySignalSink):
         self._opportunity_ai_enabled_override = opportunity_ai_enabled_override
         self._opportunity_ai_kill_switch_override = opportunity_ai_kill_switch_override
         self._opportunity_runtime_controls = opportunity_runtime_controls
+        self._max_autonomous_open_winners_per_batch = (
+            None
+            if max_autonomous_open_winners_per_batch is None
+            else max(0, int(max_autonomous_open_winners_per_batch))
+        )
         if self._opportunity_shadow_adapter is not None:
             self._opportunity_shadow_adapter.mode = self._opportunity_policy_mode.value
 
@@ -3244,6 +3250,13 @@ class DecisionAwareSignalSink(StrategySignalSink):
             risk_profile=risk_profile,
             timestamp=timestamp,
         )
+        pending_accepted = self._apply_autonomous_open_batch_cap(
+            pending_accepted=pending_accepted,
+            strategy_name=strategy_name,
+            schedule_name=schedule_name,
+            risk_profile=risk_profile,
+            timestamp=timestamp,
+        )
         for signal, candidate, evaluation, policy_resolution in pending_accepted:
             self._record_evaluation(
                 evaluation=evaluation,
@@ -3445,6 +3458,150 @@ class DecisionAwareSignalSink(StrategySignalSink):
                     },
                 )
         return survivors
+
+    def _apply_autonomous_open_batch_cap(
+        self,
+        *,
+        pending_accepted: list[
+            tuple[
+                StrategySignal,
+                DecisionCandidate,
+                DecisionEvaluation,
+                OpportunityPolicyResolution,
+            ]
+        ],
+        strategy_name: str,
+        schedule_name: str,
+        risk_profile: str,
+        timestamp: datetime,
+    ) -> list[
+        tuple[
+            StrategySignal,
+            DecisionCandidate,
+            DecisionEvaluation,
+            OpportunityPolicyResolution,
+        ]
+    ]:
+        batch_cap = self._max_autonomous_open_winners_per_batch
+        if batch_cap is None:
+            return pending_accepted
+        if batch_cap < 0:
+            return pending_accepted
+        if not pending_accepted:
+            return pending_accepted
+
+        autonomous_open_records: list[
+            tuple[
+                StrategySignal,
+                DecisionCandidate,
+                DecisionEvaluation,
+                "DecisionAwareSignalSink.OpportunityPolicyResolution",
+            ]
+        ] = []
+        passthrough_records: list[
+            tuple[
+                StrategySignal,
+                DecisionCandidate,
+                DecisionEvaluation,
+                "DecisionAwareSignalSink.OpportunityPolicyResolution",
+            ]
+        ] = []
+        for record in pending_accepted:
+            signal, candidate, _evaluation, _policy = record
+            scope_key = self._autonomous_open_arbitration_scope_key(signal=signal, candidate=candidate)
+            if scope_key is None:
+                passthrough_records.append(record)
+            else:
+                autonomous_open_records.append(record)
+
+        if len(autonomous_open_records) <= batch_cap:
+            return pending_accepted
+
+        grouped_records: dict[
+            tuple[str, tuple[str, float | None, float | None, float | None, float | None, str]],
+            list[
+                tuple[
+                    StrategySignal,
+                    DecisionCandidate,
+                    DecisionEvaluation,
+                    "DecisionAwareSignalSink.OpportunityPolicyResolution",
+                ]
+            ],
+        ] = {}
+        standalone_units: list[
+            list[
+                tuple[
+                    StrategySignal,
+                    DecisionCandidate,
+                    DecisionEvaluation,
+                    "DecisionAwareSignalSink.OpportunityPolicyResolution",
+                ]
+            ]
+        ] = []
+        for record in autonomous_open_records:
+            shadow_record_key = str((record[0].metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+            if not shadow_record_key:
+                standalone_units.append([record])
+                continue
+            identity_key = self._autonomous_open_candidate_identity_key(record)
+            grouped_records.setdefault((shadow_record_key, identity_key), []).append(record)
+
+        logical_units: list[
+            list[
+                tuple[
+                    StrategySignal,
+                    DecisionCandidate,
+                    DecisionEvaluation,
+                    "DecisionAwareSignalSink.OpportunityPolicyResolution",
+                ]
+            ]
+        ] = [*standalone_units, *grouped_records.values()]
+        if len(logical_units) <= batch_cap:
+            return pending_accepted
+
+        ranked_units = sorted(
+            logical_units,
+            key=lambda records: self._autonomous_open_candidate_rank_key(
+                sorted(records, key=self._autonomous_open_candidate_rank_key)[0]
+            ),
+        )
+        winner_units = ranked_units[:batch_cap]
+        loser_units = ranked_units[batch_cap:]
+        winners = [record for unit in winner_units for record in unit]
+        winner_shadow_keys = [
+            str((record[0].metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+            for record in winners
+        ]
+        winner_shadow_keys = list(dict.fromkeys(key for key in winner_shadow_keys if key))
+        winner_shadow_keys_payload = ",".join(winner_shadow_keys)
+        winner_primary_shadow_key = winner_shadow_keys[0] if winner_shadow_keys else ""
+        for loser_rank, loser_unit in enumerate(loser_units, start=batch_cap + 1):
+            for loser_signal, loser_candidate, _evaluation, _policy in loser_unit:
+                scope_key = self._autonomous_open_arbitration_scope_key(
+                    signal=loser_signal,
+                    candidate=loser_candidate,
+                )
+                rejection_info: dict[str, object] = {
+                    "reason": "autonomous_open_batch_cap_loser",
+                    "autonomous_open_batch_cap": str(batch_cap),
+                    "autonomous_open_batch_rank": str(loser_rank),
+                }
+                if winner_primary_shadow_key:
+                    rejection_info["winner_shadow_record_key"] = winner_primary_shadow_key
+                if winner_shadow_keys_payload:
+                    rejection_info["batch_winner_shadow_record_keys"] = winner_shadow_keys_payload
+                if scope_key is not None:
+                    rejection_info["arbitration_scope"] = "|".join(scope_key)
+                self._record_filtered_signal(
+                    signal=loser_signal,
+                    strategy_name=strategy_name,
+                    schedule_name=schedule_name,
+                    risk_profile=risk_profile,
+                    timestamp=timestamp,
+                    rejection_info=rejection_info,
+                )
+
+        return [*passthrough_records, *winners]
 
     def _autonomous_open_arbitration_scope_key(
         self,
@@ -3980,7 +4137,10 @@ class DecisionAwareSignalSink(StrategySignalSink):
         error_detail: str | None = None
         evaluation_type: str | None = None
         winner_shadow_record_key: str | None = None
+        batch_winner_shadow_record_keys: str | None = None
         arbitration_scope: str | None = None
+        autonomous_open_batch_cap: str | None = None
+        autonomous_open_batch_rank: str | None = None
         if rejection_info:
             reason = str(rejection_info.get("reason") or "") or None
             raw_probability = rejection_info.get("probability")
@@ -3990,7 +4150,16 @@ class DecisionAwareSignalSink(StrategySignalSink):
             winner_shadow_record_key = (
                 str(rejection_info.get("winner_shadow_record_key") or "") or None
             )
+            batch_winner_shadow_record_keys = (
+                str(rejection_info.get("batch_winner_shadow_record_keys") or "") or None
+            )
             arbitration_scope = str(rejection_info.get("arbitration_scope") or "") or None
+            autonomous_open_batch_cap = (
+                str(rejection_info.get("autonomous_open_batch_cap") or "") or None
+            )
+            autonomous_open_batch_rank = (
+                str(rejection_info.get("autonomous_open_batch_rank") or "") or None
+            )
             try:
                 probability = float(raw_probability) if raw_probability is not None else None
             except (TypeError, ValueError):  # pragma: no cover - defensywnie
@@ -4014,8 +4183,14 @@ class DecisionAwareSignalSink(StrategySignalSink):
             metadata.setdefault("evaluation_type", evaluation_type)
         if winner_shadow_record_key:
             metadata.setdefault("winner_shadow_record_key", winner_shadow_record_key)
+        if batch_winner_shadow_record_keys:
+            metadata.setdefault("batch_winner_shadow_record_keys", batch_winner_shadow_record_keys)
         if arbitration_scope:
             metadata.setdefault("arbitration_scope", arbitration_scope)
+        if autonomous_open_batch_cap:
+            metadata.setdefault("autonomous_open_batch_cap", autonomous_open_batch_cap)
+        if autonomous_open_batch_rank:
+            metadata.setdefault("autonomous_open_batch_rank", autonomous_open_batch_rank)
 
         metadata.setdefault("environment", self._environment)
         metadata.setdefault("exchange", self._exchange)

--- a/tests/runtime/test_streaming_feed.py
+++ b/tests/runtime/test_streaming_feed.py
@@ -2077,6 +2077,399 @@ def test_decision_aware_sink_arbitrates_opposite_side_autonomous_open_candidates
     assert filtered_events[0].metadata.get("winner_shadow_record_key") == "shadow-buy"
 
 
+@pytest.mark.parametrize("reversed_input_order", [False, True])
+def test_decision_aware_sink_batch_cap_limits_autonomous_open_winners_only(
+    reversed_input_order: bool,
+) -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    journal = _DummyJournal()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=journal,
+        max_autonomous_open_winners_per_batch=1,
+    )
+    ts = datetime(2026, 4, 18, 14, 30, tzinfo=timezone.utc)
+    btc_weaker = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.8,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-btc-weaker",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 9.0,
+            "expected_probability": 0.7,
+        },
+    )
+    btc_stronger = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.7,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-btc-stronger",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 11.0,
+            "expected_probability": 0.7,
+        },
+    )
+    eth_global_winner = StrategySignal(
+        symbol="ETH/USDT",
+        side="BUY",
+        confidence=0.6,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-eth-winner",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 12.0,
+            "expected_probability": 0.65,
+        },
+    )
+    close_signal = StrategySignal(
+        symbol="BTC/USDT",
+        side="SELL",
+        confidence=0.5,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-close",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 5.0,
+            "expected_probability": 0.5,
+        },
+    )
+    non_autonomous_signal = StrategySignal(
+        symbol="SOL/USDT",
+        side="BUY",
+        confidence=0.4,
+        metadata={
+            "opportunity_shadow_record_key": "shadow-non-autonomous",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 4.0,
+            "expected_probability": 0.5,
+        },
+    )
+    ordered_signals = [btc_weaker, btc_stronger, eth_global_winner, close_signal, non_autonomous_signal]
+    if reversed_input_order:
+        ordered_signals.reverse()
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=tuple(ordered_signals),
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    forwarded_keys = {
+        str(signal.metadata.get("opportunity_shadow_record_key"))
+        for signal in forwarded
+        if isinstance(signal.metadata, dict)
+    }
+    assert forwarded_keys == {
+        "shadow-eth-winner",
+        "shadow-close",
+        "shadow-non-autonomous",
+    }
+
+    filtered_events = [event for event in journal.events if event.status == "filtered"]
+    assert len(filtered_events) == 2
+    filtered_reasons = sorted(event.metadata.get("decision_reason") for event in filtered_events)
+    assert filtered_reasons == [
+        "autonomous_open_batch_cap_loser",
+        "autonomous_open_candidate_arbitration_loser",
+    ]
+    batch_cap_event = next(
+        event
+        for event in filtered_events
+        if event.metadata.get("decision_reason") == "autonomous_open_batch_cap_loser"
+    )
+    assert batch_cap_event.metadata.get("winner_shadow_record_key") == "shadow-eth-winner"
+    assert batch_cap_event.metadata.get("batch_winner_shadow_record_keys") == "shadow-eth-winner"
+    assert batch_cap_event.metadata.get("autonomous_open_batch_cap") == "1"
+    assert batch_cap_event.metadata.get("autonomous_open_batch_rank") == "2"
+    assert batch_cap_event.metadata.get("arbitration_scope") == "BTC/USDT|paper|paper-01|paper_autonomous"
+
+
+def test_decision_aware_sink_without_batch_cap_preserves_multi_symbol_autonomous_open_behavior() -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=_DummyJournal(),
+    )
+    ts = datetime(2026, 4, 18, 14, 45, tzinfo=timezone.utc)
+    signals = (
+        StrategySignal(
+            symbol="BTC/USDT",
+            side="BUY",
+            confidence=0.7,
+            metadata={
+                "opportunity_autonomy_mode": "paper_autonomous",
+                "opportunity_shadow_record_key": "shadow-btc",
+                "opportunity_decision_timestamp": ts.isoformat(),
+                "expected_return_bps": 9.0,
+                "expected_probability": 0.7,
+            },
+        ),
+        StrategySignal(
+            symbol="ETH/USDT",
+            side="BUY",
+            confidence=0.8,
+            metadata={
+                "opportunity_autonomy_mode": "paper_autonomous",
+                "opportunity_shadow_record_key": "shadow-eth",
+                "opportunity_decision_timestamp": ts.isoformat(),
+                "expected_return_bps": 8.0,
+                "expected_probability": 0.8,
+            },
+        ),
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=signals,
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    assert {signal.metadata.get("opportunity_shadow_record_key") for signal in forwarded} == {
+        "shadow-btc",
+        "shadow-eth",
+    }
+
+
+def test_decision_aware_sink_batch_cap_counts_true_duplicate_group_as_one_slot_when_group_wins() -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    journal = _DummyJournal()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=journal,
+        max_autonomous_open_winners_per_batch=1,
+    )
+    ts = datetime(2026, 4, 18, 15, 10, tzinfo=timezone.utc)
+    duplicate_one = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.9,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-duplicate-group",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 12.0,
+            "expected_probability": 0.7,
+        },
+    )
+    duplicate_two = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.9,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-duplicate-group",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 12.0,
+            "expected_probability": 0.7,
+        },
+    )
+    weaker_other = StrategySignal(
+        symbol="ETH/USDT",
+        side="BUY",
+        confidence=0.6,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-other-weaker",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 9.0,
+            "expected_probability": 0.7,
+        },
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=(duplicate_one, duplicate_two, weaker_other),
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    forwarded_keys = [signal.metadata.get("opportunity_shadow_record_key") for signal in forwarded]
+    assert forwarded_keys.count("shadow-duplicate-group") == 2
+    assert "shadow-other-weaker" not in forwarded_keys
+
+    filtered_events = [event for event in journal.events if event.status == "filtered"]
+    assert len(filtered_events) == 1
+    event = filtered_events[0]
+    assert event.metadata.get("decision_reason") == "autonomous_open_batch_cap_loser"
+    assert event.metadata.get("winner_shadow_record_key") == "shadow-duplicate-group"
+    assert event.metadata.get("batch_winner_shadow_record_keys") == "shadow-duplicate-group"
+
+
+def test_decision_aware_sink_batch_cap_filters_entire_true_duplicate_group_when_group_loses() -> None:
+    base_sink = InMemoryStrategySignalSink()
+
+    class _StubOrchestrator:
+        def evaluate_candidate(self, candidate, _context):
+            return SimpleNamespace(
+                candidate=candidate,
+                accepted=True,
+                cost_bps=None,
+                net_edge_bps=5.0,
+                reasons=(),
+                risk_flags=(),
+                stress_failures=(),
+            )
+
+    journal = _DummyJournal()
+    sink = DecisionAwareSignalSink(
+        base_sink=base_sink,
+        orchestrator=_StubOrchestrator(),
+        risk_engine=SimpleNamespace(snapshot_state=lambda _: {}),
+        default_notional=1_000.0,
+        environment="paper",
+        exchange="binance_spot",
+        min_probability=0.1,
+        portfolio="paper-01",
+        journal=journal,
+        max_autonomous_open_winners_per_batch=1,
+    )
+    ts = datetime(2026, 4, 18, 15, 20, tzinfo=timezone.utc)
+    stronger_other = StrategySignal(
+        symbol="ETH/USDT",
+        side="BUY",
+        confidence=0.9,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-other-stronger",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 15.0,
+            "expected_probability": 0.8,
+        },
+    )
+    duplicate_one = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.7,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-duplicate-loser-group",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 12.0,
+            "expected_probability": 0.7,
+        },
+    )
+    duplicate_two = StrategySignal(
+        symbol="BTC/USDT",
+        side="BUY",
+        confidence=0.7,
+        metadata={
+            "opportunity_autonomy_mode": "paper_autonomous",
+            "opportunity_shadow_record_key": "shadow-duplicate-loser-group",
+            "opportunity_decision_timestamp": ts.isoformat(),
+            "expected_return_bps": 12.0,
+            "expected_probability": 0.7,
+        },
+    )
+
+    sink.submit(
+        strategy_name="daily",
+        schedule_name="schedule",
+        risk_profile="balanced",
+        timestamp=ts,
+        signals=(stronger_other, duplicate_one, duplicate_two),
+    )
+
+    records = sink.export()
+    assert len(records) == 1
+    _, forwarded = records[0]
+    assert [signal.metadata.get("opportunity_shadow_record_key") for signal in forwarded] == [
+        "shadow-other-stronger"
+    ]
+
+    filtered_events = [event for event in journal.events if event.status == "filtered"]
+    assert len(filtered_events) == 2
+    assert all(
+        event.metadata.get("decision_reason") == "autonomous_open_batch_cap_loser"
+        for event in filtered_events
+    )
+    assert all(
+        event.metadata.get("winner_shadow_record_key") == "shadow-other-stronger"
+        for event in filtered_events
+    )
+    assert all(
+        event.metadata.get("batch_winner_shadow_record_keys") == "shadow-other-stronger"
+        for event in filtered_events
+    )
+
+
 def test_decision_aware_sink_opposite_side_open_arbitration_tie_uses_stable_technical_tiebreak() -> None:
     base_sink = InMemoryStrategySignalSink()
 


### PR DESCRIPTION
### Motivation
- Add configurable limit to the number of autonomous "open" winners forwarded in a single submission to prevent too many autonomous entries being executed in one batch.
- Ensure duplicate/related autonomous candidates (grouped by shadow record key and identity) count as a single logical unit against the batch cap when appropriate.

### Description
- Add constructor parameter `max_autonomous_open_winners_per_batch` and store it as `_max_autonomous_open_winners_per_batch` on `DecisionAwareSignalSink`.
- Apply a new `._apply_autonomous_open_batch_cap` step in the acceptance flow after arbitration to enforce the configured batch cap on autonomous-open candidates.
- Implement `_apply_autonomous_open_batch_cap` to separate autonomous-open records from passthrough records, group records by shadow identity so duplicates count as one logical unit, rank units, select winners up to the cap and mark losing records as filtered with rejection metadata.
- Extend `_record_filtered_signal` to emit additional metadata fields `batch_winner_shadow_record_keys`, `autonomous_open_batch_cap`, and `autonomous_open_batch_rank` when applicable.
- Add multiple unit tests in `tests/runtime/test_streaming_feed.py` to cover batch-cap behavior, grouping semantics, passthrough preservation when cap is unset, and interactions with existing arbitration logic.

### Testing
- Ran the added unit tests in `tests/runtime/test_streaming_feed.py`, including `test_decision_aware_sink_batch_cap_limits_autonomous_open_winners_only`, `test_decision_aware_sink_without_batch_cap_preserves_multi_symbol_autonomous_open_behavior`, `test_decision_aware_sink_batch_cap_counts_true_duplicate_group_as_one_slot_when_group_wins`, and `test_decision_aware_sink_batch_cap_filters_entire_true_duplicate_group_when_group_loses`, and they passed.
- Existing arbitration-related tests (e.g. `test_decision_aware_sink_arbitrates_opposite_side_autonomous_open_candidates`) were exercised and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4baa6c43c832ab7ef9a64937285db)