### PR TITLE
test: apply ruff-format reflow to tests/test_trading_controller.py (active_budget_ranked_mode)

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -12647,9 +12647,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_deferred_losers_rejected
 @pytest.mark.parametrize("open_partial_status", ["partially_filled", "partial"])
 def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_without_mode_in_same_batch_promotes_deferred_loser_with_exact_proof_event(
     open_partial_status: str,
-) -> (
-    None
-):
+) -> None:
     decision_timestamp = datetime(2026, 1, 12, 11, 22, 30, tzinfo=timezone.utc)
     primary_a_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -12745,7 +12743,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_
 
     controller.process_signals([open_a_signal, deferred_b_signal, close_a_signal])
 
-    assert _request_shadow_keys(execution.requests) == [primary_a_key, primary_a_key, deferred_b_key]
+    assert _request_shadow_keys(execution.requests) == [
+        primary_a_key,
+        primary_a_key,
+        deferred_b_key,
+    ]
     primary_a_order_events = _order_path_events_with_shadow_key(journal, primary_a_key)
     assert any(
         event.get("event") == "order_partially_executed"
@@ -12757,16 +12759,12 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_
         and str(event.get("side") or "").upper() == "BUY"
         for event in primary_a_order_events
     )
-    assert any(
-        event.get("event") == "order_executed"
-        for event in primary_a_order_events
-    )
+    assert any(event.get("event") == "order_executed" for event in primary_a_order_events)
     assert (
         sum(1 for event in primary_a_order_events if event.get("event") == "order_submitted") == 2
     )
     assert any(
-        event.get("event") == "order_executed"
-        and str(event.get("side") or "").upper() == "SELL"
+        event.get("event") == "order_executed" and str(event.get("side") or "").upper() == "SELL"
         for event in primary_a_order_events
     )
     assert any(
@@ -12788,9 +12786,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_
     )
     open_outcome_keys = sorted(row.correlation_key for row in repository.load_open_outcomes())
     assert open_outcome_keys == [deferred_b_key]
-    assert not any(
-        row.correlation_key == primary_a_key for row in repository.load_open_outcomes()
-    )
+    assert not any(row.correlation_key == primary_a_key for row in repository.load_open_outcomes())
     _assert_single_ranked_selection_event_payload(
         journal,
         remaining_slots="1",
@@ -12901,7 +12897,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_future_close_deferred_re
 
     controller.process_signals([open_a_signal, deferred_b_signal, close_a_signal])
 
-    assert _request_shadow_keys(execution.requests) == [primary_a_key, primary_a_key, deferred_b_key]
+    assert _request_shadow_keys(execution.requests) == [
+        primary_a_key,
+        primary_a_key,
+        deferred_b_key,
+    ]
     open_outcome_keys = sorted(row.correlation_key for row in repository.load_open_outcomes())
     assert open_outcome_keys == []
     deferred_b_order_events = _order_path_events_with_shadow_key(journal, deferred_b_key)
@@ -12927,9 +12927,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_future_close_deferred_re
 @pytest.mark.parametrize("open_partial_status", ["partially_filled", "partial"])
 def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_in_same_batch_real_reverse_keeps_deferred_loser(
     open_partial_status: str,
-) -> (
-    None
-):
+) -> None:
     decision_timestamp = datetime(2026, 1, 12, 11, 22, 31, tzinfo=timezone.utc)
     primary_a_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -13022,7 +13020,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_
 
     controller.process_signals([close_a_signal, deferred_b_signal, open_a_signal])
 
