### PR TITLE
Add comprehensive tests for ranked autonomy selection, close_ranked behavior, and cross-scope tracker handling

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -13992,6 +13992,265 @@ def test_opportunity_autonomy_active_budget_ranked_close_ranked_same_scope_non_a
     _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
 
 
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_same_scope_exhausted_non_autonomous_tracker_future_close_executes_but_does_not_unlock_deferred_fallback_batch_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 20, 11, 7, tzinfo=timezone.utc)
+    active_local_key = "same-scope-exhausted-manual-anchor"
+    exhausted_non_autonomous_target_key = "same-scope-exhausted-manual-target"
+    blocked_top_key = "same-scope-exhausted-manual-blocked-top"
+    promoted_lower_key = "same-scope-exhausted-manual-promoted-lower"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_local_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            ),
+            _shadow_record_for_key(
+                correlation_key=exhausted_non_autonomous_target_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=promoted_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_local_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=3),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=exhausted_non_autonomous_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=101.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            entry_quantity=1.0,
+            closed_quantity=1.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_assisted",
+                "autonomy_requested_mode": "paper_assisted",
+                "autonomy_upstream_effective_mode": "paper_assisted",
+                "autonomy_local_guard_effective_mode": "paper_assisted",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 90.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 2.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    promoted_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=promoted_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    promoted_lower_signal.symbol = "SOL/USDT"
+    promoted_lower_signal.metadata = {
+        **dict(promoted_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+    close_exhausted_non_autonomous_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=exhausted_non_autonomous_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+    )
+    close_exhausted_non_autonomous_signal.metadata = {
+        **dict(close_exhausted_non_autonomous_signal.metadata),
+        "mode": "close_ranked",
+    }
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+
+    controller.process_signals(
+        [blocked_top_signal, promoted_lower_signal, close_exhausted_non_autonomous_signal]
+    )
+
+    assert _request_shadow_keys(execution.requests) == [exhausted_non_autonomous_target_key]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    events = list(journal.export())
+    assert _order_path_events_with_shadow_key(journal, exhausted_non_autonomous_target_key)
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, promoted_lower_key) == []
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == promoted_lower_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, promoted_lower_key}
+    ] == []
+    blocked_top_attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+            or str(event.get("proxy_correlation_key") or "").strip() == blocked_top_key
+        )
+    ]
+    assert blocked_top_attach_events == []
+    promoted_lower_attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            == promoted_lower_key
+            or str(event.get("proxy_correlation_key") or "").strip() == promoted_lower_key
+        )
+    ]
+    assert promoted_lower_attach_events == []
+    close_attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            == exhausted_non_autonomous_target_key
+            or str(event.get("proxy_correlation_key") or "").strip()
+            == exhausted_non_autonomous_target_key
+        )
+    ]
+    assert len(close_attach_events) == 1
+    assert str(close_attach_events[0].get("status") or "").strip() == "conflict_rejected"
+    assert str(close_attach_events[0].get("execution_status") or "").strip() == "filled"
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="0",
+        candidate_count="2",
+        selected_count="0",
+        loser_count="2",
+        selected_shadow_keys=[],
+        loser_shadow_keys=[blocked_top_key, promoted_lower_key],
+    )
+    active_open_keys = sorted(
+        row.correlation_key
+        for row in repository.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == [active_local_key]
+    close_rows = [
+        row
+        for row in repository.load_open_outcomes()
+        if row.correlation_key == exhausted_non_autonomous_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        events, shadow_key=exhausted_non_autonomous_target_key
+    )
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=promoted_lower_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
+
+
 def test_opportunity_autonomy_active_budget_ranked_close_ranked_same_scope_active_autonomous_tracker_future_close_unlocks_deferred_fallback_batch_level(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -26685,6 +26944,590 @@ def test_opportunity_autonomy_active_budget_ranked_close_ranked_same_environment
 
 
 @pytest.mark.parametrize(
+    ("foreign_environment", "foreign_portfolio"),
+    [
+        ("live", "live-1"),
+        ("paper", "paper-foreign"),
+    ],
+)
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_foreign_scope_exhausted_non_autonomous_future_close_executes_but_does_not_unlock_deferred_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    foreign_environment: str,
+    foreign_portfolio: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 12, 16, 10, tzinfo=timezone.utc)
+    active_local_key = f"foreign-exhausted-non-auton-anchor-{foreign_environment}-{foreign_portfolio}"
+    blocked_top_key = (
+        f"foreign-exhausted-non-auton-blocked-{foreign_environment}-{foreign_portfolio}"
+    )
+    promoted_lower_key = (
+        f"foreign-exhausted-non-auton-lower-{foreign_environment}-{foreign_portfolio}"
+    )
+    foreign_exhausted_open_key = (
+        f"foreign-exhausted-non-auton-close-{foreign_environment}-{foreign_portfolio}"
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    shadow_context = (
+        OpportunityShadowContext(environment=foreign_environment)
+        if foreign_environment != "paper"
+        else None
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_local_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=promoted_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=foreign_exhausted_open_key,
+                    decision_timestamp=decision_timestamp - timedelta(minutes=1),
+                ),
+                symbol="BTC/USDT",
+                context=shadow_context or OpportunityShadowContext(environment="paper"),
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_local_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=3),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=foreign_exhausted_open_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=95.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            entry_quantity=1.0,
+            closed_quantity=1.0,
+            provenance={
+                "environment": foreign_environment,
+                "portfolio": foreign_portfolio,
+                "autonomy_final_mode": "paper_assisted",
+                "autonomy_requested_mode": "paper_assisted",
+                "autonomy_upstream_effective_mode": "paper_assisted",
+                "autonomy_local_guard_effective_mode": "paper_assisted",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 90.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 2.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    promoted_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=promoted_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    promoted_lower_signal.symbol = "SOL/USDT"
+    promoted_lower_signal.metadata = {
+        **dict(promoted_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+    close_foreign_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=foreign_exhausted_open_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+    )
+    close_foreign_signal.metadata = {**dict(close_foreign_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+
+    results = controller.process_signals(
+        [blocked_top_signal, promoted_lower_signal, close_foreign_signal]
+    )
+    request_keys = _request_shadow_keys(execution.requests)
+    assert request_keys == [foreign_exhausted_open_key]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    assert len(results) == 1
+    assert str(results[0].status or "").strip().lower() == "filled"
+
+    events = list(journal.export())
+    assert _order_path_events_with_shadow_key(journal, foreign_exhausted_open_key)
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, promoted_lower_key) == []
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == promoted_lower_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, promoted_lower_key}
+    ] == []
+    blocked_top_attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+            or str(event.get("proxy_correlation_key") or "").strip() == blocked_top_key
+        )
+    ]
+    assert blocked_top_attach_events == []
+    promoted_lower_attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            == promoted_lower_key
+            or str(event.get("proxy_correlation_key") or "").strip() == promoted_lower_key
+        )
+    ]
+    assert promoted_lower_attach_events == []
+    close_attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            == foreign_exhausted_open_key
+            or str(event.get("proxy_correlation_key") or "").strip() == foreign_exhausted_open_key
+        )
+    ]
+    assert len(close_attach_events) == 1
+    assert str(close_attach_events[0].get("status") or "").strip() == "conflict_rejected"
+    assert str(close_attach_events[0].get("execution_status") or "").strip() == "filled"
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="0",
+        candidate_count="2",
+        selected_count="0",
+        loser_count="2",
+        selected_shadow_keys=[],
+        loser_shadow_keys=[blocked_top_key, promoted_lower_key],
+    )
+    active_open_keys = sorted(
+        row.correlation_key
+        for row in repository.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == [active_local_key]
+    close_rows = [
+        row
+        for row in repository.load_open_outcomes()
+        if row.correlation_key == foreign_exhausted_open_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=foreign_exhausted_open_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=promoted_lower_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
+
+
+@pytest.mark.parametrize(
+    ("foreign_environment", "foreign_portfolio"),
+    [
+        ("live", "live-1"),
+        ("paper", "paper-foreign"),
+    ],
+)
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_foreign_scope_exhausted_autonomous_future_close_is_suppressed_and_does_not_unlock_deferred_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    foreign_environment: str,
+    foreign_portfolio: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 12, 16, 15, tzinfo=timezone.utc)
+    active_local_key = (
+        f"foreign-exhausted-auton-anchor-{foreign_environment}-{foreign_portfolio}"
+    )
+    blocked_top_key = (
+        f"foreign-exhausted-auton-blocked-{foreign_environment}-{foreign_portfolio}"
+    )
+    promoted_lower_key = (
+        f"foreign-exhausted-auton-lower-{foreign_environment}-{foreign_portfolio}"
+    )
+    foreign_exhausted_open_key = (
+        f"foreign-exhausted-auton-close-{foreign_environment}-{foreign_portfolio}"
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    shadow_context = (
+        OpportunityShadowContext(environment=foreign_environment)
+        if foreign_environment != "paper"
+        else None
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_local_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=promoted_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=foreign_exhausted_open_key,
+                    decision_timestamp=decision_timestamp - timedelta(minutes=1),
+                ),
+                symbol="BTC/USDT",
+                context=shadow_context or OpportunityShadowContext(environment="paper"),
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_local_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=3),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=foreign_exhausted_open_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=95.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            entry_quantity=1.0,
+            closed_quantity=1.0,
+            provenance={
+                "environment": foreign_environment,
+                "portfolio": foreign_portfolio,
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 90.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 2.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    promoted_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=promoted_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    promoted_lower_signal.symbol = "SOL/USDT"
+    promoted_lower_signal.metadata = {
+        **dict(promoted_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+    close_foreign_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=foreign_exhausted_open_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+    )
+    close_foreign_signal.metadata = {**dict(close_foreign_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+
+    results = controller.process_signals(
+        [blocked_top_signal, promoted_lower_signal, close_foreign_signal]
+    )
+
+    request_keys = _request_shadow_keys(execution.requests)
+    assert request_keys == []
+    assert [request.side for request in execution.requests] == []
+    assert results == []
+
+    events = list(journal.export())
+    assert _order_path_events_with_shadow_key(journal, foreign_exhausted_open_key) == []
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, promoted_lower_key) == []
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == foreign_exhausted_open_key
+    ] == ["restored_tracker_remaining_quantity_exhausted_suppressed"]
+    enforcement_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == foreign_exhausted_open_key
+    ]
+    assert len(enforcement_events) == 1
+    assert str(enforcement_events[0].get("status") or "").strip() == "allowed"
+    assert str(enforcement_events[0].get("execution_permission") or "").strip() == "allowed"
+    assert str(enforcement_events[0].get("autonomous_execution_allowed") or "").strip() == "true"
+    assert str(enforcement_events[0].get("autonomy_mode") or "").strip() == "paper_autonomous"
+    assert str(enforcement_events[0].get("proxy_correlation_key") or "").strip() == ""
+    assert str(enforcement_events[0].get("existing_open_correlation_key") or "").strip() == ""
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == promoted_lower_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, promoted_lower_key}
+    ] == []
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            in {blocked_top_key, promoted_lower_key, foreign_exhausted_open_key}
+            or str(event.get("proxy_correlation_key") or "").strip()
+            in {blocked_top_key, promoted_lower_key, foreign_exhausted_open_key}
+        )
+    ] == []
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="0",
+        candidate_count="2",
+        selected_count="0",
+        loser_count="2",
+        selected_shadow_keys=[],
+        loser_shadow_keys=[blocked_top_key, promoted_lower_key],
+    )
+    active_open_keys = sorted(
+        row.correlation_key
+        for row in repository.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == [active_local_key]
+    close_rows = [
+        row
+        for row in repository.load_open_outcomes()
+        if row.correlation_key == foreign_exhausted_open_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity == close_rows[0].entry_quantity
+    foreign_key_events = [
+        event
+        for event in events
+        if (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            == foreign_exhausted_open_key
+            or str(event.get("proxy_correlation_key") or "").strip() == foreign_exhausted_open_key
+            or str(event.get("existing_open_correlation_key") or "").strip()
+            == foreign_exhausted_open_key
+        )
+    ]
+    assert foreign_key_events
+    assert {
+        str(event.get("event") or "").strip()
+        for event in foreign_key_events
+    } <= {"signal_received", "opportunity_autonomy_enforcement", "signal_skipped"}
+    suppression_events = [
+        event
+        for event in foreign_key_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+    ]
+    assert len(suppression_events) == 1
+    assert (
+        str(suppression_events[0].get("proxy_correlation_key") or "").strip()
+        == foreign_exhausted_open_key
+    )
+    assert str(suppression_events[0].get("existing_open_correlation_key") or "").strip() == ""
+    assert all(
+        str(event.get("existing_open_correlation_key") or "").strip() != foreign_exhausted_open_key
+        for event in foreign_key_events
+    )
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=promoted_lower_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
+
+@pytest.mark.parametrize(
     ("runtime_environment", "tracker_environment", "tracker_portfolio"),
     [
         ("paper", "live", "live-1"),
@@ -27239,6 +28082,178 @@ def test_opportunity_autonomy_close_ranked_execution_path_same_scope_exhausted_n
     assert len(close_rows) == 1
     assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity
     _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+
+
+@pytest.mark.parametrize(
+    ("case_suffix", "autonomy_final_mode", "closed_quantity", "expect_execute"),
+    [
+        ("active-autonomous", "paper_autonomous", 0.0, True),
+        ("active-non-autonomous", "paper_assisted", 0.0, True),
+        ("exhausted-autonomous", "paper_autonomous", 1.0, False),
+        ("exhausted-non-autonomous", "paper_assisted", 1.0, True),
+    ],
+)
+def test_opportunity_autonomy_close_ranked_execution_path_same_scope_existing_tracker_exhaustion_contract_switch_depends_on_autonomous_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    case_suffix: str,
+    autonomy_final_mode: str,
+    closed_quantity: float,
+    expect_execute: bool,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 21, 9, 30, tzinfo=timezone.utc)
+    close_target_key = f"close-ranked-exhaustion-contract-switch-{case_suffix}"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            entry_quantity=1.0,
+            closed_quantity=closed_quantity,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": autonomy_final_mode,
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = None
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        lambda self, *, signal, request: (
+            _ForcedPermission(allowed=True),
+            {"autonomy_mode": "paper_autonomous"},
+        ),
+    )
+
+    results = controller.process_signals([close_signal])
+    events = list(journal.export())
+
+    if expect_execute:
+        assert _request_shadow_keys(execution.requests) == [close_target_key]
+        assert [request.side for request in execution.requests] == ["SELL"]
+        assert len(results) == 1
+        assert str(results[0].status or "").strip().lower() == "filled"
+        order_path_events = _order_path_events_with_shadow_key(journal, close_target_key)
+        assert order_path_events
+        assert any(
+            event.get("event") == "order_executed"
+            and str(event.get("side") or "").upper() == "SELL"
+            for event in order_path_events
+        )
+        assert [
+            event
+            for event in events
+            if event.get("event") == "signal_skipped"
+            and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            == close_target_key
+        ] == []
+        attach_events = [
+            event
+            for event in events
+            if event.get("event") == "opportunity_outcome_attach"
+            and (
+                str(event.get("order_opportunity_shadow_record_key") or "").strip()
+                == close_target_key
+                or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+            )
+        ]
+        assert len(attach_events) == 1
+        assert str(attach_events[0].get("status") or "").strip() == "conflict_rejected"
+        assert str(attach_events[0].get("execution_status") or "").strip() == "filled"
+    else:
+        assert _request_shadow_keys(execution.requests) == []
+        assert [request.side for request in execution.requests] == []
+        assert results == []
+        assert _order_path_events_with_shadow_key(journal, close_target_key) == []
+        assert [
+            str(event.get("reason") or "")
+            for event in events
+            if event.get("event") == "signal_skipped"
+            and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            == close_target_key
+        ] == ["restored_tracker_remaining_quantity_exhausted_suppressed"]
+        assert [
+            event
+            for event in events
+            if event.get("event") == "opportunity_outcome_attach"
+            and (
+                str(event.get("order_opportunity_shadow_record_key") or "").strip()
+                == close_target_key
+                or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+            )
+        ] == []
+
+    assert [
+        str(event.get("status") or "")
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == ["allowed"]
+    assert _ranked_selection_events(journal) == []
+    active_open_keys = sorted(
+        row.correlation_key
+        for row in repository.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == []
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    if expect_execute:
+        assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity
+    else:
+        assert close_rows[0].closed_quantity == close_rows[0].entry_quantity
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

- Add coverage to ensure correct behavior of ranked open selection and `close_ranked` signals when active autonomy budget constraints interact with existing trackers and cross-scope (foreign environment/portfolio) trackers.
- Validate suppression vs execution behavior for exhausted vs active trackers and for autonomous vs non-autonomous provenance when deciding whether a `close_ranked` should run or be suppressed. 

### Description

- Add multiple new tests to `tests/test_trading_controller.py` covering scenarios including same-scope and foreign-scope interactions, exhausted vs active trackers, and autonomous vs non-autonomous provenance such as `test_opportunity_autonomy_active_budget_ranked_close_ranked_same_scope_exhausted_non_autonomous_tracker_future_close_executes_but_does_not_unlock_deferred_fallback_batch_level` and several parametrized foreign-scope cases.
- Introduce a param rename and new parameterizations to cover `foreign_environment`/`foreign_portfolio` permutations and add a parametrized contract-switch test `test_opportunity_autonomy_close_ranked_execution_path_same_scope_existing_tracker_exhaustion_contract_switch_depends_on_autonomous_contract` to assert execution depends on `autonomy_final_mode` and `closed_quantity`.
- Use a `SequencedExecutionService` test stub and `OpportunityShadowContext` where appropriate and monkeypatch `TradingController._evaluate_opportunity_execution_permission` with a test `*_ForcedPermission` evaluator to simulate allowed/denied autonomous execution paths.
- Add assertions that check journaled events (such as `signal_skipped`, `opportunity_autonomy_enforcement`, and `opportunity_outcome_attach`), repository open-outcome state, and that ranked selection payloads and attach/execution outcomes match expected suppression or execution semantics.

### Testing

- Executed the modified and newly added tests in `tests/test_trading_controller.py` using `pytest` and validated the new scenarios covering same-scope and foreign-scope close/ranked interactions. 
- All added and affected tests completed successfully under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8f85b6dc832aaca8996cd4f6b877)