### PR TITLE
Add in-batch ranked autonomous-open selection, duplicate-replay suppression, and proof event

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1483,6 +1483,8 @@ class TradingController:
         results: list[OrderResult] = []
         ai_blocked = self._update_ai_failover_state()
         autonomous_open_conflicts = self._collect_autonomous_open_arbitration_conflicts(signals)
+        ranked_selection_proof_pending = False
+        ranked_selection_proof_candidate: dict[str, object] | None = None
 
         prioritized: list[tuple[int, int, StrategySignal, str]] = []
         for index, signal in enumerate(signals):
@@ -1534,13 +1536,62 @@ class TradingController:
             for expanded_signal in expanded_signals:
                 expanded_batch.append((expanded_batch_index, expanded_signal))
                 expanded_batch_index += 1
+        in_batch_ranked_duplicate_replay_pairs = (
+            self._collect_in_batch_ranked_duplicate_replay_pairs(expanded_batch)
+            if self._enable_autonomous_open_ranked_selection_within_batch
+            and self._max_active_autonomous_open_positions is not None
+            else {}
+        )
+        in_batch_actual_duplicate_suppressed_shadow_keys: set[str] = set()
         for batch_index, expanded_signal in expanded_batch:
             per_leg_labels = dict(self._metric_labels)
             per_leg_labels["symbol"] = expanded_signal.symbol
-            if self._should_skip_signal_as_ranked_autonomous_open_loser(
+            pre_rank_request = self._build_order_request(expanded_signal)
+            pre_rank_request_metadata = (
+                pre_rank_request.metadata if isinstance(pre_rank_request.metadata, Mapping) else {}
+            )
+            pre_rank_shadow_key = str(
+                pre_rank_request_metadata.get("opportunity_shadow_record_key") or ""
+            ).strip()
+            duplicate_primary_key = in_batch_ranked_duplicate_replay_pairs.get(pre_rank_shadow_key)
+            if (
+                duplicate_primary_key is not None
+                and str(duplicate_primary_key).strip() in self._opportunity_open_outcomes
+            ):
+                self._metric_signals_total.inc(labels={**per_leg_labels, "status": "skipped"})
+                self._record_decision_event(
+                    "signal_skipped",
+                    signal=expanded_signal,
+                    request=pre_rank_request,
+                    status="skipped",
+                    metadata={
+                        "reason": "duplicate_autonomous_open_reentry_suppressed",
+                        "proxy_correlation_key": pre_rank_shadow_key,
+                        "existing_open_side": str(pre_rank_request.side),
+                        "existing_open_correlation_key": duplicate_primary_key,
+                    },
+                )
+                if pre_rank_shadow_key:
+                    in_batch_actual_duplicate_suppressed_shadow_keys.add(pre_rank_shadow_key)
+                continue
+            ranked_selection = self._evaluate_ranked_autonomous_open_selection(
                 batch_index=batch_index,
                 expanded_batch=expanded_batch,
+            )
+            if (
+                ranked_selection_proof_candidate is None
+                and ranked_selection is not None
+                and ranked_selection["loser_count"] > 0
             ):
+                ranked_selection_proof_candidate = dict(ranked_selection)
+            if (
+                not ranked_selection_proof_pending
+                and ranked_selection is not None
+                and ranked_selection["skip_current"]
+                and ranked_selection["loser_count"] > 0
+            ):
+                ranked_selection_proof_pending = True
+            if ranked_selection is not None and ranked_selection["skip_current"]:
                 request = self._build_order_request(expanded_signal)
                 active_autonomous_open_count = self._count_scope_active_autonomous_open_trackers()
                 self._metric_signals_total.inc(labels={**per_leg_labels, "status": "skipped"})
@@ -1582,8 +1633,83 @@ class TradingController:
                     },
                 )
 
+        if ranked_selection_proof_pending and ranked_selection_proof_candidate is not None:
+            selected_shadow_keys = [
+                key
+                for key in list(ranked_selection_proof_candidate["selected_shadow_keys"])
+                if str(key).strip() not in in_batch_actual_duplicate_suppressed_shadow_keys
+            ]
+            loser_shadow_keys = [
+                key
+                for key in list(ranked_selection_proof_candidate["loser_shadow_keys"])
+                if str(key).strip() not in in_batch_actual_duplicate_suppressed_shadow_keys
+            ]
+            self._record_decision_event(
+                "ranked_autonomous_open_selection",
+                status="evaluated",
+                metadata={
+                    "remaining_slots": str(ranked_selection_proof_candidate["remaining_slots"]),
+                    "candidate_count": str(len(selected_shadow_keys) + len(loser_shadow_keys)),
+                    "selected_count": str(len(selected_shadow_keys)),
+                    "loser_count": str(len(loser_shadow_keys)),
+                    "selected_shadow_keys": selected_shadow_keys,
+                    "loser_shadow_keys": loser_shadow_keys,
+                    "ranking_basis": ranked_selection_proof_candidate["ranking_basis"],
+                    "ranked_mode_source": ranked_selection_proof_candidate["ranked_mode_source"],
+                },
+            )
         self.maybe_report_health()
         return results
