### PR TITLE
Apply ruff-format tail reflow in tests/test_trading_controller.py

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -28130,7 +28130,9 @@ def test_opportunity_autonomy_close_ranked_exhausted_existing_tracker_permission
         )
         assert active_open_keys == []
         close_rows = [
-            row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+            row
+            for row in repository.load_open_outcomes()
+            if row.correlation_key == close_target_key
         ]
         assert len(close_rows) == 1
         assert close_rows[0].closed_quantity == close_rows[0].entry_quantity
@@ -28138,7 +28140,8 @@ def test_opportunity_autonomy_close_ranked_exhausted_existing_tracker_permission
             event
             for event in events
             if (
-                str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+                str(event.get("order_opportunity_shadow_record_key") or "").strip()
+                == close_target_key
                 or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
                 or str(event.get("existing_open_correlation_key") or "").strip() == close_target_key
             )
@@ -28157,7 +28160,9 @@ def test_opportunity_autonomy_close_ranked_exhausted_existing_tracker_permission
         )
         assert active_open_keys == []
         close_rows = [
-            row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+            row
+            for row in repository.load_open_outcomes()
+            if row.correlation_key == close_target_key
         ]
         assert len(close_rows) == 1
         assert close_rows[0].closed_quantity >= close_rows[0].entry_quantity


### PR DESCRIPTION
### Motivation
- Accept the remaining `ruff-format` reflow drift in `tests/test_trading_controller.py` to satisfy formatter-only changes without touching logic.

### Description
- Reflowed three expressions in `tests/test_trading_controller.py` (two `close_rows` list comprehensions and one wrapped comparison of `order_opportunity_shadow_record_key`) and committed the change, with no semantic or production/test logic modifications.

### Testing
- Ran `python -m pre_commit run --all-files --show-diff-on-failure`, which could not run in this environment due to `No module named pre_commit` (environmental failure). 
- Ran `python -m pytest -q tests/test_trading_controller.py -k "close_ranked_exhausted_existing_tracker_permission" -xvv`, which failed collection due to missing dependency `numpy` (`ModuleNotFoundError`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbb04820c832aa7f680a892766a1f)