-    assert _request_shadow_keys(execution.requests) == [primary_a_key, primary_a_key, deferred_b_key]
+    assert _request_shadow_keys(execution.requests) == [
+        primary_a_key,
+        primary_a_key,
+        deferred_b_key,
+    ]
     primary_a_order_events = _order_path_events_with_shadow_key(journal, primary_a_key)
     assert (
         sum(1 for event in primary_a_order_events if event.get("event") == "order_submitted") == 2
@@ -13034,8 +13036,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_
         for event in primary_a_order_events
     )
     assert not any(
-        event.get("event") == "order_executed"
-        and str(event.get("side") or "").upper() == "SELL"
+        event.get("event") == "order_executed" and str(event.get("side") or "").upper() == "SELL"
         for event in primary_a_order_events
     )
     assert any(
@@ -13073,9 +13074,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_
 @pytest.mark.parametrize("open_partial_status", ["partially_filled", "partial"])
 def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_non_closing_close_does_not_promote_deferred_loser(
     open_partial_status: str,
-) -> (
-    None
-):
+) -> None:
     decision_timestamp = datetime(2026, 1, 12, 11, 22, 32, tzinfo=timezone.utc)
     primary_a_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -13699,8 +13698,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_non_
         )
 
 
-def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_promoted_open_late_replay_is_duplicate_suppressed_and_proof_aligned(
-) -> None:
+def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_promoted_open_late_replay_is_duplicate_suppressed_and_proof_aligned() -> (
+    None
+):
     decision_timestamp = datetime(2026, 1, 12, 11, 25, tzinfo=timezone.utc)
     key_a = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -13790,7 +13790,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         include_decision_payload=True,
         decision_effective_mode="paper_autonomous",
     )
-    signal_a.metadata = {**dict(signal_a.metadata), "expected_return_bps": 9.0, "expected_probability": 0.66}
+    signal_a.metadata = {
+        **dict(signal_a.metadata),
+        "expected_return_bps": 9.0,
+        "expected_probability": 0.66,
+    }
     signal_b = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -13800,7 +13804,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         decision_effective_mode="paper_autonomous",
     )
     signal_b.symbol = "ETH/USDT"
-    signal_b.metadata = {**dict(signal_b.metadata), "expected_return_bps": 8.0, "expected_probability": 0.64}
+    signal_b.metadata = {
+        **dict(signal_b.metadata),
+        "expected_return_bps": 8.0,
+        "expected_probability": 0.64,
+    }
     signal_c = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -13810,7 +13818,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         decision_effective_mode="paper_autonomous",
     )
     signal_c.symbol = "XRP/USDT"
-    signal_c.metadata = {**dict(signal_c.metadata), "expected_return_bps": 6.0, "expected_probability": 0.60}
+    signal_c.metadata = {
+        **dict(signal_c.metadata),
+        "expected_return_bps": 6.0,
+        "expected_probability": 0.60,
+    }
     replay_c_signal = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -13834,7 +13846,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         decision_effective_mode="paper_autonomous",
     )
     signal_d.symbol = "SOL/USDT"
-    signal_d.metadata = {**dict(signal_d.metadata), "expected_return_bps": 3.0, "expected_probability": 0.55}
+    signal_d.metadata = {
+        **dict(signal_d.metadata),
+        "expected_return_bps": 3.0,
+        "expected_probability": 0.55,
+    }
 
     signals = [signal_a, signal_b, signal_c, replay_c_signal, signal_d]
     controller.process_signals(signals)
@@ -13868,7 +13884,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         loser_shadow_keys=[key_d],
     )
     ranked_selection_event = _ranked_selection_events(journal)[0]
-    selected_shadow_keys = _ranked_selection_shadow_keys(ranked_selection_event, "selected_shadow_keys")
+    selected_shadow_keys = _ranked_selection_shadow_keys(
+        ranked_selection_event, "selected_shadow_keys"
+    )
     loser_shadow_keys = _ranked_selection_shadow_keys(ranked_selection_event, "loser_shadow_keys")
     assert sorted(selected_shadow_keys) == sorted([key_a, promoted_open_key])
     assert loser_shadow_keys == [key_d]
@@ -13883,8 +13901,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
     assert key_d not in open_outcome_keys
 
 