+
+    def _collect_in_batch_ranked_duplicate_replay_pairs(
+        self,
+        expanded_batch: Sequence[tuple[int, StrategySignal]],
+    ) -> Mapping[str, str]:
+        grouped_candidates: MutableMapping[
+            tuple[str, str], list[tuple[float, float, float, tuple[str, ...], int, str]]
+        ] = {}
+        for candidate_batch_index, signal in expanded_batch:
+            if not self._is_budget_ranked_autonomous_open_candidate(signal):
+                continue
+            normalized_side = _normalize_trade_side(signal.side)
+            if normalized_side is None:
+                continue
+            metadata = self._normalize_signal_metadata(signal)
+            symbol = str(signal.symbol).strip()
+            shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+            if not shadow_key:
+                continue
+            expected_return = self._decision_extract_expected_return(signal, metadata)
+            expected_probability = self._decision_extract_probability(signal, metadata)
+            try:
+                confidence = float(signal.confidence)
+            except (TypeError, ValueError):
+                confidence = 0.0
+            grouped_candidates.setdefault((symbol, normalized_side), []).append(
+                (
+                    expected_return,
+                    expected_probability,
+                    confidence,
+                    self._ranked_autonomous_open_stable_tie_break_key(signal),
+                    candidate_batch_index,
+                    shadow_key,
+                )
+            )
+
+        duplicate_pairs: dict[str, str] = {}
+        for candidates in grouped_candidates.values():
+            if len(candidates) <= 1:
+                continue
+            ranked_candidates = sorted(
+                candidates,
+                key=lambda item: (-item[0], -item[1], -item[2], item[3], item[4]),
+            )
+            primary_shadow_key = ranked_candidates[0][5]
+            for _, _, _, _, _, shadow_key in ranked_candidates[1:]:
+                if shadow_key == primary_shadow_key:
+                    continue
+                duplicate_pairs[shadow_key] = primary_shadow_key
+        return duplicate_pairs
 
     def _should_skip_signal_as_ranked_autonomous_open_loser(
         self,
@@ -1591,16 +1717,28 @@ class TradingController:
         batch_index: int,
         expanded_batch: Sequence[tuple[int, StrategySignal]],
     ) -> bool:
+        ranked_selection = self._evaluate_ranked_autonomous_open_selection(
+            batch_index=batch_index,
+            expanded_batch=expanded_batch,
+        )
+        return bool(ranked_selection is not None and ranked_selection["skip_current"])
+
+    def _evaluate_ranked_autonomous_open_selection(
+        self,
+        *,
+        batch_index: int,
+        expanded_batch: Sequence[tuple[int, StrategySignal]],
+    ) -> dict[str, object] | None:
         if not self._enable_autonomous_open_ranked_selection_within_batch:
-            return False
+            return None
         if self._max_active_autonomous_open_positions is None:
-            return False
+            return None
         active_autonomous_open_count = self._count_scope_active_autonomous_open_trackers()
         remaining_slots = self._max_active_autonomous_open_positions - active_autonomous_open_count
         if remaining_slots < 0:
             remaining_slots = 0
 
-        scored_candidates: list[tuple[float, float, float, tuple[str, ...], int]] = []
+        scored_candidates: list[tuple[float, float, float, tuple[str, ...], int, str]] = []
         for candidate_batch_index, signal in expanded_batch:
             if candidate_batch_index < batch_index:
                 continue
@@ -1612,6 +1750,7 @@ class TradingController:
                     confidence = float(signal.confidence)
                 except (TypeError, ValueError):
                     confidence = 0.0
+                shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
                 scored_candidates.append(
                     (
                         expected_return,
@@ -1619,18 +1758,34 @@ class TradingController:
                         confidence,
                         self._ranked_autonomous_open_stable_tie_break_key(signal),
                         candidate_batch_index,
+                        shadow_key,
                     )
                 )
-        if not any(item[4] == batch_index for item in scored_candidates):
-            return False
+        current_item = next((item for item in scored_candidates if item[4] == batch_index), None)
+        if current_item is None:
+            return None
         if len(scored_candidates) <= remaining_slots:
-            return False
+            return None
         ranked_candidates = sorted(
             scored_candidates,
             key=lambda item: (-item[0], -item[1], -item[2], item[3]),
         )
         winner_indices = {item[4] for item in ranked_candidates[:remaining_slots]}
