### PR TITLE
Refactor deferred-ranked diagnostic test helper and tighten event assertions

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -24609,13 +24609,21 @@ def test_opportunity_autonomy_active_budget_ranked_exact_two_deferred_ranked_can
     _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
 
 
-def _run_exact_deferred_ranked_diagnostic_case(
+def _execute_exact_deferred_ranked_seam_case(
     *,
     monkeypatch: pytest.MonkeyPatch,
     seed_mode: str,
-    apply_permission_patch: bool,
-    apply_future_close_patch: bool,
-) -> dict[str, object]:
+    shift_deferred_signal_timestamps: bool,
+) -> tuple[
+    SequencedExecutionService,
+    object,
+    TradingController,
+    object,
+    str,
+    str,
+    str,
+    str,
+]:
     decision_timestamp = datetime(2026, 1, 12, 15, 0, tzinfo=timezone.utc)
     active_a_key = OpportunityShadowRecord.build_record_key(
         symbol="BTC/USDT",
@@ -24747,18 +24755,30 @@ def _run_exact_deferred_ranked_diagnostic_case(
         seed_open_b_signal.symbol = "ETH/USDT"
         controller.process_signals([seed_open_a_signal, seed_open_b_signal])
 
+    close_a_timestamp = decision_timestamp
+    blocked_top_timestamp = (
+        decision_timestamp + timedelta(minutes=5)
+        if shift_deferred_signal_timestamps
+        else decision_timestamp + timedelta(minutes=2)
+    )
+    promoted_lower_timestamp = (
+        decision_timestamp + timedelta(minutes=6)
+        if shift_deferred_signal_timestamps
+        else decision_timestamp + timedelta(minutes=3)
+    )
+
     close_a_signal = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="SELL",
         correlation_key=active_a_key,
-        decision_timestamp=decision_timestamp + timedelta(minutes=4),
+        decision_timestamp=close_a_timestamp,
     )
     close_a_signal.metadata = {**dict(close_a_signal.metadata), "mode": "close_ranked"}
     blocked_top_signal = _autonomy_signal_with_correlation(
         mode="paper_autonomous",
         side="BUY",
         correlation_key=blocked_top_key,
-        decision_timestamp=decision_timestamp + timedelta(minutes=5),
+        decision_timestamp=blocked_top_timestamp,
         include_decision_payload=True,
         decision_effective_mode="paper_autonomous",
     )
@@ -24772,7 +24792,7 @@ def _run_exact_deferred_ranked_diagnostic_case(
         mode="paper_autonomous",
         side="BUY",
         correlation_key=promoted_lower_key,
-        decision_timestamp=decision_timestamp + timedelta(minutes=6),
+        decision_timestamp=promoted_lower_timestamp,
         include_decision_payload=True,
         decision_effective_mode="paper_autonomous",
     )
@@ -24783,275 +24803,345 @@ def _run_exact_deferred_ranked_diagnostic_case(
         "expected_return_bps": 3.0,
     }
 
-    if apply_permission_patch:
-        class _ForcedPermission:
-            def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
-                self.autonomous_execution_allowed = allowed
-                self.primary_reason = "test_forced_permission"
-                self.denial_reason = denial_reason
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
 
-            def to_dict(self) -> Mapping[str, object]:
-                return {
-                    "autonomy_mode": "paper_autonomous",
-                    "autonomous_execution_allowed": self.autonomous_execution_allowed,
-                    "assisted_override_used": False,
-                    "primary_reason": self.primary_reason,
-                    "denial_reason": self.denial_reason,
-                }
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
 
-        def _forced_permission_evaluation(
-            self: TradingController,
-            *,
-            signal: StrategySignal,
-            request: OrderRequest,
-        ):
-            metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
-            shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
-            if shadow_key == blocked_top_key:
-                return _ForcedPermission(
-                    allowed=False,
-                    denial_reason="autonomous_mode_requires_assisted_execution",
-                ), {"autonomy_mode": "paper_autonomous"}
-            return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
 
-        monkeypatch.setattr(
-            TradingController,
-            "_evaluate_opportunity_execution_permission",
-            _forced_permission_evaluation,
-        )
-    if apply_future_close_patch:
-        monkeypatch.setattr(
-            TradingController,
-            "_has_future_potential_slot_releasing_close",
-            lambda self, *, batch_index, expanded_batch: any(
-                candidate_batch_index > batch_index
-                and candidate_signal.side.upper() == "SELL"
-                and str(candidate_signal.metadata.get("opportunity_shadow_record_key") or "").strip()
-                == active_a_key
-                for candidate_batch_index, candidate_signal in expanded_batch
-            ),
-        )
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+    monkeypatch.setattr(
+        TradingController,
+        "_has_future_potential_slot_releasing_close",
+        lambda self, *, batch_index, expanded_batch: any(
+            candidate_batch_index > batch_index
+            and candidate_signal.side.upper() == "SELL"
+            and str(candidate_signal.metadata.get("opportunity_shadow_record_key") or "").strip()
+            == active_a_key
+            for candidate_batch_index, candidate_signal in expanded_batch
+        ),
+    )
 
     controller.process_signals([close_a_signal, blocked_top_signal, promoted_lower_signal])
-
-    exported = list(journal.export())
-
-    def _skips_for_key(shadow_key: str) -> list[str]:
-        return [
-            str(event.get("reason") or "")
-            for event in exported
-            if event.get("event") == "signal_skipped"
-            and str(event.get("order_opportunity_shadow_record_key") or "").strip() == shadow_key
-        ]
-
-    def _enforcement_for_key(shadow_key: str) -> list[str]:
-        return [
-            str(event.get("status") or "")
-            for event in exported
-            if event.get("event") == "opportunity_autonomy_enforcement"
-            and str(event.get("order_opportunity_shadow_record_key") or "").strip() == shadow_key
-        ]
-
-    ranked_events = _ranked_selection_events(journal)
-    ranked_selected: list[str] = []
-    ranked_loser: list[str] = []
-    if ranked_events:
-        ranked_selected = _ranked_selection_shadow_keys(ranked_events[-1], "selected_shadow_keys")
-        ranked_loser = _ranked_selection_shadow_keys(ranked_events[-1], "loser_shadow_keys")
-
-    open_rows = repository.load_open_outcomes()
-    active_open_keys = sorted(
-        row.correlation_key for row in open_rows if row.closed_quantity < row.entry_quantity
+    return (
+        execution,
+        repository,
+        controller,
+        journal,
+        active_a_key,
+        active_b_key,
+        blocked_top_key,
+        promoted_lower_key,
     )
-    return {
-        "request_keys": _request_shadow_keys(execution.requests),
-        "request_sides": [request.side for request in execution.requests],
-        "active_a_order_path_present": bool(_order_path_events_with_shadow_key(journal, active_a_key)),
-        "blocked_top_order_path_present": bool(
-            _order_path_events_with_shadow_key(journal, blocked_top_key)
-        ),
-        "promoted_lower_order_path_present": bool(
-            _order_path_events_with_shadow_key(journal, promoted_lower_key)
-        ),
-        "blocked_top_skips": _skips_for_key(blocked_top_key),
-        "promoted_lower_skips": _skips_for_key(promoted_lower_key),
-        "blocked_top_enforcement_statuses": _enforcement_for_key(blocked_top_key),
-        "promoted_lower_enforcement_statuses": _enforcement_for_key(promoted_lower_key),
-        "ranked_event_count": len(ranked_events),
-        "ranked_selected_shadow_keys": ranked_selected,
-        "ranked_loser_shadow_keys": ranked_loser,
-        "active_open_keys": active_open_keys,
-        "active_a_key": active_a_key,
-        "active_b_key": active_b_key,
-        "blocked_top_key": blocked_top_key,
-        "promoted_lower_key": promoted_lower_key,
-    }
+
+
+def _assert_no_duplicate_residue_metadata_for_shadow_key(
+    events: Sequence[Mapping[str, object]],
+    *,
+    shadow_key: str,
+) -> None:
+    key_events = [
+        event
+        for event in events
+        if (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == shadow_key
+            or str(event.get("proxy_correlation_key") or "").strip() == shadow_key
+            or str(event.get("existing_open_correlation_key") or "").strip() == shadow_key
+        )
+    ]
+    for event in key_events:
+        assert str(event.get("existing_open_correlation_key") or "").strip() != shadow_key
+        if str(event.get("proxy_correlation_key") or "").strip() == shadow_key:
+            assert event.get("event") == "opportunity_outcome_attach"
 
 
 def test_opportunity_autonomy_active_budget_ranked_repo_seeded_seam_diagnostic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     with monkeypatch.context() as context:
-        result_no_patch = _run_exact_deferred_ranked_diagnostic_case(
+        (
+            execution_aligned,
+            repository_aligned,
+            _,
+            journal_aligned,
+            active_a_key,
+            active_b_key,
+            blocked_top_key,
+            promoted_lower_key,
+        ) = _execute_exact_deferred_ranked_seam_case(
             monkeypatch=context,
             seed_mode="repo_seeded",
-            apply_permission_patch=False,
-            apply_future_close_patch=False,
+            shift_deferred_signal_timestamps=False,
         )
-    assert result_no_patch["request_keys"] == [str(result_no_patch["active_a_key"])]
-    assert result_no_patch["request_sides"] == ["SELL"]
-    assert result_no_patch["active_a_order_path_present"] is True
-    assert result_no_patch["blocked_top_order_path_present"] is False
-    assert result_no_patch["promoted_lower_order_path_present"] is False
-    assert result_no_patch["blocked_top_enforcement_statuses"] == []
-    assert result_no_patch["promoted_lower_enforcement_statuses"] == []
-    assert result_no_patch["blocked_top_skips"] == ["autonomous_open_active_budget_ranked_loser"]
-    assert result_no_patch["promoted_lower_skips"] == ["autonomous_open_active_budget_ranked_loser"]
-    assert result_no_patch["ranked_event_count"] == 1
-    assert result_no_patch["ranked_selected_shadow_keys"] == []
-    assert result_no_patch["ranked_loser_shadow_keys"] == [
-        str(result_no_patch["blocked_top_key"]),
-        str(result_no_patch["promoted_lower_key"]),
-    ]
-    assert result_no_patch["active_open_keys"] == [str(result_no_patch["active_b_key"])]
+    assert _request_shadow_keys(execution_aligned.requests) == [active_a_key, promoted_lower_key]
+    assert [request.side for request in execution_aligned.requests] == ["SELL", "BUY"]
+    assert _order_path_events_with_shadow_key(journal_aligned, blocked_top_key) == []
+    promoted_order_events = _order_path_events_with_shadow_key(journal_aligned, promoted_lower_key)
+    assert promoted_order_events
+    assert all("proxy_correlation_key" not in event for event in promoted_order_events)
+    assert all("existing_open_correlation_key" not in event for event in promoted_order_events)
+    aligned_events = list(journal_aligned.export())
+    assert [
+        str(event.get("status") or "")
+        for event in aligned_events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["blocked"]
+    assert [
+        str(event.get("status") or "")
+        for event in aligned_events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == promoted_lower_key
+    ] == ["allowed"]
+    assert [
+        event
+        for event in aligned_events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, promoted_lower_key}
+    ] == []
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        aligned_events, shadow_key=blocked_top_key
+    )
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        aligned_events, shadow_key=promoted_lower_key
+    )
+    _assert_single_ranked_selection_event_payload(
+        journal_aligned,
+        remaining_slots="0",
+        candidate_count="1",
+        selected_count="1",
+        loser_count="0",
+        selected_shadow_keys=[promoted_lower_key],
+        loser_shadow_keys=[],
+    )
+    active_open_keys_aligned = sorted(
+        row.correlation_key
+        for row in repository_aligned.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys_aligned == sorted([active_b_key, promoted_lower_key])
+    _assert_no_durable_artifacts_for_shadow_key(repository_aligned, shadow_key=blocked_top_key)
 
     with monkeypatch.context() as context:
-        result_permission_only = _run_exact_deferred_ranked_diagnostic_case(
+        (
+            execution_shifted,
+            repository_shifted,
+            _,
+            journal_shifted,
+            active_a_key_shifted,
+            active_b_key_shifted,
+            blocked_top_key_shifted,
+            promoted_lower_key_shifted,
+        ) = _execute_exact_deferred_ranked_seam_case(
             monkeypatch=context,
             seed_mode="repo_seeded",
-            apply_permission_patch=True,
-            apply_future_close_patch=False,
+            shift_deferred_signal_timestamps=True,
         )
-    assert result_permission_only["request_keys"] == [str(result_permission_only["active_a_key"])]
-    assert result_permission_only["request_sides"] == ["SELL"]
-    assert result_permission_only["active_a_order_path_present"] is True
-    assert result_permission_only["blocked_top_order_path_present"] is False
-    assert result_permission_only["promoted_lower_order_path_present"] is False
-    assert result_permission_only["blocked_top_enforcement_statuses"] == []
-    assert result_permission_only["promoted_lower_enforcement_statuses"] == []
-    assert result_permission_only["blocked_top_skips"] == ["autonomous_open_active_budget_ranked_loser"]
-    assert result_permission_only["promoted_lower_skips"] == [
-        "autonomous_open_active_budget_ranked_loser"
-    ]
-    assert result_permission_only["ranked_event_count"] == 1
-    assert result_permission_only["ranked_selected_shadow_keys"] == []
-    assert result_permission_only["ranked_loser_shadow_keys"] == [
-        str(result_permission_only["blocked_top_key"]),
-        str(result_permission_only["promoted_lower_key"]),
-    ]
-    assert result_permission_only["active_open_keys"] == [str(result_permission_only["active_b_key"])]
-
-    with monkeypatch.context() as context:
-        result_permission_plus_future = _run_exact_deferred_ranked_diagnostic_case(
-            monkeypatch=context,
-            seed_mode="repo_seeded",
-            apply_permission_patch=True,
-            apply_future_close_patch=True,
-        )
-    assert result_permission_plus_future["request_keys"] == [str(result_permission_plus_future["active_a_key"])]
-    assert result_permission_plus_future["request_sides"] == ["SELL"]
-    assert result_permission_plus_future["active_a_order_path_present"] is True
-    assert result_permission_plus_future["blocked_top_order_path_present"] is False
-    assert result_permission_plus_future["promoted_lower_order_path_present"] is False
-    assert result_permission_plus_future["blocked_top_enforcement_statuses"] == ["blocked"]
-    assert result_permission_plus_future["promoted_lower_enforcement_statuses"] == ["blocked"]
-    assert result_permission_plus_future["blocked_top_skips"] == []
-    assert result_permission_plus_future["promoted_lower_skips"] == []
-    assert result_permission_plus_future["ranked_event_count"] == 0
-    assert result_permission_plus_future["ranked_selected_shadow_keys"] == []
-    assert result_permission_plus_future["ranked_loser_shadow_keys"] == []
-    assert result_permission_plus_future["active_open_keys"] == [
-        str(result_permission_plus_future["active_b_key"])
-    ]
+    assert _request_shadow_keys(execution_shifted.requests) == [active_a_key_shifted]
+    assert [request.side for request in execution_shifted.requests] == ["SELL"]
+    assert _order_path_events_with_shadow_key(journal_shifted, blocked_top_key_shifted) == []
+    assert _order_path_events_with_shadow_key(journal_shifted, promoted_lower_key_shifted) == []
+    shifted_events = list(journal_shifted.export())
+    assert [
+        str(event.get("status") or "")
+        for event in shifted_events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == blocked_top_key_shifted
+    ] == ["blocked"]
+    assert [
+        str(event.get("status") or "")
+        for event in shifted_events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == promoted_lower_key_shifted
+    ] == ["blocked"]
+    assert [
+        event
+        for event in shifted_events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key_shifted, promoted_lower_key_shifted}
+    ] == []
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        shifted_events, shadow_key=blocked_top_key_shifted
+    )
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        shifted_events, shadow_key=promoted_lower_key_shifted
+    )
+    assert _ranked_selection_events(journal_shifted) == []
+    active_open_keys_shifted = sorted(
+        row.correlation_key
+        for row in repository_shifted.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys_shifted == [active_b_key_shifted]
+    _assert_no_durable_artifacts_for_shadow_key(repository_shifted, shadow_key=blocked_top_key_shifted)
+    _assert_no_durable_artifacts_for_shadow_key(repository_shifted, shadow_key=promoted_lower_key_shifted)
 
 
 def test_opportunity_autonomy_active_budget_ranked_runtime_seeded_seam_diagnostic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     with monkeypatch.context() as context:
-        result_no_patch = _run_exact_deferred_ranked_diagnostic_case(
+        (
+            execution_aligned,
+            repository_aligned,
+            _,
+            journal_aligned,
+            active_a_key,
+            active_b_key,
+            blocked_top_key,
+            promoted_lower_key,
+        ) = _execute_exact_deferred_ranked_seam_case(
             monkeypatch=context,
             seed_mode="runtime_seeded",
-            apply_permission_patch=False,
-            apply_future_close_patch=False,
+            shift_deferred_signal_timestamps=False,
         )
-    assert result_no_patch["request_keys"] == [
-        str(result_no_patch["active_a_key"]),
-        str(result_no_patch["active_b_key"]),
-        str(result_no_patch["active_a_key"]),
+    assert _request_shadow_keys(execution_aligned.requests) == [
+        active_a_key,
+        active_b_key,
+        active_a_key,
+        promoted_lower_key,
     ]
-    assert result_no_patch["request_sides"] == ["BUY", "BUY", "SELL"]
-    assert result_no_patch["active_a_order_path_present"] is True
-    assert result_no_patch["blocked_top_order_path_present"] is False
-    assert result_no_patch["promoted_lower_order_path_present"] is False
-    assert result_no_patch["blocked_top_enforcement_statuses"] == []
-    assert result_no_patch["promoted_lower_enforcement_statuses"] == []
-    assert result_no_patch["blocked_top_skips"] == ["autonomous_open_active_budget_ranked_loser"]
-    assert result_no_patch["promoted_lower_skips"] == ["autonomous_open_active_budget_ranked_loser"]
-    assert result_no_patch["ranked_event_count"] == 1
-    assert result_no_patch["ranked_selected_shadow_keys"] == []
-    assert result_no_patch["ranked_loser_shadow_keys"] == [
-        str(result_no_patch["blocked_top_key"]),
-        str(result_no_patch["promoted_lower_key"]),
-    ]
-    assert result_no_patch["active_open_keys"] == [str(result_no_patch["active_b_key"])]
+    assert [request.side for request in execution_aligned.requests] == ["BUY", "BUY", "SELL", "BUY"]
+    assert _order_path_events_with_shadow_key(journal_aligned, blocked_top_key) == []
+    promoted_order_events = _order_path_events_with_shadow_key(journal_aligned, promoted_lower_key)
+    assert promoted_order_events
+    assert all("proxy_correlation_key" not in event for event in promoted_order_events)
+    assert all("existing_open_correlation_key" not in event for event in promoted_order_events)
+    aligned_events = list(journal_aligned.export())
+    assert [
+        str(event.get("status") or "")
+        for event in aligned_events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["blocked"]
+    assert [
+        str(event.get("status") or "")
+        for event in aligned_events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == promoted_lower_key
+    ] == ["allowed"]
+    assert [
+        event
+        for event in aligned_events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, promoted_lower_key}
+    ] == []
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        aligned_events, shadow_key=blocked_top_key
+    )
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        aligned_events, shadow_key=promoted_lower_key
+    )
+    _assert_single_ranked_selection_event_payload(
+        journal_aligned,
+        remaining_slots="0",
+        candidate_count="1",
+        selected_count="1",
+        loser_count="0",
+        selected_shadow_keys=[promoted_lower_key],
+        loser_shadow_keys=[],
+    )
+    active_open_keys_aligned = sorted(
+        row.correlation_key
+        for row in repository_aligned.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys_aligned == sorted([active_b_key, promoted_lower_key])
+    _assert_no_durable_artifacts_for_shadow_key(repository_aligned, shadow_key=blocked_top_key)
 
     with monkeypatch.context() as context:
-        result_permission_only = _run_exact_deferred_ranked_diagnostic_case(
+        (
+            execution_shifted,
+            repository_shifted,
+            _,
+            journal_shifted,
+            active_a_key_shifted,
+            active_b_key_shifted,
+            blocked_top_key_shifted,
+            promoted_lower_key_shifted,
+        ) = _execute_exact_deferred_ranked_seam_case(
             monkeypatch=context,
             seed_mode="runtime_seeded",
-            apply_permission_patch=True,
-            apply_future_close_patch=False,
+            shift_deferred_signal_timestamps=True,
         )
-    assert result_permission_only["request_keys"] == [
-        str(result_permission_only["active_a_key"]),
-        str(result_permission_only["active_b_key"]),
-        str(result_permission_only["active_a_key"]),
+    assert _request_shadow_keys(execution_shifted.requests) == [
+        active_a_key_shifted,
+        active_b_key_shifted,
+        active_a_key_shifted,
     ]
-    assert result_permission_only["request_sides"] == ["BUY", "BUY", "SELL"]
-    assert result_permission_only["active_a_order_path_present"] is True
-    assert result_permission_only["blocked_top_order_path_present"] is False
-    assert result_permission_only["promoted_lower_order_path_present"] is False
-    assert result_permission_only["blocked_top_enforcement_statuses"] == []
-    assert result_permission_only["promoted_lower_enforcement_statuses"] == []
-    assert result_permission_only["blocked_top_skips"] == ["autonomous_open_active_budget_ranked_loser"]
-    assert result_permission_only["promoted_lower_skips"] == [
-        "autonomous_open_active_budget_ranked_loser"
-    ]
-    assert result_permission_only["ranked_event_count"] == 1
-    assert result_permission_only["ranked_selected_shadow_keys"] == []
-    assert result_permission_only["ranked_loser_shadow_keys"] == [
-        str(result_permission_only["blocked_top_key"]),
-        str(result_permission_only["promoted_lower_key"]),
-    ]
-    assert result_permission_only["active_open_keys"] == [str(result_permission_only["active_b_key"])]
-
-    with monkeypatch.context() as context:
-        result_permission_plus_future = _run_exact_deferred_ranked_diagnostic_case(
-            monkeypatch=context,
-            seed_mode="runtime_seeded",
-            apply_permission_patch=True,
-            apply_future_close_patch=True,
-        )
-    assert result_permission_plus_future["request_keys"] == [
-        str(result_permission_plus_future["active_a_key"]),
-        str(result_permission_plus_future["active_b_key"]),
-        str(result_permission_plus_future["active_a_key"]),
-    ]
-    assert result_permission_plus_future["request_sides"] == ["BUY", "BUY", "SELL"]
-    assert result_permission_plus_future["active_a_order_path_present"] is True
-    assert result_permission_plus_future["blocked_top_order_path_present"] is False
-    assert result_permission_plus_future["promoted_lower_order_path_present"] is False
-    assert result_permission_plus_future["blocked_top_enforcement_statuses"] == ["blocked"]
-    assert result_permission_plus_future["promoted_lower_enforcement_statuses"] == ["blocked"]
-    assert result_permission_plus_future["blocked_top_skips"] == []
-    assert result_permission_plus_future["promoted_lower_skips"] == []
-    assert result_permission_plus_future["ranked_event_count"] == 0
-    assert result_permission_plus_future["ranked_selected_shadow_keys"] == []
-    assert result_permission_plus_future["ranked_loser_shadow_keys"] == []
-    assert result_permission_plus_future["active_open_keys"] == [
-        str(result_permission_plus_future["active_b_key"])
-    ]
+    assert [request.side for request in execution_shifted.requests] == ["BUY", "BUY", "SELL"]
+    assert _order_path_events_with_shadow_key(journal_shifted, blocked_top_key_shifted) == []
+    assert _order_path_events_with_shadow_key(journal_shifted, promoted_lower_key_shifted) == []
+    shifted_events = list(journal_shifted.export())
+    assert [
+        str(event.get("status") or "")
+        for event in shifted_events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == blocked_top_key_shifted
+    ] == ["blocked"]
+    assert [
+        str(event.get("status") or "")
+        for event in shifted_events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == promoted_lower_key_shifted
+    ] == ["blocked"]
+    assert [
+        event
+        for event in shifted_events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key_shifted, promoted_lower_key_shifted}
+    ] == []
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        shifted_events, shadow_key=blocked_top_key_shifted
+    )
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        shifted_events, shadow_key=promoted_lower_key_shifted
+    )
+    assert _ranked_selection_events(journal_shifted) == []
+    active_open_keys_shifted = sorted(
+        row.correlation_key
+        for row in repository_shifted.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys_shifted == [active_b_key_shifted]
+    _assert_no_durable_artifacts_for_shadow_key(repository_shifted, shadow_key=blocked_top_key_shifted)
+    _assert_no_durable_artifacts_for_shadow_key(repository_shifted, shadow_key=promoted_lower_key_shifted)
 
 
 def test_opportunity_autonomy_active_budget_ranked_mode_reverse_specific_one_filled_one_rejected_close_keeps_deferred_paths_as_ranked_losers() -> (


### PR DESCRIPTION
### Motivation
- Simplify and generalize the deferred-ranked diagnostic test helper to make signal timing easier to vary and to return test artifacts for richer assertions.
- Consolidate permission and future-close monkeypatch logic so tests can assert journal and repository state directly.
- Add explicit checks to ensure no residue metadata is left on unrelated events for a given shadow key.

### Description
- Renamed and refactored ` _run_exact_deferred_ranked_diagnostic_case` to ` _execute_exact_deferred_ranked_seam_case` and changed its signature to accept `shift_deferred_signal_timestamps: bool` and to return the execution service, repository, controller, journal and shadow keys tuple instead of an aggregated dict.
- Reworked timestamp setup for deferred signals to depend on `shift_deferred_signal_timestamps` and removed the old boolean flags `apply_permission_patch` and `apply_future_close_patch` in favor of always applying the monkeypatches inside the helper.
- Centralized the `_ForcedPermission` class and `_forced_permission_evaluation` monkeypatch and the `_has_future_potential_slot_releasing_close` monkeypatch inside the helper.
- Replaced previous aggregated return payload with direct use of returned objects in tests, and added a new assertion helper ` _assert_no_duplicate_residue_metadata_for_shadow_key` to validate that no duplicate/leftover metadata fields exist for events related to a shadow key.
- Updated multiple tests (`test_opportunity_autonomy_active_budget_ranked_repo_seeded_seam_diagnostic` and `test_opportunity_autonomy_active_budget_ranked_runtime_seeded_seam_diagnostic`) to use the new helper return values and to assert event-level details, request lists, and repository state directly.

### Testing
- Ran the modified unit tests under `pytest` for the affected test module `tests/test_trading_controller.py` that exercise deferred-ranked seam diagnostics, and they passed locally.
- Verified the new helper-based assertions and ` _assert_no_duplicate_residue_metadata_for_shadow_key` checks executed successfully against the produced `journal` export events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2e80d95c832a97046b0b83121633)