-def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_promoted_open_real_reverse_has_distinct_ranked_loser_replay_contract(
-) -> None:
+def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_promoted_open_real_reverse_has_distinct_ranked_loser_replay_contract() -> (
+    None
+):
     decision_timestamp = datetime(2026, 1, 12, 11, 25, tzinfo=timezone.utc)
     key_a = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -13974,7 +13993,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         include_decision_payload=True,
         decision_effective_mode="paper_autonomous",
     )
-    signal_a.metadata = {**dict(signal_a.metadata), "expected_return_bps": 9.0, "expected_probability": 0.66}
+    signal_a.metadata = {
+        **dict(signal_a.metadata),
+        "expected_return_bps": 9.0,
+        "expected_probability": 0.66,
+    }
     signal_b = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -13984,7 +14007,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         decision_effective_mode="paper_autonomous",
     )
     signal_b.symbol = "ETH/USDT"
-    signal_b.metadata = {**dict(signal_b.metadata), "expected_return_bps": 8.0, "expected_probability": 0.64}
+    signal_b.metadata = {
+        **dict(signal_b.metadata),
+        "expected_return_bps": 8.0,
+        "expected_probability": 0.64,
+    }
     signal_c = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -13994,7 +14021,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         decision_effective_mode="paper_autonomous",
     )
     signal_c.symbol = "XRP/USDT"
-    signal_c.metadata = {**dict(signal_c.metadata), "expected_return_bps": 6.0, "expected_probability": 0.60}
+    signal_c.metadata = {
+        **dict(signal_c.metadata),
+        "expected_return_bps": 6.0,
+        "expected_probability": 0.60,
+    }
     replay_c_signal = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -14018,7 +14049,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_prom
         decision_effective_mode="paper_autonomous",
     )
     signal_d.symbol = "SOL/USDT"
-    signal_d.metadata = {**dict(signal_d.metadata), "expected_return_bps": 3.0, "expected_probability": 0.55}
+    signal_d.metadata = {
+        **dict(signal_d.metadata),
+        "expected_return_bps": 3.0,
+        "expected_probability": 0.55,
+    }
 
     signals = [signal_a, signal_b, signal_c, replay_c_signal, signal_d]
     signals = list(reversed(signals))
@@ -14165,7 +14200,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_non_
         include_decision_payload=True,
         decision_effective_mode="paper_autonomous",
     )
-    signal_a.metadata = {**dict(signal_a.metadata), "expected_return_bps": 9.0, "expected_probability": 0.66}
+    signal_a.metadata = {
+        **dict(signal_a.metadata),
+        "expected_return_bps": 9.0,
+        "expected_probability": 0.66,
+    }
     signal_b = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -14175,7 +14214,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_non_
         decision_effective_mode="paper_autonomous",
     )
     signal_b.symbol = "ETH/USDT"
-    signal_b.metadata = {**dict(signal_b.metadata), "expected_return_bps": 8.0, "expected_probability": 0.64}
+    signal_b.metadata = {
+        **dict(signal_b.metadata),
+        "expected_return_bps": 8.0,
+        "expected_probability": 0.64,
+    }
     signal_c = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -14185,7 +14228,11 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_non_
         decision_effective_mode="paper_autonomous",
     )
     signal_c.symbol = "XRP/USDT"
-    signal_c.metadata = {**dict(signal_c.metadata), "expected_return_bps": 6.0, "expected_probability": 0.60}
+    signal_c.metadata = {
+        **dict(signal_c.metadata),
+        "expected_return_bps": 6.0,
+        "expected_probability": 0.60,
+    }
     replay_c_signal = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
@@ -14243,8 +14290,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_budget_two_deferred_non_
     assert open_keys == expected_open_keys
 
 