-        return batch_index not in winner_indices
+        winner_shadow_keys = [item[5] for item in ranked_candidates[:remaining_slots] if item[5]]
+        loser_shadow_keys = [item[5] for item in ranked_candidates[remaining_slots:] if item[5]]
+        return {
+            "skip_current": batch_index not in winner_indices,
+            "remaining_slots": remaining_slots,
+            "candidate_count": len(scored_candidates),
+            "selected_count": len(ranked_candidates[:remaining_slots]),
+            "loser_count": len(ranked_candidates[remaining_slots:]),
+            "selected_shadow_keys": winner_shadow_keys,
+            "loser_shadow_keys": loser_shadow_keys,
+            "ranking_basis": (
+                "expected_return_bps,expected_probability,signal_confidence,stable_tie_break_key"
+            ),
+            "ranked_mode_source": "enable_autonomous_open_ranked_selection_within_batch",
+        }
 
     def _is_budget_ranked_autonomous_open_candidate(self, signal: StrategySignal) -> bool:
         metadata = signal.metadata if isinstance(signal.metadata, Mapping) else {}

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -377,6 +377,53 @@ def _last_event(journal: CollectingDecisionJournal, event_type: str) -> Mapping[
     return events[-1]
 
 
+def _ranked_selection_events(journal: CollectingDecisionJournal) -> list[Mapping[str, str]]:
+    return [
+        event
+        for event in journal.export()
+        if event.get("event") == "ranked_autonomous_open_selection"
+    ]
+
+
+def _ranked_selection_shadow_keys(event: Mapping[str, str], field: str) -> list[str]:
+    payload = json.loads(str(event.get(field) or "[]"))
+    assert isinstance(payload, list)
+    return [str(item) for item in payload]
+
+
+def _assert_single_ranked_selection_event_payload(
+    journal: CollectingDecisionJournal,
+    *,
+    remaining_slots: str,
+    candidate_count: str,
+    selected_count: str,
+    loser_count: str,
+    selected_shadow_keys: list[str],
+    loser_shadow_keys: list[str],
+) -> None:
+    ranked_selection_events = _ranked_selection_events(journal)
+    assert len(ranked_selection_events) == 1
+    ranked_selection_event = ranked_selection_events[0]
+    assert ranked_selection_event["remaining_slots"] == remaining_slots
+    assert ranked_selection_event["candidate_count"] == candidate_count
+    assert ranked_selection_event["selected_count"] == selected_count
+    assert ranked_selection_event["loser_count"] == loser_count
+    assert _ranked_selection_shadow_keys(ranked_selection_event, "selected_shadow_keys") == (
+        selected_shadow_keys
+    )
+    assert _ranked_selection_shadow_keys(ranked_selection_event, "loser_shadow_keys") == (
+        loser_shadow_keys
+    )
+    assert (
+        ranked_selection_event["ranking_basis"]
+        == "expected_return_bps,expected_probability,signal_confidence,stable_tie_break_key"
+    )
+    assert (
+        ranked_selection_event["ranked_mode_source"]
+        == "enable_autonomous_open_ranked_selection_within_batch"
+    )
+
+
 _ORDER_PATH_EVENT_TYPES = {
     "order_submitted",
     "order_executed",
@@ -11016,6 +11063,15 @@ def test_opportunity_autonomy_active_budget_ranked_mode_is_order_independent_wit
     assert skipped_events
     assert skipped_events[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
     assert skipped_events[-1]["max_active_autonomous_open_positions"] == "1"
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count="2",
+        selected_count="1",
+        loser_count="1",
+        selected_shadow_keys=[high_rank_key],
+        loser_shadow_keys=[low_rank_key],
+    )
 
 
 @pytest.mark.parametrize("reversed_input_order", [False, True])
@@ -11117,7 +11173,17 @@ def test_opportunity_autonomy_active_budget_ranked_mode_exact_tie_is_order_indep
         if event["event"] == "signal_skipped"
         and str(event.get("order_opportunity_shadow_record_key") or "").strip() == expected_loser
     ]
+    assert skipped_events
     assert skipped_events[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count="2",
+        selected_count="1",
+        loser_count="1",
+        selected_shadow_keys=[expected_winner],
+        loser_shadow_keys=[expected_loser],
+    )
 
 
 @pytest.mark.parametrize("reversed_input_order", [False, True])
@@ -11226,6 +11292,15 @@ def test_opportunity_autonomy_active_budget_ranked_mode_exact_tie_with_sparse_id
     ]
     assert skipped_events
     assert skipped_events[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count="2",
+        selected_count="1",
+        loser_count="1",
+        selected_shadow_keys=[first_key],
+        loser_shadow_keys=[second_key],
+    )
 
 
 @pytest.mark.parametrize("reversed_input_order", [False, True])
@@ -11344,6 +11419,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_full_stable_key_tie_is_d
     assert skipped_events
     assert skipped_events[-1]["reason"] == "duplicate_autonomous_open_reentry_suppressed"
     assert skipped_events[-1]["reason"] != "autonomous_open_active_budget_ranked_loser"
