### PR TITLE
Apply ruff-format reflow in active_budget tests

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -11575,7 +11575,9 @@ def test_opportunity_autonomy_active_budget_mixed_batch_close_then_open_frees_sl
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=active_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=active_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=new_open_key,
@@ -11677,7 +11679,9 @@ def test_opportunity_autonomy_active_budget_mixed_batch_open_then_close_preserve
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=active_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=active_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=blocked_open_key,


### PR DESCRIPTION
### Motivation
- Accept the remaining `ruff-format` formatter drift limited to `tests/test_trading_controller.py` so the repository conforms to the formatter expectations without changing behavior.

### Description
- Reflowed two long single-line calls to `_shadow_record_for_key(...)` into multi-line calls in `tests/test_trading_controller.py`, with no changes to logic, semantics, contracts, messages, or assertions.

### Testing
- Ran `python -m pre_commit run --all-files --show-diff-on-failure` which failed in this environment due to missing `pre_commit` module.  
- Ran `python -m pytest -q tests/test_trading_controller.py -k "active_budget" -xvv` which failed during collection due to missing `numpy` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51fcffb08832a919212f42c0390e7)