-def test_opportunity_autonomy_active_budget_ranked_proof_duplicate_suppressed_without_deferred_promotion_keeps_counts_and_sets_aligned(
-) -> None:
+def test_opportunity_autonomy_active_budget_ranked_proof_duplicate_suppressed_without_deferred_promotion_keeps_counts_and_sets_aligned() -> (
+    None
+):
     decision_timestamp = datetime(2026, 1, 12, 11, 27, tzinfo=timezone.utc)
     winner_a_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -14361,6 +14409,7 @@ def test_opportunity_autonomy_active_budget_ranked_proof_duplicate_suppressed_wi
         selected_shadow_keys=[winner_a_key],
         loser_shadow_keys=[loser_b_key],
     )
+
 
 def test_opportunity_autonomy_active_budget_ranked_proof_includes_replay_when_primary_later_rejected() -> (
     None
@@ -15693,9 +15742,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_preserves_duplicate_guar
 @pytest.mark.parametrize("partial_status", ["partially_filled", "partial"])
 def test_opportunity_autonomy_active_budget_ranked_mode_partial_primary_consumes_slot_and_blocks_ranked_loser(
     partial_status: str,
-) -> (
-    None
-):
+) -> None:
     decision_timestamp = datetime(2026, 1, 12, 12, 11, tzinfo=timezone.utc)
     primary_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -15714,7 +15761,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_primary_consumes
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=primary_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=primary_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=loser_key,
@@ -15796,9 +15845,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_primary_consumes
 @pytest.mark.parametrize("partial_status", ["partially_filled", "partial"])
 def test_opportunity_autonomy_active_budget_ranked_mode_partial_primary_contract_is_stable_for_reversed_input(
     partial_status: str,
-) -> (
-    None
-):
+) -> None:
     decision_timestamp = datetime(2026, 1, 12, 12, 12, tzinfo=timezone.utc)
     primary_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -15817,7 +15864,9 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_primary_contract
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=primary_key, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(
+                correlation_key=primary_key, decision_timestamp=decision_timestamp
+            ),
             replace(
                 _shadow_record_for_key(
                     correlation_key=loser_key,
@@ -15897,9 +15946,7 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_primary_contract
 @pytest.mark.parametrize("partial_status", ["partially_filled", "partial"])
 def test_opportunity_autonomy_active_budget_ranked_mode_partial_primary_suppresses_duplicate_replay_and_keeps_proof_aligned(
     partial_status: str,
-) -> (
-    None
-):
+) -> None:
     decision_timestamp = datetime(2026, 1, 12, 12, 13, tzinfo=timezone.utc)
     primary_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -15924,9 +15971,12 @@ def test_opportunity_autonomy_active_budget_ranked_mode_partial_primary_suppress
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(correlation_key=primary_key, decision_timestamp=decision_timestamp),
             _shadow_record_for_key(
-                correlation_key=replay_key, decision_timestamp=decision_timestamp + timedelta(minutes=1)
+                correlation_key=primary_key, decision_timestamp=decision_timestamp
+            ),
+            _shadow_record_for_key(
+                correlation_key=replay_key,
+                decision_timestamp=decision_timestamp + timedelta(minutes=1),
             ),
             replace(
                 _shadow_record_for_key(


### PR DESCRIPTION
### Motivation
- Finalize the last formatter-only drift reported by `ruff-format` for the `active_budget_ranked_mode` cluster in `tests/test_trading_controller.py` without changing any logic, semantics, contracts or assertions.

### Description
- Applied mechanical formatting changes only to `tests/test_trading_controller.py`, including collapsing multi-line `-> None` annotations and reflowing long lists, dicts and assertions to match `ruff-format` style. 
- No behavioral, semantic, assertion or contract changes were introduced, and no other files were modified.

### Testing
- Ran `python -m pre_commit run --all-files --show-diff-on-failure`, which exercised the `ruff-format` hook and produced formatting edits for the scoped test file (hook run results indicated `ruff-format` reformatted the test file). 
- Ran `python -m pytest -q tests/test_trading_controller.py -k "active_budget_ranked_mode" -xvv`, which failed during collection due to a missing environment dependency (`ModuleNotFoundError: No module named 'numpy'`), so test execution could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6bbdc813c832abfcd1837bf0e3ab8)