+    assert _ranked_selection_events(journal) == []
 
 
 def test_opportunity_autonomy_active_budget_ranked_mode_full_stable_key_tie_is_unreachable_for_non_duplicate_candidates() -> (
@@ -11457,6 +11533,1106 @@ def test_opportunity_autonomy_active_budget_ranked_mode_full_stable_key_tie_is_u
     assert skipped_events[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
 
 
+@pytest.mark.parametrize("reversed_input_order", [False, True])
+def test_opportunity_autonomy_active_budget_ranked_proof_keeps_duplicate_replay_candidate_in_mixed_batch(
+    reversed_input_order: bool,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 12, 11, 14, tzinfo=timezone.utc)
+    winner_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-mixed-dup-v1",
+        rank=1,
+    )
+    loser_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-mixed-dup-v1",
+        rank=2,
+    )
+    duplicate_replay_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        model_version="opportunity-budget-ranked-mixed-dup-v1",
+        rank=3,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(correlation_key=winner_key, decision_timestamp=decision_timestamp),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=loser_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="ETH/USDT",
+            ),
+            _shadow_record_for_key(
+                correlation_key=duplicate_replay_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=2),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 98.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    winner_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=winner_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    winner_signal.metadata = {
+        **dict(winner_signal.metadata),
+        "expected_return_bps": 12.0,
+        "expected_probability": 0.72,
+    }
+    loser_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=loser_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    loser_signal.symbol = "ETH/USDT"
+    loser_signal.metadata = {
+        **dict(loser_signal.metadata),
+        "expected_return_bps": 3.0,
+        "expected_probability": 0.55,
+    }
+    duplicate_replay_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=duplicate_replay_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    duplicate_replay_signal.metadata = {
+        **dict(duplicate_replay_signal.metadata),
+        "expected_return_bps": 2.0,
+        "expected_probability": 0.5,
+    }
+
+    batch = [winner_signal, loser_signal, duplicate_replay_signal]
+    if reversed_input_order:
+        batch = [duplicate_replay_signal, winner_signal, loser_signal]
+
+    controller.process_signals(batch)
+
+    assert len(execution.requests) == 1
+    assert _request_shadow_keys(execution.requests) == [winner_key]
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=loser_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=duplicate_replay_key)
+    assert _order_path_events_with_shadow_key(journal, loser_key) == []
+    assert _order_path_events_with_shadow_key(journal, duplicate_replay_key) == []
+    expected_candidate_count = "3" if reversed_input_order else "2"
+    expected_loser_count = "2" if reversed_input_order else "1"
+    expected_loser_shadow_keys = (
+        [loser_key, duplicate_replay_key] if reversed_input_order else [loser_key]
+    )
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count=expected_candidate_count,
+        selected_count="1",
+        loser_count=expected_loser_count,
+        selected_shadow_keys=[winner_key],
+        loser_shadow_keys=expected_loser_shadow_keys,
+    )
+    ranked_selection_event = _ranked_selection_events(journal)[0]
+    assert duplicate_replay_key not in _ranked_selection_shadow_keys(
+        ranked_selection_event, "selected_shadow_keys"
+    )
+    if reversed_input_order:
+        assert duplicate_replay_key in _ranked_selection_shadow_keys(
+            ranked_selection_event, "loser_shadow_keys"
+        )
+    else:
+        assert duplicate_replay_key not in _ranked_selection_shadow_keys(
+            ranked_selection_event, "loser_shadow_keys"
+        )
+    replay_events = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == duplicate_replay_key
+    ]
+    assert replay_events
+    if reversed_input_order:
+        assert replay_events[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+    else:
+        assert replay_events[-1]["reason"] == "duplicate_autonomous_open_reentry_suppressed"
+        assert replay_events[-1]["reason"] != "autonomous_open_active_budget_ranked_loser"
+    ranked_loser_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == loser_key
+    ]
+    assert ranked_loser_skips
+    assert ranked_loser_skips[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+
+
+def test_opportunity_autonomy_active_budget_ranked_proof_contains_full_set_for_three_ranked_candidates() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 12, 11, 16, tzinfo=timezone.utc)
+    high_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-top3-v1",
+        rank=1,
+    )
+    mid_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-top3-v1",
+        rank=2,
+    )
+    low_key = OpportunityShadowRecord.build_record_key(
+        symbol="XRP/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        model_version="opportunity-budget-ranked-top3-v1",
+        rank=3,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(correlation_key=high_key, decision_timestamp=decision_timestamp),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=mid_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="ETH/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=low_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="XRP/USDT",
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 98.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    high_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=high_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    high_signal.metadata = {
+        **dict(high_signal.metadata),
+        "expected_return_bps": 12.0,
+        "expected_probability": 0.72,
+    }
+    mid_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=mid_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    mid_signal.symbol = "ETH/USDT"
+    mid_signal.metadata = {
+        **dict(mid_signal.metadata),
+        "expected_return_bps": 8.0,
+        "expected_probability": 0.66,
+    }
+    low_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=low_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    low_signal.symbol = "XRP/USDT"
+    low_signal.metadata = {
+        **dict(low_signal.metadata),
+        "expected_return_bps": 3.0,
+        "expected_probability": 0.55,
+    }
+
+    controller.process_signals([high_signal, mid_signal, low_signal])
+
+    assert len(execution.requests) == 1
+    assert _request_shadow_keys(execution.requests) == [high_key]
+    assert _order_path_events_with_shadow_key(journal, high_key)
+    assert _order_path_events_with_shadow_key(journal, mid_key) == []
+    assert _order_path_events_with_shadow_key(journal, low_key) == []
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=mid_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=low_key)
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count="3",
+        selected_count="1",
+        loser_count="2",
+        selected_shadow_keys=[high_key],
+        loser_shadow_keys=[mid_key, low_key],
+    )
+    loser_events = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() in {mid_key, low_key}
+    ]
+    assert len(loser_events) == 2
+    loser_reasons = {event["reason"] for event in loser_events}
+    assert loser_reasons == {"autonomous_open_active_budget_ranked_loser"}
+
+
+def test_opportunity_autonomy_active_budget_ranked_duplicate_replay_not_suppressed_against_non_opened_primary() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 12, 11, 18, tzinfo=timezone.utc)
+    winner_b_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-dup-non-open-primary-v1",
+        rank=1,
+    )
+    primary_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-dup-non-open-primary-v1",
+        rank=2,
+    )
+    replay_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        model_version="opportunity-budget-ranked-dup-non-open-primary-v1",
+        rank=3,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=winner_b_key,
+                    decision_timestamp=decision_timestamp,
+                ),
+                symbol="ETH/USDT",
+            ),
+            _shadow_record_for_key(
+                correlation_key=primary_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=1),
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=2),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 200.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    winner_b_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=winner_b_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    winner_b_signal.symbol = "ETH/USDT"
+    winner_b_signal.metadata = {
+        **dict(winner_b_signal.metadata),
+        "expected_return_bps": 15.0,
+        "expected_probability": 0.8,
+    }
+    primary_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=primary_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    primary_a_signal.metadata = {
+        **dict(primary_a_signal.metadata),
+        "expected_return_bps": 7.0,
+        "expected_probability": 0.62,
+    }
+    replay_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    replay_a_signal.metadata = {
+        **dict(replay_a_signal.metadata),
+        "expected_return_bps": 2.0,
+        "expected_probability": 0.51,
+    }
+
+    controller.process_signals([winner_b_signal, primary_a_signal, replay_a_signal])
+
+    assert len(execution.requests) == 1
+    assert _request_shadow_keys(execution.requests) == [winner_b_key]
+    assert _order_path_events_with_shadow_key(journal, winner_b_key)
+    assert _order_path_events_with_shadow_key(journal, primary_a_key) == []
+    assert _order_path_events_with_shadow_key(journal, replay_a_key) == []
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=primary_a_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=replay_a_key)
+    primary_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == primary_a_key
+    ]
+    replay_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == replay_a_key
+    ]
+    assert primary_skips
+    assert replay_skips
+    assert primary_skips[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+    assert replay_skips[-1]["reason"] != "duplicate_autonomous_open_reentry_suppressed"
+    assert replay_skips[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+
+
+def test_opportunity_autonomy_active_budget_ranked_duplicate_replay_not_suppressed_against_selected_primary_rejected_before_open() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 12, 11, 19, tzinfo=timezone.utc)
+    primary_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-selected-primary-rejected-v1",
+        rank=1,
+    )
+    replay_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-selected-primary-rejected-v1",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=primary_a_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=1),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {
+                "status": "rejected",
+                "filled_quantity": 0.0,
+                "avg_price": None,
+            },
+            {
+                "status": "filled",
+                "filled_quantity": 1.0,
+                "avg_price": 101.0,
+            },
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    primary_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=primary_a_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    primary_a_signal.metadata = {
+        **dict(primary_a_signal.metadata),
+        "expected_return_bps": 9.0,
+        "expected_probability": 0.66,
+    }
+    replay_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    replay_a_signal.metadata = {
+        **dict(replay_a_signal.metadata),
+        "expected_return_bps": 3.0,
+        "expected_probability": 0.55,
+    }
+
+    controller.process_signals([primary_a_signal, replay_a_signal])
+
+    assert len(execution.requests) == 2
+    assert _request_shadow_keys(execution.requests) == [primary_a_key, replay_a_key]
+    duplicate_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == replay_a_key
+    ]
+    assert duplicate_skips == []
+    replay_order_events = _order_path_events_with_shadow_key(journal, replay_a_key)
+    assert replay_order_events
+    assert any(event.get("event") == "order_executed" for event in replay_order_events)
+    assert any(row.correlation_key == replay_a_key for row in repository.load_open_outcomes())
+
+
+def test_opportunity_autonomy_active_budget_ranked_replay_before_selected_primary_rejected_is_not_duplicate_suppressed() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 12, 11, 21, tzinfo=timezone.utc)
+    replay_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-replay-before-primary-rejected-v1",
+        rank=1,
+    )
+    primary_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-replay-before-primary-rejected-v1",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=replay_a_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            _shadow_record_for_key(
+                correlation_key=primary_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=1),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {
+                "status": "rejected",
+                "filled_quantity": 0.0,
+                "avg_price": None,
+            },
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    replay_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_a_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    replay_a_signal.metadata = {
+        **dict(replay_a_signal.metadata),
+        "expected_return_bps": 3.0,
+        "expected_probability": 0.55,
+    }
+    primary_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=primary_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    primary_a_signal.metadata = {
+        **dict(primary_a_signal.metadata),
+        "expected_return_bps": 9.0,
+        "expected_probability": 0.66,
+    }
+
+    controller.process_signals([replay_a_signal, primary_a_signal])
+
+    assert _request_shadow_keys(execution.requests) == [primary_a_key]
+    replay_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == replay_a_key
+    ]
+    assert replay_skips
+    assert replay_skips[-1]["reason"] != "duplicate_autonomous_open_reentry_suppressed"
+    assert replay_skips[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+    assert "existing_open_correlation_key" not in replay_skips[-1]
+    primary_events = _order_path_events_with_shadow_key(journal, primary_a_key)
+    assert primary_events
+    assert any(event.get("event") == "order_execution_result" for event in primary_events)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=replay_a_key)
+
+
+def test_opportunity_autonomy_active_budget_ranked_proof_includes_replay_when_primary_later_rejected() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 12, 11, 24, tzinfo=timezone.utc)
+    replay_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-proof-replay-primary-rejected-v1",
+        rank=1,
+    )
+    primary_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-proof-replay-primary-rejected-v1",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=replay_a_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            _shadow_record_for_key(
+                correlation_key=primary_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=1),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {
+                "status": "rejected",
+                "filled_quantity": 0.0,
+                "avg_price": None,
+            },
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    replay_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_a_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    replay_a_signal.metadata = {
+        **dict(replay_a_signal.metadata),
+        "expected_return_bps": 3.0,
+        "expected_probability": 0.55,
+    }
+    primary_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=primary_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    primary_a_signal.metadata = {
+        **dict(primary_a_signal.metadata),
+        "expected_return_bps": 9.0,
+        "expected_probability": 0.66,
+    }
+
+    controller.process_signals([replay_a_signal, primary_a_signal])
+
+    replay_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == replay_a_key
+    ]
+    assert replay_skips
+    assert replay_skips[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+    assert replay_skips[-1]["reason"] != "duplicate_autonomous_open_reentry_suppressed"
+    assert "existing_open_correlation_key" not in replay_skips[-1]
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count="2",
+        selected_count="1",
+        loser_count="1",
+        selected_shadow_keys=[primary_a_key],
+        loser_shadow_keys=[replay_a_key],
+    )
+
+
+def test_opportunity_autonomy_active_budget_ranked_proof_includes_replay_when_primary_loses_to_other_symbol_winner() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 12, 11, 26, tzinfo=timezone.utc)
+    replay_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-proof-cross-symbol-winner-v1",
+        rank=1,
+    )
+    primary_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-proof-cross-symbol-winner-v1",
+        rank=2,
+    )
+    winner_b_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        model_version="opportunity-budget-ranked-proof-cross-symbol-winner-v1",
+        rank=3,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=replay_a_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            _shadow_record_for_key(
+                correlation_key=primary_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=1),
+            ),
+            _shadow_record_for_key(
+                correlation_key=winner_b_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=2),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {
+                "status": "filled",
+                "filled_quantity": 1.0,
+                "avg_price": 101.0,
+            }
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    replay_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_a_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    replay_a_signal.metadata = {
+        **dict(replay_a_signal.metadata),
+        "expected_return_bps": 4.0,
+        "expected_probability": 0.55,
+    }
+    primary_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=primary_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    primary_a_signal.metadata = {
+        **dict(primary_a_signal.metadata),
+        "expected_return_bps": 7.0,
+        "expected_probability": 0.62,
+    }
+    winner_b_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=winner_b_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    winner_b_signal.metadata = {
+        **dict(winner_b_signal.metadata),
+        "expected_return_bps": 10.0,
+        "expected_probability": 0.71,
+    }
+
+    controller.process_signals([replay_a_signal, primary_a_signal, winner_b_signal])
+
+    assert _request_shadow_keys(execution.requests) == [winner_b_key]
+    replay_events = _order_path_events_with_shadow_key(journal, replay_a_key)
+    primary_events = _order_path_events_with_shadow_key(journal, primary_a_key)
+    assert replay_events == []
+    assert primary_events == []
+    replay_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == replay_a_key
+    ]
+    assert replay_skips
+    assert replay_skips[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+    assert replay_skips[-1]["reason"] != "duplicate_autonomous_open_reentry_suppressed"
+    primary_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == primary_a_key
+    ]
+    assert primary_skips
+    assert primary_skips[-1]["reason"] == "autonomous_open_active_budget_ranked_loser"
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count="3",
+        selected_count="1",
+        loser_count="2",
+        selected_shadow_keys=[winner_b_key],
+        loser_shadow_keys=[primary_a_key, replay_a_key],
+    )
+
+
+def test_opportunity_autonomy_active_budget_ranked_proof_late_duplicate_after_earlier_ranked_loser_is_finalized() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 12, 11, 28, tzinfo=timezone.utc)
+    loser_b_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-proof-late-duplicate-v1",
+        rank=1,
+    )
+    primary_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-proof-late-duplicate-v1",
+        rank=2,
+    )
+    replay_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        model_version="opportunity-budget-ranked-proof-late-duplicate-v1",
+        rank=3,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=loser_b_key,
+                    decision_timestamp=decision_timestamp,
+                ),
+                symbol="ETH/USDT",
+            ),
+            _shadow_record_for_key(
+                correlation_key=primary_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=1),
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=2),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    loser_b_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=loser_b_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    loser_b_signal.symbol = "ETH/USDT"
+    loser_b_signal.metadata = {
+        **dict(loser_b_signal.metadata),
+        "expected_return_bps": 6.0,
+        "expected_probability": 0.60,
+    }
+    primary_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=primary_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    primary_a_signal.metadata = {
+        **dict(primary_a_signal.metadata),
+        "expected_return_bps": 10.0,
+        "expected_probability": 0.72,
+    }
+    replay_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    replay_a_signal.metadata = {
+        **dict(replay_a_signal.metadata),
+        "expected_return_bps": 2.0,
+        "expected_probability": 0.51,
+    }
+
+    controller.process_signals([loser_b_signal, primary_a_signal, replay_a_signal])
+
+    assert _request_shadow_keys(execution.requests) == [primary_a_key]
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=loser_b_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=replay_a_key)
+    assert _order_path_events_with_shadow_key(journal, loser_b_key) == []
+    assert _order_path_events_with_shadow_key(journal, replay_a_key) == []
+    replay_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == replay_a_key
+    ]
+    assert replay_skips
+    assert replay_skips[-1]["reason"] == "duplicate_autonomous_open_reentry_suppressed"
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count="2",
+        selected_count="1",
+        loser_count="1",
+        selected_shadow_keys=[primary_a_key],
+        loser_shadow_keys=[loser_b_key],
+    )
+
+
+def test_opportunity_autonomy_active_budget_ranked_proof_late_duplicate_with_multiple_ranked_losers_is_finalized() -> (
+    None
+):
+    decision_timestamp = datetime(2026, 1, 12, 11, 30, tzinfo=timezone.utc)
+    loser_b_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-ranked-proof-late-duplicate-multi-v1",
+        rank=1,
+    )
+    loser_c_key = OpportunityShadowRecord.build_record_key(
+        symbol="XRP/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-ranked-proof-late-duplicate-multi-v1",
+        rank=2,
+    )
+    primary_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        model_version="opportunity-budget-ranked-proof-late-duplicate-multi-v1",
+        rank=3,
+    )
+    replay_a_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+        model_version="opportunity-budget-ranked-proof-late-duplicate-multi-v1",
+        rank=4,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=loser_b_key,
+                    decision_timestamp=decision_timestamp,
+                ),
+                symbol="ETH/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=loser_c_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            _shadow_record_for_key(
+                correlation_key=primary_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=2),
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_a_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=3),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 102.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+    )
+    loser_b_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=loser_b_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    loser_b_signal.symbol = "ETH/USDT"
+    loser_b_signal.metadata = {
+        **dict(loser_b_signal.metadata),
+        "expected_return_bps": 7.0,
+        "expected_probability": 0.62,
+    }
+    loser_c_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=loser_c_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    loser_c_signal.symbol = "XRP/USDT"
+    loser_c_signal.metadata = {
+        **dict(loser_c_signal.metadata),
+        "expected_return_bps": 5.0,
+        "expected_probability": 0.57,
+    }
+    primary_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=primary_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    primary_a_signal.metadata = {
+        **dict(primary_a_signal.metadata),
+        "expected_return_bps": 10.0,
+        "expected_probability": 0.71,
+    }
+    replay_a_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=replay_a_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    replay_a_signal.metadata = {
+        **dict(replay_a_signal.metadata),
+        "expected_return_bps": 2.0,
+        "expected_probability": 0.51,
+    }
+
+    controller.process_signals([loser_b_signal, loser_c_signal, primary_a_signal, replay_a_signal])
+
+    assert _request_shadow_keys(execution.requests) == [primary_a_key]
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=loser_b_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=loser_c_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=replay_a_key)
+    replay_skips = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == replay_a_key
+    ]
+    assert replay_skips
+    assert replay_skips[-1]["reason"] == "duplicate_autonomous_open_reentry_suppressed"
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="1",
+        candidate_count="3",
+        selected_count="1",
+        loser_count="2",
+        selected_shadow_keys=[primary_a_key],
+        loser_shadow_keys=[loser_b_key, loser_c_key],
+    )
+
+
 def test_opportunity_autonomy_active_budget_ranked_mode_close_then_open_frees_slot() -> None:
     decision_timestamp = datetime(2026, 1, 12, 11, 20, tzinfo=timezone.utc)
     existing_key = OpportunityShadowRecord.build_record_key(
@@ -11542,6 +12718,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_close_then_open_frees_sl
         and str(event.get("order_opportunity_shadow_record_key") or "").strip() == new_key
     ]
     assert skipped_new_key == []
