### PR TITLE
Add test to ensure permission-blocked close does not unlock deferred fallback for non-autonomous variants

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -14774,6 +14774,322 @@ def test_opportunity_autonomy_active_budget_ranked_close_ranked_same_scope_activ
     _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
 
 
+@pytest.mark.parametrize(
+    ("target_variant", "initial_closed_quantity", "target_autonomy_mode"),
+    [
+        # Keep assisted mode aligned with paper runtime scope; this contract tests
+        # close permission blocking + deferred fallback behavior, not cross-env mode mixing.
+        ("same_scope_non_autonomous", 0.0, "paper_assisted"),
+        ("same_scope_exhausted_non_autonomous", 1.0, "paper_assisted"),
+    ],
+)
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_permission_blocked_future_close_does_not_unlock_deferred_fallback_for_non_autonomous_variants(
+    monkeypatch: pytest.MonkeyPatch,
+    target_variant: str,
+    initial_closed_quantity: float,
+    target_autonomy_mode: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 20, 11, 15, tzinfo=timezone.utc)
+    active_local_key = f"{target_variant}-anchor"
+    close_target_key = f"{target_variant}-close-target"
+    blocked_top_key = f"{target_variant}-blocked-top"
+    promoted_lower_key = f"{target_variant}-promoted-lower"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_local_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            ),
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=promoted_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_local_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=3),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=101.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            entry_quantity=1.0,
+            closed_quantity=initial_closed_quantity,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": target_autonomy_mode,
+                "autonomy_requested_mode": target_autonomy_mode,
+                "autonomy_upstream_effective_mode": target_autonomy_mode,
+                "autonomy_local_guard_effective_mode": target_autonomy_mode,
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 2.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    promoted_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=promoted_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    promoted_lower_signal.symbol = "SOL/USDT"
+    promoted_lower_signal.metadata = {
+        **dict(promoted_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+    close_target_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+    )
+    close_target_signal.metadata = {**dict(close_target_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if shadow_key == close_target_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="test_forced_close_permission_blocked_non_autonomous",
+            ), {"autonomy_mode": "paper_autonomous"}
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+
+    results = controller.process_signals(
+        [blocked_top_signal, promoted_lower_signal, close_target_signal]
+    )
+    assert results == []
+
+    events = list(journal.export())
+    close_enforcement_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ]
+    assert len(close_enforcement_events) == 1
+    close_enforcement = close_enforcement_events[0]
+    assert str(close_enforcement.get("status") or "").strip() == "blocked"
+    assert str(close_enforcement.get("execution_permission") or "").strip() == "blocked"
+    assert str(close_enforcement.get("autonomous_execution_allowed") or "").strip().lower() == "false"
+    assert (
+        str(close_enforcement.get("blocking_reason") or "").strip()
+        == "test_forced_close_permission_blocked_non_autonomous"
+    )
+    assert (
+        str(close_enforcement.get("denial_reason") or "").strip()
+        == "test_forced_close_permission_blocked_non_autonomous"
+    )
+    assert str(close_enforcement.get("autonomy_mode") or "").strip() == "paper_autonomous"
+    assert str(close_enforcement.get("proxy_correlation_key") or "").strip() == ""
+    assert str(close_enforcement.get("existing_open_correlation_key") or "").strip() == ""
+    assert _request_shadow_keys(execution.requests) == []
+    assert [request.side for request in execution.requests] == []
+    assert _order_path_events_with_shadow_key(journal, close_target_key) == []
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, promoted_lower_key) == []
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == []
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("reason") or "").strip()
+        == "restored_tracker_remaining_quantity_exhausted_suppressed"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == []
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ] == []
+    close_key_events = [
+        event
+        for event in events
+        if (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+            or str(event.get("existing_open_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert close_key_events
+    assert str(close_key_events[-1].get("event") or "").strip() == "opportunity_autonomy_enforcement"
+    assert {str(event.get("event") or "").strip() for event in close_key_events} <= {
+        "signal_received",
+        "opportunity_autonomy_enforcement",
+    }
+    assert all(
+        str(event.get("proxy_correlation_key") or "").strip() != close_target_key
+        for event in close_key_events
+    )
+    assert all(
+        str(event.get("existing_open_correlation_key") or "").strip() != close_target_key
+        for event in close_key_events
+    )
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, promoted_lower_key}
+    ] == []
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == promoted_lower_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            in {blocked_top_key, promoted_lower_key}
+            or str(event.get("proxy_correlation_key") or "").strip()
+            in {blocked_top_key, promoted_lower_key}
+        )
+    ] == []
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="0",
+        candidate_count="2",
+        selected_count="0",
+        loser_count="2",
+        selected_shadow_keys=[],
+        loser_shadow_keys=[blocked_top_key, promoted_lower_key],
+    )
+    active_open_keys = sorted(
+        row.correlation_key
+        for row in repository.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    if initial_closed_quantity < 1.0:
+        assert active_open_keys == sorted([active_local_key, close_target_key])
+    else:
+        assert active_open_keys == [active_local_key]
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity == initial_closed_quantity
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=promoted_lower_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
+
+
 @pytest.mark.parametrize("open_partial_status", ["partially_filled", "partial"])
 def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_without_mode_in_same_batch_promotes_deferred_loser_with_exact_proof_event(
     open_partial_status: str,


### PR DESCRIPTION
### Motivation

- Add coverage to verify that a permission-blocked `close_ranked` signal for non-autonomous variants does not enable deferred fallback or change active open position state.
- Verify enforcement events and repository state remain consistent when close permission is denied and other deferred-ranked candidates exist.
- Ensure telemetry and order-request behavior are correct when permission evaluation blocks execution for specific shadow records.

### Description

- Add a parametrized test `test_opportunity_autonomy_active_budget_ranked_close_ranked_permission_blocked_future_close_does_not_unlock_deferred_fallback_for_non_autonomous_variants` to `tests/test_trading_controller.py` covering two non-autonomous target variants and initial closed quantities. 
- Construct a shadow repository, append multiple shadow records, upsert open outcomes, and use `SequencedExecutionService` plus a controller configured with ranked selection priorities to exercise the close/ deferred interactions. 
- Monkeypatch `TradingController._evaluate_opportunity_execution_permission` with a `_forced_permission_evaluation` that forces close permission to be denied for the close target and specific behavior for other shadows, then assert no execution requests and validate journal events and repository state. 

### Testing

- Ran the new test directly with `pytest -q tests/test_trading_controller.py::test_opportunity_autonomy_active_budget_ranked_close_ranked_permission_blocked_future_close_does_not_unlock_deferred_fallback_for_non_autonomous_variants`, and it passed.
- Verified the test assertions for journal event contents, no order requests in `SequencedExecutionService`, and repository open outcome quantities, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece6f11324832a92341a6c7c5d93d5)