### PR TITLE
Accept ruff-format formatter drift in runtime and tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2030,9 +2030,7 @@ class TradingController:
                 duplicate_open_guard_enabled
                 and (
                     existing_open_tracker is None
-                    or not self._is_closing_side(
-                        str(existing_open_tracker.side), str(request.side)
-                    )
+                    or not self._is_closing_side(str(existing_open_tracker.side), str(request.side))
                 )
                 and self._max_active_autonomous_open_positions is not None
             ):
@@ -2046,9 +2044,7 @@ class TradingController:
                         status="skipped",
                         metadata={
                             "reason": "autonomous_open_active_budget_exhausted",
-                            "active_autonomous_open_positions": str(
-                                active_autonomous_open_count
-                            ),
+                            "active_autonomous_open_positions": str(active_autonomous_open_count),
                             "max_active_autonomous_open_positions": str(
                                 self._max_active_autonomous_open_positions
                             ),

--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -3412,7 +3412,9 @@ class DecisionAwareSignalSink(StrategySignalSink):
         ] = []
         for record in pending_accepted:
             signal, candidate, _evaluation, _policy = record
-            scope_key = self._autonomous_open_arbitration_scope_key(signal=signal, candidate=candidate)
+            scope_key = self._autonomous_open_arbitration_scope_key(
+                signal=signal, candidate=candidate
+            )
             if scope_key is None:
                 passthrough.append(record)
                 continue
@@ -3516,7 +3518,9 @@ class DecisionAwareSignalSink(StrategySignalSink):
         ] = []
         for record in pending_accepted:
             signal, candidate, _evaluation, _policy = record
-            scope_key = self._autonomous_open_arbitration_scope_key(signal=signal, candidate=candidate)
+            scope_key = self._autonomous_open_arbitration_scope_key(
+                signal=signal, candidate=candidate
+            )
             if scope_key is None:
                 passthrough_records.append(record)
             else:
@@ -3547,7 +3551,9 @@ class DecisionAwareSignalSink(StrategySignalSink):
             ]
         ] = []
         for record in autonomous_open_records:
-            shadow_record_key = str((record[0].metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+            shadow_record_key = str(
+                (record[0].metadata or {}).get("opportunity_shadow_record_key") or ""
+            ).strip()
             if not shadow_record_key:
                 standalone_units.append([record])
                 continue
@@ -3623,7 +3629,9 @@ class DecisionAwareSignalSink(StrategySignalSink):
         autonomy_mode = str(metadata.get("opportunity_autonomy_mode") or "").strip().lower()
         if autonomy_mode not in {"paper_autonomous", "live_autonomous"}:
             return None
-        portfolio_scope = str(metadata.get("portfolio_id") or metadata.get("portfolio") or "").strip()
+        portfolio_scope = str(
+            metadata.get("portfolio_id") or metadata.get("portfolio") or ""
+        ).strip()
         if not portfolio_scope:
             portfolio_scope = self._portfolio or self._environment
         return (

--- a/tests/runtime/test_streaming_feed.py
+++ b/tests/runtime/test_streaming_feed.py
@@ -1811,7 +1811,9 @@ def test_decision_aware_sink_missing_shadow_key_tie_uses_stable_technical_tiebre
     assert forwarded[0].metadata.get("candidate_tag") == "alpha"
 
 
-def test_decision_aware_sink_single_key_duplicate_contract_requires_same_candidate_identity() -> None:
+def test_decision_aware_sink_single_key_duplicate_contract_requires_same_candidate_identity() -> (
+    None
+):
     base_sink = InMemoryStrategySignalSink()
 
     class _StubOrchestrator:
@@ -2168,7 +2170,13 @@ def test_decision_aware_sink_batch_cap_limits_autonomous_open_winners_only(
             "expected_probability": 0.5,
         },
     )
-    ordered_signals = [btc_weaker, btc_stronger, eth_global_winner, close_signal, non_autonomous_signal]
+    ordered_signals = [
+        btc_weaker,
+        btc_stronger,
+        eth_global_winner,
+        close_signal,
+        non_autonomous_signal,
+    ]
     if reversed_input_order:
         ordered_signals.reverse()
 
@@ -2210,10 +2218,15 @@ def test_decision_aware_sink_batch_cap_limits_autonomous_open_winners_only(
     assert batch_cap_event.metadata.get("batch_winner_shadow_record_keys") == "shadow-eth-winner"
     assert batch_cap_event.metadata.get("autonomous_open_batch_cap") == "1"
     assert batch_cap_event.metadata.get("autonomous_open_batch_rank") == "2"
-    assert batch_cap_event.metadata.get("arbitration_scope") == "BTC/USDT|paper|paper-01|paper_autonomous"
+    assert (
+        batch_cap_event.metadata.get("arbitration_scope")
+        == "BTC/USDT|paper|paper-01|paper_autonomous"
+    )
 
 
-def test_decision_aware_sink_without_batch_cap_preserves_multi_symbol_autonomous_open_behavior() -> None:
+def test_decision_aware_sink_without_batch_cap_preserves_multi_symbol_autonomous_open_behavior() -> (
+    None
+):
     base_sink = InMemoryStrategySignalSink()
 
     class _StubOrchestrator:
@@ -2284,7 +2297,9 @@ def test_decision_aware_sink_without_batch_cap_preserves_multi_symbol_autonomous
     }
 
 
-def test_decision_aware_sink_batch_cap_zero_filters_all_autonomous_open_and_keeps_passthrough() -> None:
+def test_decision_aware_sink_batch_cap_zero_filters_all_autonomous_open_and_keeps_passthrough() -> (
+    None
+):
     base_sink = InMemoryStrategySignalSink()
 
     class _StubOrchestrator:
@@ -2394,7 +2409,10 @@ def test_decision_aware_sink_batch_cap_zero_filters_all_autonomous_open_and_keep
         for event in filtered_events
     )
     assert all(event.metadata.get("autonomous_open_batch_cap") == "0" for event in filtered_events)
-    assert {event.metadata.get("autonomous_open_batch_rank") for event in filtered_events} == {"1", "2"}
+    assert {event.metadata.get("autonomous_open_batch_rank") for event in filtered_events} == {
+        "1",
+        "2",
+    }
 
 
 def test_build_decision_sink_passes_batch_cap_from_decision_engine_config() -> None:
@@ -2425,7 +2443,9 @@ def test_build_decision_sink_passes_batch_cap_from_decision_engine_config() -> N
     assert sink._max_autonomous_open_winners_per_batch == 2
 
 
-def test_decision_aware_sink_batch_cap_counts_true_duplicate_group_as_one_slot_when_group_wins() -> None:
+def test_decision_aware_sink_batch_cap_counts_true_duplicate_group_as_one_slot_when_group_wins() -> (
+    None
+):
     base_sink = InMemoryStrategySignalSink()
 
     class _StubOrchestrator:
@@ -2514,7 +2534,9 @@ def test_decision_aware_sink_batch_cap_counts_true_duplicate_group_as_one_slot_w
     assert event.metadata.get("batch_winner_shadow_record_keys") == "shadow-duplicate-group"
 
 
-def test_decision_aware_sink_batch_cap_filters_entire_true_duplicate_group_when_group_loses() -> None:
+def test_decision_aware_sink_batch_cap_filters_entire_true_duplicate_group_when_group_loses() -> (
+    None
+):
     base_sink = InMemoryStrategySignalSink()
 
     class _StubOrchestrator:
@@ -2611,7 +2633,9 @@ def test_decision_aware_sink_batch_cap_filters_entire_true_duplicate_group_when_
     )
 
 
-def test_decision_aware_sink_opposite_side_open_arbitration_tie_uses_stable_technical_tiebreak() -> None:
+def test_decision_aware_sink_opposite_side_open_arbitration_tie_uses_stable_technical_tiebreak() -> (
+    None
+):
     base_sink = InMemoryStrategySignalSink()
 
     class _StubOrchestrator:

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -416,12 +416,8 @@ def _assert_no_durable_artifacts_for_shadow_key(
     *,
     shadow_key: str,
 ) -> None:
-    assert all(
-        row.correlation_key != shadow_key for row in repository.load_open_outcomes()
-    )
-    assert all(
-        row.correlation_key != shadow_key for row in repository.load_outcome_labels()
-    )
+    assert all(row.correlation_key != shadow_key for row in repository.load_open_outcomes())
+    assert all(row.correlation_key != shadow_key for row in repository.load_outcome_labels())
 
 
 _AUTONOMY_CHAIN_EXPECTED_KEYS = (
@@ -9892,7 +9888,9 @@ def test_opportunity_autonomy_opposite_side_cross_correlation_is_not_suppressed_
         row for row in repository.load_open_outcomes() if row.correlation_key == buy_correlation_key
     )
     buy_labels_before_sell = [
-        row for row in repository.load_outcome_labels() if row.correlation_key == buy_correlation_key
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == buy_correlation_key
     ]
     controller.process_signals([sell_signal_other_key])
 
@@ -9904,25 +9902,31 @@ def test_opportunity_autonomy_opposite_side_cross_correlation_is_not_suppressed_
         event.get("reason") != "duplicate_autonomous_open_reentry_suppressed"
         for event in skipped_events
     )
-    open_outcomes_by_key = {
-        row.correlation_key: row for row in repository.load_open_outcomes()
-    }
+    open_outcomes_by_key = {row.correlation_key: row for row in repository.load_open_outcomes()}
     assert buy_correlation_key in open_outcomes_by_key
     assert sell_correlation_key in open_outcomes_by_key
     assert open_outcomes_by_key[buy_correlation_key].side == "BUY"
     assert open_outcomes_by_key[sell_correlation_key].side == "SELL"
-    assert open_outcomes_by_key[buy_correlation_key].closed_quantity == buy_state_before_sell.closed_quantity
+    assert (
+        open_outcomes_by_key[buy_correlation_key].closed_quantity
+        == buy_state_before_sell.closed_quantity
+    )
     buy_labels_after_sell = [
-        row for row in repository.load_outcome_labels() if row.correlation_key == buy_correlation_key
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == buy_correlation_key
     ]
     assert [row.label_quality for row in buy_labels_after_sell] == [
         row.label_quality for row in buy_labels_before_sell
     ]
     assert all(
-        row.label_quality not in {"partial_exit_unconfirmed", "final"} for row in buy_labels_after_sell
+        row.label_quality not in {"partial_exit_unconfirmed", "final"}
+        for row in buy_labels_after_sell
     )
     sell_labels = [
-        row for row in repository.load_outcome_labels() if row.correlation_key == sell_correlation_key
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == sell_correlation_key
     ]
     assert sell_labels
     assert any(row.label_quality == "execution_proxy_pending_exit" for row in sell_labels)
@@ -10029,15 +10033,14 @@ def test_opportunity_autonomy_opposite_side_cross_correlation_after_restore_is_n
         }
         for event in skipped_events
     )