+    assert _ranked_selection_events(journal) == []
 
 
 def test_opportunity_autonomy_active_budget_ranked_mode_open_then_close_preserves_input_order() -> None:
@@ -11712,6 +12889,7 @@ def test_opportunity_autonomy_active_budget_preserves_duplicate_guard_precedence
     assert all(
         event.get("reason") != "autonomous_open_active_budget_exhausted" for event in skipped_events
     )
+    assert _ranked_selection_events(journal) == []
 
 
 def test_opportunity_autonomy_active_budget_ranked_mode_preserves_duplicate_guard_precedence_within_single_batch() -> (
@@ -11795,6 +12973,83 @@ def test_opportunity_autonomy_active_budget_ranked_mode_preserves_duplicate_guar
         event.get("reason") != "autonomous_open_active_budget_ranked_loser"
         for event in skipped_events
     )
+    ranked_selection_events = _ranked_selection_events(journal)
+    assert ranked_selection_events == []
+
+
+def test_opportunity_autonomy_active_budget_non_ranked_mode_has_no_ranked_selection_proof_event() -> None:
+    decision_timestamp = datetime(2026, 1, 12, 12, 0, tzinfo=timezone.utc)
+    first_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-budget-default-mode-v1",
+        rank=1,
+    )
+    second_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        model_version="opportunity-budget-default-mode-v1",
+        rank=2,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0, 6.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(correlation_key=first_key, decision_timestamp=decision_timestamp),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=second_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="ETH/USDT",
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 200.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=False,
+    )
+    first_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=first_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    second_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=second_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    second_signal.symbol = "ETH/USDT"
+
+    controller.process_signals([first_signal, second_signal])
+
+    assert len(execution.requests) == 1
+    assert _request_shadow_keys(execution.requests) == [first_key]
+    skipped_events = [
+        event
+        for event in journal.export()
+        if event["event"] == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == second_key
+    ]
+    assert skipped_events
+    assert skipped_events[-1]["reason"] == "autonomous_open_active_budget_exhausted"
+    assert _ranked_selection_events(journal) == []
 
 
 def test_opportunity_autonomy_active_budget_ranked_mode_restore_aware_preserves_duplicate_guard_precedence() -> (
@@ -11884,6 +13139,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_restore_aware_preserves_
     assert event["order_opportunity_policy_mode"] == "paper"
     assert event["order_decision_authority"] == "shared_live_policy"
     assert "order_opportunity_ai_enabled" not in event
+    assert _ranked_selection_events(journal) == []
 
 
 def test_opportunity_autonomy_active_budget_restore_aware_preserves_duplicate_guard_precedence() -> (


### PR DESCRIPTION
### Motivation
- Enforce budgeted limits on concurrently opening autonomous positions within a single input batch by ranking candidates and skipping losers. 
- Ensure duplicate replay candidates are suppressed correctly when they replay a previously selected primary in the same batch. 
- Emit an auditable decision event summarizing ranked selection outcomes for observability and debugging. 

### Description
- Added in-batch duplicate detection with `TradingController._collect_in_batch_ranked_duplicate_replay_pairs` to map replay shadow keys to their primary candidate keys. 
- Implemented ranked selection evaluation with `TradingController._evaluate_ranked_autonomous_open_selection` and integrated it into `process_signals` to skip ranked losers while preserving duplicate-suppression precedence. 
- Added logic in `process_signals` to record a `ranked_autonomous_open_selection` decision event containing `remaining_slots`, `candidate_count`, `selected_count`, `loser_count`, `selected_shadow_keys`, `loser_shadow_keys`, `ranking_basis`, and `ranked_mode_source`. 
- Adjusted duplicate suppression behavior so in-batch duplicate replays may be suppressed or allowed depending on ranking and existing open outcomes, and introduced `in_batch_actual_duplicate_suppressed_shadow_keys` to avoid including suppressed replays in the final proof payload. 
- Updated `TradingController._should_skip_signal_as_ranked_autonomous_open_loser` to use the new evaluation method and normalized return semantics for the evaluation helper. 
- Extended and added tests and helpers in `tests/test_trading_controller.py` to validate ranked selection ordering, tie-breaking, duplicate replay handling, and the emitted proof event payload via new helpers `ranked_selection_events`, `_ranked_selection_shadow_keys`, and `_assert_single_ranked_selection_event_payload` (note: these appear as `_ranked_selection_events`, `_ranked_selection_shadow_keys`, `_assert_single_ranked_selection_event_payload`). 

### Testing
- Ran the autonomous-budget ranked tests in `tests/test_trading_controller.py` with `pytest` to validate ranked selection, duplicate suppression and the emitted decision event, and they completed successfully. 
- New and modified unit tests assert ordering independence, stable tie-break behavior, duplicate-replay suppression semantics, and the structure/content of the `ranked_autonomous_open_selection` event, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e538686dd8832a9631095578c8e9cf)