### PR TITLE
Add close-ranked autonomy tests for tracker scope and exhaustion states

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -26832,6 +26832,848 @@ def test_opportunity_autonomy_close_ranked_execution_path_is_scope_agnostic_for_
     _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
 
 
+
+
+def test_opportunity_autonomy_close_ranked_execution_path_same_scope_non_autonomous_existing_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 21, 9, 0, tzinfo=timezone.utc)
+    close_target_key = "close-ranked-execution-same-scope-non-autonomous-target"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_assisted",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = None
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        lambda self, *, signal, request: (
+            _ForcedPermission(allowed=True),
+            {"autonomy_mode": "paper_autonomous"},
+        ),
+    )
+
+    results = controller.process_signals([close_signal])
+
+    assert _request_shadow_keys(execution.requests) == [close_target_key]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    events = list(journal.export())
+    order_path_events = _order_path_events_with_shadow_key(journal, close_target_key)
+    assert order_path_events
+    assert any(
+        event.get("event") == "order_executed"
+        and str(event.get("side") or "").upper() == "SELL"
+        for event in order_path_events
+    )
+    assert len(results) == 1
+    assert str(results[0].status or "").strip().lower() == "filled"
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == []
+    assert [
+        str(event.get("status") or "")
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["allowed"]
+    attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert len(attach_events) == 1
+    assert (
+        str(attach_events[0].get("order_opportunity_shadow_record_key") or "").strip()
+        == close_target_key
+    )
+    assert str(attach_events[0].get("proxy_correlation_key") or "").strip() == close_target_key
+    assert str(attach_events[0].get("existing_open_correlation_key") or "").strip() == ""
+    assert str(attach_events[0].get("status") or "").strip() == "conflict_rejected"
+    assert str(attach_events[0].get("execution_status") or "").strip() == "filled"
+    assert _ranked_selection_events(journal) == []
+    active_open_keys = sorted(
+        row.correlation_key for row in repository.load_open_outcomes() if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == []
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+
+
+def test_opportunity_autonomy_close_ranked_execution_path_same_scope_exhausted_existing_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 21, 9, 0, tzinfo=timezone.utc)
+    close_target_key = "close-ranked-execution-same-scope-exhausted-target"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            entry_quantity=1.0,
+            closed_quantity=1.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = None
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        lambda self, *, signal, request: (
+            _ForcedPermission(allowed=True),
+            {"autonomy_mode": "paper_autonomous"},
+        ),
+    )
+
+    results = controller.process_signals([close_signal])
+
+    assert _request_shadow_keys(execution.requests) == []
+    assert [request.side for request in execution.requests] == []
+    events = list(journal.export())
+    assert results == []
+    assert _order_path_events_with_shadow_key(journal, close_target_key) == []
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] and [
+        str(event.get("reason") or "")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["restored_tracker_remaining_quantity_exhausted_suppressed"]
+    assert [
+        str(event.get("status") or "")
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["allowed"]
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ] == []
+    assert _ranked_selection_events(journal) == []
+    active_open_keys = sorted(
+        row.correlation_key for row in repository.load_open_outcomes() if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == []
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity == close_rows[0].entry_quantity
+    key_events = [
+        event
+        for event in events
+        if (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+            or str(event.get("existing_open_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert key_events
+    assert all(
+        str(event.get("existing_open_correlation_key") or "").strip() != close_target_key
+        for event in key_events
+    )
+
+
+def test_opportunity_autonomy_close_ranked_execution_path_same_scope_exhausted_non_autonomous_existing_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 21, 9, 0, tzinfo=timezone.utc)
+    close_target_key = "close-ranked-execution-same-scope-exhausted-non-autonomous-target"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            entry_quantity=1.0,
+            closed_quantity=1.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_assisted",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = None
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        lambda self, *, signal, request: (
+            _ForcedPermission(allowed=True),
+            {"autonomy_mode": "paper_autonomous"},
+        ),
+    )
+
+    results = controller.process_signals([close_signal])
+
+    assert _request_shadow_keys(execution.requests) == [close_target_key]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    events = list(journal.export())
+    order_path_events = _order_path_events_with_shadow_key(journal, close_target_key)
+    assert order_path_events
+    assert any(
+        event.get("event") == "order_executed"
+        and str(event.get("side") or "").upper() == "SELL"
+        for event in order_path_events
+    )
+    assert len(results) == 1
+    assert str(results[0].status or "").strip().lower() == "filled"
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == []
+    assert [
+        str(event.get("status") or "")
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["allowed"]
+    attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert len(attach_events) == 1
+    assert (
+        str(attach_events[0].get("order_opportunity_shadow_record_key") or "").strip()
+        == close_target_key
+    )
+    assert str(attach_events[0].get("proxy_correlation_key") or "").strip() == close_target_key
+    assert str(attach_events[0].get("existing_open_correlation_key") or "").strip() == ""
+    assert str(attach_events[0].get("status") or "").strip() == "conflict_rejected"
+    assert str(attach_events[0].get("execution_status") or "").strip() == "filled"
+    assert _ranked_selection_events(journal) == []
+    active_open_keys = sorted(
+        row.correlation_key for row in repository.load_open_outcomes() if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == []
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+
+
+@pytest.mark.parametrize(
+    ("tracker_environment", "tracker_portfolio"),
+    [
+        ("live", "live-1"),
+        ("paper", "paper-foreign"),
+    ],
+)
+def test_opportunity_autonomy_close_ranked_execution_path_foreign_scope_exhausted_autonomous_existing_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker_environment: str,
+    tracker_portfolio: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 21, 9, 0, tzinfo=timezone.utc)
+    close_target_key = "close-ranked-execution-foreign-scope-exhausted-autonomous-target"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            entry_quantity=1.0,
+            closed_quantity=1.0,
+            provenance={
+                "environment": tracker_environment,
+                "portfolio": tracker_portfolio,
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = None
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        lambda self, *, signal, request: (
+            _ForcedPermission(allowed=True),
+            {"autonomy_mode": "paper_autonomous"},
+        ),
+    )
+
+    results = controller.process_signals([close_signal])
+
+    assert _request_shadow_keys(execution.requests) == []
+    assert [request.side for request in execution.requests] == []
+    events = list(journal.export())
+    assert results == []
+    assert _order_path_events_with_shadow_key(journal, close_target_key) == []
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] and [
+        str(event.get("reason") or "")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["restored_tracker_remaining_quantity_exhausted_suppressed"]
+    assert [
+        str(event.get("status") or "")
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["allowed"]
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ] == []
+    assert _ranked_selection_events(journal) == []
+    active_open_keys = sorted(
+        row.correlation_key for row in repository.load_open_outcomes() if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == []
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity == close_rows[0].entry_quantity
+    key_events = [
+        event
+        for event in events
+        if (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+            or str(event.get("existing_open_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert key_events
+    assert all(
+        str(event.get("existing_open_correlation_key") or "").strip() != close_target_key
+        for event in key_events
+    )
+
+
+@pytest.mark.parametrize(
+    ("tracker_environment", "tracker_portfolio"),
+    [
+        ("live", "live-1"),
+        ("paper", "paper-foreign"),
+    ],
+)
+def test_opportunity_autonomy_close_ranked_execution_path_foreign_scope_exhausted_non_autonomous_existing_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker_environment: str,
+    tracker_portfolio: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 21, 9, 0, tzinfo=timezone.utc)
+    close_target_key = "close-ranked-execution-foreign-scope-exhausted-non-autonomous-target"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            entry_quantity=1.0,
+            closed_quantity=1.0,
+            provenance={
+                "environment": tracker_environment,
+                "portfolio": tracker_portfolio,
+                "autonomy_final_mode": "paper_assisted",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = None
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        lambda self, *, signal, request: (
+            _ForcedPermission(allowed=True),
+            {"autonomy_mode": "paper_autonomous"},
+        ),
+    )
+
+    results = controller.process_signals([close_signal])
+
+    assert _request_shadow_keys(execution.requests) == [close_target_key]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    events = list(journal.export())
+    order_path_events = _order_path_events_with_shadow_key(journal, close_target_key)
+    assert order_path_events
+    assert any(
+        event.get("event") == "order_executed"
+        and str(event.get("side") or "").upper() == "SELL"
+        for event in order_path_events
+    )
+    assert len(results) == 1
+    assert str(results[0].status or "").strip().lower() == "filled"
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == []
+    assert [
+        str(event.get("status") or "")
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["allowed"]
+    attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert len(attach_events) == 1
+    assert (
+        str(attach_events[0].get("order_opportunity_shadow_record_key") or "").strip()
+        == close_target_key
+    )
+    assert str(attach_events[0].get("proxy_correlation_key") or "").strip() == close_target_key
+    assert str(attach_events[0].get("existing_open_correlation_key") or "").strip() == ""
+    assert str(attach_events[0].get("status") or "").strip() == "conflict_rejected"
+    assert str(attach_events[0].get("execution_status") or "").strip() == "filled"
+    assert _ranked_selection_events(journal) == []
+    active_open_keys = sorted(
+        row.correlation_key for row in repository.load_open_outcomes() if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == []
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+
+
+@pytest.mark.parametrize(
+    ("tracker_environment", "tracker_portfolio"),
+    [
+        ("live", "live-1"),
+        ("paper", "paper-foreign"),
+    ],
+)
+def test_opportunity_autonomy_close_ranked_execution_path_foreign_scope_active_non_autonomous_existing_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker_environment: str,
+    tracker_portfolio: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 21, 9, 0, tzinfo=timezone.utc)
+    close_target_key = "close-ranked-execution-foreign-scope-active-non-autonomous-target"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": tracker_environment,
+                "portfolio": tracker_portfolio,
+                "autonomy_final_mode": "paper_assisted",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = None
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        lambda self, *, signal, request: (
+            _ForcedPermission(allowed=True),
+            {"autonomy_mode": "paper_autonomous"},
+        ),
+    )
+
+    results = controller.process_signals([close_signal])
+
+    assert _request_shadow_keys(execution.requests) == [close_target_key]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    events = list(journal.export())
+    order_path_events = _order_path_events_with_shadow_key(journal, close_target_key)
+    assert order_path_events
+    assert any(
+        event.get("event") == "order_executed"
+        and str(event.get("side") or "").upper() == "SELL"
+        for event in order_path_events
+    )
+    assert len(results) == 1
+    assert str(results[0].status or "").strip().lower() == "filled"
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == []
+    assert [
+        str(event.get("status") or "")
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["allowed"]
+    attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert len(attach_events) == 1
+    assert (
+        str(attach_events[0].get("order_opportunity_shadow_record_key") or "").strip()
+        == close_target_key
+    )
+    assert str(attach_events[0].get("proxy_correlation_key") or "").strip() == close_target_key
+    assert str(attach_events[0].get("existing_open_correlation_key") or "").strip() == ""
+    assert str(attach_events[0].get("status") or "").strip() == "conflict_rejected"
+    assert str(attach_events[0].get("execution_status") or "").strip() == "filled"
+    assert _ranked_selection_events(journal) == []
+    active_open_keys = sorted(
+        row.correlation_key for row in repository.load_open_outcomes() if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == []
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+
 def test_opportunity_autonomy_active_budget_ranked_mode_reverse_specific_one_filled_one_rejected_close_keeps_deferred_paths_as_ranked_losers() -> (
     None
 ):


### PR DESCRIPTION
### Motivation
- Increase test coverage for close-ranked autonomy execution paths across tracker scope variants and tracker exhaustion states. 
- Validate behavior differences when restored tracker provenance is `paper_autonomous` vs `paper_assisted` and when tracker records are active vs exhausted. 
- Ensure enforcement events, signal skipping reasons, attach metadata, and open-outcome state integrity are correct for these scenarios.

### Description
- Added a set of new tests to `tests/test_trading_controller.py` that cover same-scope and foreign-scope tracker combinations and both autonomous and non-autonomous provenance variants, including exhausted and active tracker states. 
- New test functions include patterns such as `test_opportunity_autonomy_close_ranked_execution_path_same_scope_*`, `test_opportunity_autonomy_close_ranked_execution_path_foreign_scope_*`, and parameterized variants for tracker environments/portfolios. 
- Tests construct shadow repositories and open-outcome states, use `SequencedExecutionService` for deterministic execution simulation, and monkeypatch `TradingController._evaluate_opportunity_execution_permission` with a `_ForcedPermission` helper to control permission outcomes. 
- Each test asserts on execution requests (`_request_shadow_keys` / request sides), exported journal events (order/execution events, `opportunity_autonomy_enforcement`, `signal_skipped`, and `opportunity_outcome_attach`), and repository state (open outcomes and no duplicate residue metadata).

### Testing
- Ran a targeted pytest invocation: `pytest -q tests/test_trading_controller.py -k "close_ranked_execution_path_same_scope_non_autonomous_existing_tracker or close_ranked_execution_path_same_scope_exhausted_existing_tracker or close_ranked_execution_path_same_scope_exhausted_non_autonomous_existing_tracker or close_ranked_execution_path_foreign_scope_exhausted_autonomous_existing_tracker or close_ranked_execution_path_foreign_scope_exhausted_non_autonomous_existing_tracker or close_ranked_execution_path_foreign_scope_active_non_autonomous_existing_tracker"` which attempted to collect and run the new tests. 
- Test collection failed with an import error (`ModuleNotFoundError: No module named 'numpy'`) in this environment, so the new tests were not executed to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8d5b02b8832a84c248b1263a6b2e)