### PR TITLE
Add max_autonomous_open_winners_per_batch config and propagate to DecisionAwareSignalSink

### DIFF
--- a/bot_core/config/loader.py
+++ b/bot_core/config/loader.py
@@ -3228,6 +3228,18 @@ def _load_decision_engine_config(
             raise ValueError(
                 "decision_engine.evaluation_history_limit musi być liczbą całkowitą"
             ) from exc
+    max_autonomous_open_winners_per_batch_raw = raw.get("max_autonomous_open_winners_per_batch")
+    max_autonomous_open_winners_per_batch: int | None = None
+    if max_autonomous_open_winners_per_batch_raw not in (None, ""):
+        try:
+            max_autonomous_open_winners_per_batch = max(
+                0,
+                _coerce_int(max_autonomous_open_winners_per_batch_raw, 0),
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "decision_engine.max_autonomous_open_winners_per_batch musi być liczbą całkowitą"
+            ) from exc
     tco_config: DecisionEngineTCOConfig | None = None
     tco_raw = raw.get("tco")
     if DecisionEngineTCOConfig is not None and tco_raw:
@@ -3329,6 +3341,7 @@ def _load_decision_engine_config(
         require_cost_data=require_cost_data,
         penalty_cost_bps=penalty_cost_bps,
         evaluation_history_limit=evaluation_history_limit,
+        max_autonomous_open_winners_per_batch=max_autonomous_open_winners_per_batch,
         opportunity_policy_mode=opportunity_policy_mode,
         opportunity_ai_enabled=opportunity_ai_enabled,
         tco=tco_config,

--- a/bot_core/config/models.py
+++ b/bot_core/config/models.py
@@ -655,6 +655,7 @@ class DecisionEngineConfig:
     require_cost_data: bool = False
     penalty_cost_bps: float = 0.0
     evaluation_history_limit: int = 256
+    max_autonomous_open_winners_per_batch: int | None = None
     opportunity_policy_mode: str = "shadow"
     opportunity_ai_enabled: bool = True
     tco: DecisionEngineTCOConfig | None = None

--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -2861,11 +2861,18 @@ def _build_decision_sink(
     exchange_name = getattr(bootstrap.environment, "exchange", "")
     journal = getattr(bootstrap, "decision_journal", None)
     history_limit = 256
+    max_autonomous_open_winners_per_batch: int | None = None
     if decision_config is not None:
         try:
             history_limit = int(getattr(decision_config, "evaluation_history_limit", history_limit))
         except (TypeError, ValueError):  # pragma: no cover - konfiguracja może być uszkodzona
             history_limit = 256
+        raw_batch_cap = getattr(decision_config, "max_autonomous_open_winners_per_batch", None)
+        if raw_batch_cap not in (None, ""):
+            try:
+                max_autonomous_open_winners_per_batch = max(0, int(raw_batch_cap))
+            except (TypeError, ValueError):  # pragma: no cover - konfiguracja może być uszkodzona
+                max_autonomous_open_winners_per_batch = None
 
     opportunity_shadow_adapter = OpportunityRuntimeShadowAdapter(
         journal=journal,
@@ -2892,6 +2899,7 @@ def _build_decision_sink(
         opportunity_ai_enabled_override=enabled_override,
         opportunity_ai_kill_switch_override=kill_switch_override,
         opportunity_runtime_controls=get_opportunity_runtime_controls(),
+        max_autonomous_open_winners_per_batch=max_autonomous_open_winners_per_batch,
     )
 
 

--- a/tests/runtime/test_streaming_feed.py
+++ b/tests/runtime/test_streaming_feed.py
@@ -2284,6 +2284,34 @@ def test_decision_aware_sink_without_batch_cap_preserves_multi_symbol_autonomous
     }
 
 
+def test_build_decision_sink_passes_batch_cap_from_decision_engine_config() -> None:
+    base_sink = InMemoryStrategySignalSink()
+    bootstrap = SimpleNamespace(
+        decision_orchestrator=SimpleNamespace(),
+        risk_engine=SimpleNamespace(),
+        decision_engine_config=SimpleNamespace(
+            min_probability=0.6,
+            opportunity_policy_mode="shadow",
+            opportunity_ai_enabled=True,
+            evaluation_history_limit=128,
+            max_autonomous_open_winners_per_batch=2,
+        ),
+        environment=SimpleNamespace(exchange="binance_spot"),
+        decision_journal=None,
+    )
+
+    sink = pipeline_module._build_decision_sink(
+        bootstrap=bootstrap,
+        base_sink=base_sink,
+        default_notional=1_000.0,
+        environment_name="paper",
+        portfolio_id="paper-01",
+    )
+
+    assert sink is not None
+    assert sink._max_autonomous_open_winners_per_batch == 2
+
+
 def test_decision_aware_sink_batch_cap_counts_true_duplicate_group_as_one_slot_when_group_wins() -> None:
     base_sink = InMemoryStrategySignalSink()
 

--- a/tests/test_decision_engine_config_loader.py
+++ b/tests/test_decision_engine_config_loader.py
@@ -8,6 +8,50 @@ import yaml
 from bot_core.config.loader import load_core_config
 
 
+def _decision_engine_loader_base_payload() -> dict:
+    return {
+        "risk_profiles": {
+            "conservative": {
+                "max_daily_loss_pct": 0.02,
+                "max_position_pct": 0.1,
+                "target_volatility": 0.1,
+                "max_leverage": 2.0,
+                "stop_loss_atr_multiple": 1.0,
+                "max_open_positions": 5,
+                "hard_drawdown_pct": 0.2,
+            }
+        },
+        "alerts": {},
+        "environments": {
+            "paper_binance": {
+                "exchange": "binance_spot",
+                "environment": "paper",
+                "keychain_key": "binance_key",
+                "credential_purpose": "trading",
+                "data_cache_path": "./cache",
+                "risk_profile": "conservative",
+                "alert_channels": [],
+                "ip_allowlist": [],
+                "required_permissions": [],
+                "forbidden_permissions": [],
+            }
+        },
+        "decision_engine": {
+            "orchestrator": {
+                "max_cost_bps": 25.0,
+                "min_net_edge_bps": 5.0,
+                "max_daily_loss_pct": 0.2,
+                "max_drawdown_pct": 0.3,
+                "max_position_ratio": 3.0,
+                "max_open_positions": 8,
+                "max_latency_ms": 250.0,
+            },
+            "min_probability": 0.5,
+            "require_cost_data": True,
+        },
+    }
+
+
 def test_load_core_config_parses_decision_engine_tco(tmp_path: Path) -> None:
     config_data = {
         "risk_profiles": {
@@ -192,3 +236,60 @@ def test_load_core_config_maps_thresholds_and_overrides(tmp_path: Path) -> None:
     )
     assert len(normalized_paths) == 1
     assert Path(normalized_paths[0]).resolve() == report_path.resolve()
+
+
+def test_load_core_config_parses_autonomous_open_batch_cap_integer(tmp_path: Path) -> None:
+    config_data = _decision_engine_loader_base_payload()
+    config_data["decision_engine"]["max_autonomous_open_winners_per_batch"] = 3
+
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(yaml.safe_dump(config_data, sort_keys=False), encoding="utf-8")
+
+    core_config = load_core_config(config_path)
+
+    assert core_config.decision_engine is not None
+    assert core_config.decision_engine.max_autonomous_open_winners_per_batch == 3
+
+
+@pytest.mark.parametrize("raw_value", [None, ""])
+def test_load_core_config_keeps_autonomous_open_batch_cap_none_for_empty_values(
+    tmp_path: Path,
+    raw_value: object,
+) -> None:
+    config_data = _decision_engine_loader_base_payload()
+    config_data["decision_engine"]["max_autonomous_open_winners_per_batch"] = raw_value
+
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(yaml.safe_dump(config_data, sort_keys=False), encoding="utf-8")
+
+    core_config = load_core_config(config_path)
+
+    assert core_config.decision_engine is not None
+    assert core_config.decision_engine.max_autonomous_open_winners_per_batch is None
+
+
+def test_load_core_config_rejects_invalid_autonomous_open_batch_cap_type(tmp_path: Path) -> None:
+    config_data = _decision_engine_loader_base_payload()
+    config_data["decision_engine"]["max_autonomous_open_winners_per_batch"] = {"invalid": "type"}
+
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(yaml.safe_dump(config_data, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match=r"decision_engine.max_autonomous_open_winners_per_batch musi być liczbą całkowitą",
+    ):
+        load_core_config(config_path)
+
+
+def test_load_core_config_clamps_negative_autonomous_open_batch_cap_to_zero(tmp_path: Path) -> None:
+    config_data = _decision_engine_loader_base_payload()
+    config_data["decision_engine"]["max_autonomous_open_winners_per_batch"] = -7
+
+    config_path = tmp_path / "core.yaml"
+    config_path.write_text(yaml.safe_dump(config_data, sort_keys=False), encoding="utf-8")
+
+    core_config = load_core_config(config_path)
+
+    assert core_config.decision_engine is not None
+    assert core_config.decision_engine.max_autonomous_open_winners_per_batch == 0


### PR DESCRIPTION
### Motivation
- Introduce a configurable cap for how many autonomous "open winner" opportunities can be accepted per batch so the decision engine can limit simultaneous autonomous executions.

### Description
- Add `max_autonomous_open_winners_per_batch: int | None` to `DecisionEngineConfig` and include it in the config object produced by the loader.  
- Parse and validate `decision_engine.max_autonomous_open_winners_per_batch` in the loader, treating `None`/empty as unset, clamping negatives to zero, and raising `ValueError` for non-integer types.  
- Thread the value through `_build_decision_sink` and pass it into `DecisionAwareSignalSink` via the `max_autonomous_open_winners_per_batch` argument so the runtime sink receives the configured cap.  
- Add unit tests for loader parsing and pipeline wiring, and extend streaming-feed tests to assert the sink receives the batch cap.

### Testing
- Ran the new and updated unit tests with `pytest tests/test_decision_engine_config_loader.py tests/runtime/test_streaming_feed.py` and the tests relating to the new behavior passed.  
- Verified loader error handling by asserting a `ValueError` is raised for invalid types and that negative values are clamped to zero via unit tests.  
- Confirmed the pipeline test `test_build_decision_sink_passes_batch_cap_from_decision_engine_config` verifies the sink attribute is set from the config and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c262cfe0832ab06264c5c4510163)