### PR TITLE
Apply final ruff-format drift for active_budget_ranked_mode tail

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1570,9 +1570,7 @@ class TradingController:
                 results.append(result)
                 normalized_status = _normalize_execution_status(result.status)
                 metric_result = (
-                    "executed"
-                    if normalized_status in _FILLED_EXECUTION_STATUSES
-                    else "not_filled"
+                    "executed" if normalized_status in _FILLED_EXECUTION_STATUSES else "not_filled"
                 )
                 self._metric_orders_total.inc(
                     labels={
@@ -1648,9 +1646,8 @@ class TradingController:
         existing_open_tracker = (
             self._opportunity_open_outcomes.get(correlation_key) if correlation_key else None
         )
-        if (
-            existing_open_tracker is not None
-            and self._is_closing_side(str(existing_open_tracker.side), str(request.side))
+        if existing_open_tracker is not None and self._is_closing_side(
+            str(existing_open_tracker.side), str(request.side)
         ):
             return False
         duplicate_open_tracker_key = correlation_key

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -11042,7 +11042,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_exact_tie_is_order_indep
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=first_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=first_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=second_key,
@@ -11311,7 +11313,10 @@ def test_opportunity_autonomy_active_budget_ranked_mode_full_stable_key_tie_is_d
 
     assert len(execution.requests) == 1
     assert _request_shadow_keys(execution.requests) == [shared_key]
-    assert str((execution.requests[0].metadata or {}).get("audit_probe") or "") == expected_winner_probe
+    assert (
+        str((execution.requests[0].metadata or {}).get("audit_probe") or "")
+        == expected_winner_probe
+    )
     assert all(
         str((request.metadata or {}).get("audit_probe") or "") != expected_loser_probe
         for request in execution.requests
@@ -11330,9 +11335,12 @@ def test_opportunity_autonomy_active_budget_ranked_mode_full_stable_key_tie_is_d
     ]
     assert order_events
     assert {
-        str(event.get("order_opportunity_shadow_record_key") or "").strip() for event in order_events
+        str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        for event in order_events
     } == {shared_key}
-    assert all(str(event.get("order_audit_probe") or "") != expected_loser_probe for event in order_events)
+    assert all(
+        str(event.get("order_audit_probe") or "") != expected_loser_probe for event in order_events
+    )
     assert [row.correlation_key for row in repository.load_open_outcomes()] == [shared_key]
     label_keys_after = {
         str(label.correlation_key or "").strip()
@@ -11476,7 +11484,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_close_then_open_frees_sl
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=existing_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=existing_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=new_key,
@@ -11544,7 +11554,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_close_then_open_frees_sl
     assert skipped_new_key == []
 
 
-def test_opportunity_autonomy_active_budget_ranked_mode_open_then_close_preserves_input_order() -> None:
+def test_opportunity_autonomy_active_budget_ranked_mode_open_then_close_preserves_input_order() -> (
+    None
+):
     decision_timestamp = datetime(2026, 1, 12, 11, 40, tzinfo=timezone.utc)
     existing_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -11563,7 +11575,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_open_then_close_preserve
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=existing_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=existing_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=blocked_open_key,
@@ -11813,14 +11827,18 @@ def test_opportunity_autonomy_active_budget_ranked_mode_restore_aware_preserves_
         model_version="opportunity-budget-ranked-dup-v2",
         rank=2,
     )
-    repository = OpportunityShadowRepository(Path(tempfile.mkdtemp(prefix="autonomy-budget-ranked-dup-")))
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="autonomy-budget-ranked-dup-"))
+    )
     repository.append_shadow_records(
         [
             _shadow_record_for_key(
                 correlation_key=restored_key,
                 decision_timestamp=decision_timestamp,
             ),
-            _shadow_record_for_key(correlation_key=replay_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=replay_key, decision_timestamp=decision_timestamp
+            ),
         ]
     )
     repository.upsert_open_outcome(
@@ -11844,7 +11862,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_restore_aware_preserves_
             },
         )
     )
-    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}])
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
     controller, journal = _build_autonomy_controller_with_execution(
         environment="paper",
         execution_service=execution,


### PR DESCRIPTION
### Motivation
- The last blocker was a formatter-only drift reported by `ruff-format` affecting two files in the scoped change and requiring acceptance of formatting edits only.
- Maintain the very narrow scope limited to `bot_core/runtime/controller.py` and `tests/test_trading_controller.py` and avoid any logic, semantic, contract, assertion, or message changes.

### Description
- Apply reflow-only formatting in `bot_core/runtime/controller.py`, collapsing a multi-line ternary and adjusting `if` condition line breaks with no semantic change.
- Apply reflow-only formatting in `tests/test_trading_controller.py` within the `active_budget_ranked_mode` test cluster, wrapping long expressions and breaking lines without changing assertions or behavior.
- Commit created for the formatting acceptance is `7a934189e5abec7dbf9d650db0780f9787f454ca`.

### Testing
- Ran `python -m ruff format bot_core/runtime/controller.py tests/test_trading_controller.py` which succeeded and reported `2 files reformatted`.
- Ran `python -m pre_commit run --all-files --show-diff-on-failure` which failed in this environment with `No module named pre_commit`.
- Ran `python -m pytest -q tests/test_trading_controller.py -k "active_budget_ranked_mode" -xvv` which failed during collection due to missing dependency `numpy`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e538953e94832a9b41000d9beb2f07)