-    open_outcomes_by_key = {
-        row.correlation_key: row for row in repository.load_open_outcomes()
-    }
+    open_outcomes_by_key = {row.correlation_key: row for row in repository.load_open_outcomes()}
     assert restored_buy_key in open_outcomes_by_key
     assert fresh_sell_key in open_outcomes_by_key
     assert open_outcomes_by_key[restored_buy_key].side == "BUY"
     assert open_outcomes_by_key[fresh_sell_key].side == "SELL"
     assert (
-        open_outcomes_by_key[restored_buy_key].closed_quantity == restored_state_before_sell.closed_quantity
+        open_outcomes_by_key[restored_buy_key].closed_quantity
+        == restored_state_before_sell.closed_quantity
     )
     restored_labels_after_sell = [
         row for row in repository.load_outcome_labels() if row.correlation_key == restored_buy_key
@@ -10131,10 +10134,11 @@ def test_opportunity_autonomy_opposite_side_cross_correlation_ignores_foreign_sc
 
     assert len(execution.requests) == 1
     skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
-    assert all(event.get("reason") != "duplicate_autonomous_open_reentry_suppressed" for event in skipped_events)
-    open_outcomes_by_key = {
-        row.correlation_key: row for row in repository.load_open_outcomes()
-    }
+    assert all(
+        event.get("reason") != "duplicate_autonomous_open_reentry_suppressed"
+        for event in skipped_events
+    )
+    open_outcomes_by_key = {row.correlation_key: row for row in repository.load_open_outcomes()}
     assert foreign_buy_key in open_outcomes_by_key
     assert open_outcomes_by_key[foreign_buy_key].side == "BUY"
     assert open_outcomes_by_key[fresh_sell_key].side == "SELL"
@@ -10206,10 +10210,11 @@ def test_non_autonomous_opposite_side_cross_correlation_does_not_emit_autonomous
     assert execution.requests[0].side == "BUY"
     assert execution.requests[1].side == "SELL"
     skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
-    assert all(event.get("reason") != "duplicate_autonomous_open_reentry_suppressed" for event in skipped_events)
-    open_outcomes_by_key = {
-        row.correlation_key: row for row in repository.load_open_outcomes()
-    }
+    assert all(
+        event.get("reason") != "duplicate_autonomous_open_reentry_suppressed"
+        for event in skipped_events
+    )
+    open_outcomes_by_key = {row.correlation_key: row for row in repository.load_open_outcomes()}
     assert open_outcomes_by_key[buy_key].side == "BUY"
     assert open_outcomes_by_key[sell_key].side == "SELL"
 
@@ -10501,7 +10506,9 @@ def test_opportunity_autonomy_duplicate_open_reentry_cross_correlation_multi_tra
     smaller_correlation_key = "aaa-cross-key"
     larger_correlation_key = "zzz-cross-key"
     replay_correlation_key = "mmm-cross-key"
-    repository = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="dup-open-cross-key-tie-")))
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="dup-open-cross-key-tie-"))
+    )
     repository.append_shadow_records(
         [
             replace(
@@ -10750,7 +10757,9 @@ def test_opportunity_autonomy_active_budget_blocks_second_open_across_submits() 
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=first_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=first_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=second_key,
@@ -10818,7 +10827,9 @@ def test_opportunity_autonomy_active_budget_restore_aware_blocks_new_open() -> N
         model_version="opportunity-budget-v2",
         rank=2,
     )
-    repository = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="autonomy-budget-restore-")))
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="autonomy-budget-restore-"))
+    )
     repository.append_shadow_records(
         [
             replace(
@@ -10966,12 +10977,20 @@ def test_opportunity_autonomy_active_budget_close_frees_slot() -> None:
 
     assert len(execution.requests) == 3
     assert [request.side for request in execution.requests] == ["BUY", "SELL", "BUY"]
-    assert [request.symbol for request in execution.requests] == ["BTC/USDT", "BTC/USDT", "ETH/USDT"]
+    assert [request.symbol for request in execution.requests] == [
+        "BTC/USDT",
+        "BTC/USDT",
+        "ETH/USDT",
+    ]
     skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
-    assert all(event.get("reason") != "autonomous_open_active_budget_exhausted" for event in skipped_events)
+    assert all(
+        event.get("reason") != "autonomous_open_active_budget_exhausted" for event in skipped_events
+    )
 
 
-def test_opportunity_autonomy_active_budget_ignores_foreign_scope_tracker_for_autonomous_open() -> None:
+def test_opportunity_autonomy_active_budget_ignores_foreign_scope_tracker_for_autonomous_open() -> (
+    None
+):
     decision_timestamp = datetime(2026, 1, 12, 13, 0, tzinfo=timezone.utc)
     local_key = OpportunityShadowRecord.build_record_key(
         symbol="ETH/USDT",
@@ -10979,7 +10998,9 @@ def test_opportunity_autonomy_active_budget_ignores_foreign_scope_tracker_for_au
         model_version="opportunity-budget-v4",
         rank=1,
     )
-    repository = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="autonomy-budget-mixed-")))
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="autonomy-budget-mixed-"))
+    )
     repository.append_shadow_records(
         [
             replace(
@@ -11046,7 +11067,9 @@ def test_opportunity_autonomy_active_budget_ignores_foreign_scope_tracker_for_au
 
 def test_opportunity_autonomy_active_budget_does_not_block_non_autonomous_open() -> None:
     decision_timestamp = datetime(2026, 1, 12, 13, 30, tzinfo=timezone.utc)
-    repository = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="autonomy-budget-non-auto-")))
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="autonomy-budget-non-auto-"))
+    )
     repository.upsert_open_outcome(
         repository.OpenOutcomeState(
             correlation_key="existing-autonomous-open",
@@ -11116,7 +11139,9 @@ def test_opportunity_autonomy_active_budget_none_is_backward_compatible() -> Non
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=first_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=first_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=second_key,
@@ -11168,7 +11193,9 @@ def test_opportunity_autonomy_active_budget_none_is_backward_compatible() -> Non
     assert any(row.correlation_key == first_key for row in repository.load_open_outcomes())
     assert any(row.correlation_key == second_key for row in repository.load_open_outcomes())
     skipped_events = [event for event in journal.export() if event["event"] == "signal_skipped"]
-    assert all(event.get("reason") != "autonomous_open_active_budget_exhausted" for event in skipped_events)
+    assert all(
+        event.get("reason") != "autonomous_open_active_budget_exhausted" for event in skipped_events
+    )
 
 
 @pytest.mark.parametrize("reversed_input_order", [False, True])
@@ -31612,9 +31639,9 @@ def test_opportunity_autonomy_batch_cap_e2e_winner_only_downstream_without_loser
     results = controller.process_signals(list(emitted))
 
     assert len(results) == 1
-    assert [request.metadata.get("opportunity_shadow_record_key") for request in execution.requests] == [
-        winner_key
-    ]
+    assert [
+        request.metadata.get("opportunity_shadow_record_key") for request in execution.requests
+    ] == [winner_key]
     order_events = [
         event
         for event in journal.export()
@@ -31627,8 +31654,12 @@ def test_opportunity_autonomy_batch_cap_e2e_winner_only_downstream_without_loser
             "order_partially_executed",
         }
     ]
-    assert {event.get("order_opportunity_shadow_record_key") for event in order_events} == {winner_key}
-    assert all(event.get("order_opportunity_shadow_record_key") != loser_key for event in order_events)
+    assert {event.get("order_opportunity_shadow_record_key") for event in order_events} == {
+        winner_key
+    }
+    assert all(
+        event.get("order_opportunity_shadow_record_key") != loser_key for event in order_events
+    )
 
     open_rows = repository.load_open_outcomes()
     assert [row.correlation_key for row in open_rows] == [winner_key]
@@ -31787,7 +31818,9 @@ def test_opportunity_autonomy_batch_cap_e2e_is_order_independent() -> None:
     assert loser_key not in forward[3]
 
 
-def test_opportunity_autonomy_batch_cap_e2e_applies_arbitration_then_cap_without_loser_leakage() -> None:
+def test_opportunity_autonomy_batch_cap_e2e_applies_arbitration_then_cap_without_loser_leakage() -> (
+    None
+):
     class _AcceptedOrchestrator:
         def evaluate_candidate(self, candidate, _context):
             return SimpleNamespace(
@@ -31889,7 +31922,9 @@ def test_opportunity_autonomy_batch_cap_e2e_applies_arbitration_then_cap_without
 
     exported = sink.export()
     emitted = exported[0][1]
-    assert [row.metadata.get("opportunity_shadow_record_key") for row in emitted] == [batch_winner_key]
+    assert [row.metadata.get("opportunity_shadow_record_key") for row in emitted] == [
+        batch_winner_key
+    ]
 
     repository = _autonomy_shadow_repository_with_final_outcomes(
         [4.0, 3.0], environment="paper", portfolio_id="paper-1"
@@ -31907,9 +31942,9 @@ def test_opportunity_autonomy_batch_cap_e2e_applies_arbitration_then_cap_without
     )
     controller.process_signals(list(emitted))
 
-    assert [request.metadata.get("opportunity_shadow_record_key") for request in execution.requests] == [
-        batch_winner_key
-    ]
+    assert [
+        request.metadata.get("opportunity_shadow_record_key") for request in execution.requests
+    ] == [batch_winner_key]
     order_events = [
         event
         for event in journal.export()
@@ -32028,7 +32063,10 @@ def test_opportunity_autonomy_batch_cap_none_preserves_previous_behavior_e2e() -
 
     exported = sink.export()
     emitted = exported[0][1]
-    assert {row.metadata.get("opportunity_shadow_record_key") for row in emitted} == {btc_key, eth_key}
+    assert {row.metadata.get("opportunity_shadow_record_key") for row in emitted} == {
+        btc_key,
+        eth_key,
+    }
 
     repository = _autonomy_shadow_repository_with_final_outcomes(
         [4.0, 3.0], environment="paper", portfolio_id="paper-1"
@@ -32045,7 +32083,9 @@ def test_opportunity_autonomy_batch_cap_none_preserves_previous_behavior_e2e() -
     )
     controller.process_signals(list(emitted))
 
-    request_keys = {request.metadata.get("opportunity_shadow_record_key") for request in execution.requests}
+    request_keys = {
+        request.metadata.get("opportunity_shadow_record_key") for request in execution.requests
+    }
     assert request_keys == {btc_key, eth_key}
     open_keys = {row.correlation_key for row in repository.load_open_outcomes()}
     assert open_keys == {btc_key, eth_key}
@@ -32148,9 +32188,9 @@ def test_opportunity_autonomy_batch_cap_duplicate_group_wins_as_single_slot_with
     )
     emitted = sink.export()[0][1]
     assert emitted
-    assert {
-        row.metadata.get("opportunity_shadow_record_key") for row in emitted
-    } == {duplicate_group_key}
+    assert {row.metadata.get("opportunity_shadow_record_key") for row in emitted} == {
+        duplicate_group_key
+    }
 
     repository = _autonomy_shadow_repository_with_final_outcomes(
         [4.0, 3.0], environment="paper", portfolio_id="paper-1"
@@ -32167,7 +32207,9 @@ def test_opportunity_autonomy_batch_cap_duplicate_group_wins_as_single_slot_with
     )
     controller.process_signals(list(emitted))
 
-    request_keys = [request.metadata.get("opportunity_shadow_record_key") for request in execution.requests]
+    request_keys = [
+        request.metadata.get("opportunity_shadow_record_key") for request in execution.requests
+    ]
     assert request_keys == [duplicate_group_key]
     assert weaker_other_symbol_key not in request_keys
     order_events = [
@@ -32310,7 +32352,9 @@ def test_opportunity_autonomy_batch_cap_duplicate_group_loses_without_any_downst
     )
     controller.process_signals(list(emitted))
 
-    request_keys = [request.metadata.get("opportunity_shadow_record_key") for request in execution.requests]
+    request_keys = [
+        request.metadata.get("opportunity_shadow_record_key") for request in execution.requests
+    ]
     assert request_keys == [stronger_other_symbol_key]
     assert duplicate_group_loser_key not in request_keys
     order_events = [


### PR DESCRIPTION
### Motivation
- Pre-commit flagged formatter-only drift from `ruff-format` in a small set of runtime and test files, blocking CI; the intent is to accept that reflow only to restore a green pre-commit state.

### Description
- Accepted `ruff-format` reflow-only changes in exactly four files: `bot_core/runtime/controller.py`, `bot_core/runtime/pipeline.py`, `tests/runtime/test_streaming_feed.py`, and `tests/test_trading_controller.py` with no logic, semantic, contract, message, or assertion changes.
- Changes are formatting/reflow only (multiline call/tuple/list styling, small inline reflows) and a commit was created with these updates.
- Commit hash: `8fc44a3`.

### Testing
- Ran `python -m pre_commit run --all-files --show-diff-on-failure`, which initially reported `ruff-format` modified 4 files and after applying the reflow the hook run passed (pre-commit green).
- Ran `python -m pytest -q tests/runtime/test_streaming_feed.py -k "batch_cap or duplicate_contract" -xvv`, which failed during import due to missing dependency `pandas` in the environment.
- Ran `python -m pytest -q tests/test_trading_controller.py -k "active_budget or batch_cap or opposite_side_cross_correlation" -xvv`, which failed during import due to missing dependency `numpy` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5159a3dd4832a8070cd70a91172d2)