### PR TITLE
Add test to ensure permission-blocked foreign close does not unlock deferred fallback

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -15090,6 +15090,341 @@ def test_opportunity_autonomy_active_budget_ranked_close_ranked_permission_block
     _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
 
 
+@pytest.mark.parametrize(
+    (
+        "scope_variant",
+        "tracker_environment",
+        "tracker_portfolio",
+        "target_autonomy_mode",
+        "state_suffix",
+        "initial_closed_quantity",
+    ),
+    [
+        ("foreign_environment", "live", "live-1", "paper_autonomous", "active", 0.0),
+        ("foreign_environment", "live", "live-1", "paper_autonomous", "exhausted", 1.0),
+        ("foreign_environment", "live", "live-1", "paper_assisted", "active", 0.0),
+        ("foreign_environment", "live", "live-1", "paper_assisted", "exhausted", 1.0),
+        ("foreign_portfolio", "paper", "paper-foreign", "paper_autonomous", "active", 0.0),
+        ("foreign_portfolio", "paper", "paper-foreign", "paper_autonomous", "exhausted", 1.0),
+        ("foreign_portfolio", "paper", "paper-foreign", "paper_assisted", "active", 0.0),
+        ("foreign_portfolio", "paper", "paper-foreign", "paper_assisted", "exhausted", 1.0),
+    ],
+)
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_foreign_scope_permission_blocked_future_close_does_not_unlock_deferred_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    scope_variant: str,
+    tracker_environment: str,
+    tracker_portfolio: str,
+    target_autonomy_mode: str,
+    state_suffix: str,
+    initial_closed_quantity: float,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 21, 11, 45, tzinfo=timezone.utc)
+    active_local_key = f"{scope_variant}-permission-blocked-anchor"
+    close_target_key = (
+        f"{scope_variant}-permission-blocked-close-target-{target_autonomy_mode}-{state_suffix}"
+    )
+    blocked_top_key = f"{scope_variant}-permission-blocked-top-{target_autonomy_mode}-{state_suffix}"
+    promoted_lower_key = (
+        f"{scope_variant}-permission-blocked-lower-{target_autonomy_mode}-{state_suffix}"
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_local_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            ),
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=promoted_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_local_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=3),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=101.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            entry_quantity=1.0,
+            closed_quantity=initial_closed_quantity,
+            provenance={
+                "environment": tracker_environment,
+                "portfolio": tracker_portfolio,
+                "autonomy_final_mode": target_autonomy_mode,
+                "autonomy_requested_mode": target_autonomy_mode,
+                "autonomy_upstream_effective_mode": target_autonomy_mode,
+                "autonomy_local_guard_effective_mode": target_autonomy_mode,
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 2.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    promoted_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=promoted_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    promoted_lower_signal.symbol = "SOL/USDT"
+    promoted_lower_signal.metadata = {
+        **dict(promoted_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+    close_target_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+    )
+    close_target_signal.metadata = {**dict(close_target_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if shadow_key == close_target_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="test_forced_foreign_close_permission_blocked",
+            ), {"autonomy_mode": "paper_autonomous"}
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+
+    results = controller.process_signals([blocked_top_signal, promoted_lower_signal, close_target_signal])
+
+    assert results == []
+    assert _request_shadow_keys(execution.requests) == []
+    assert [request.side for request in execution.requests] == []
+
+    events = list(journal.export())
+    assert _order_path_events_with_shadow_key(journal, close_target_key) == []
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, promoted_lower_key) == []
+
+    close_enforcement_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ]
+    assert len(close_enforcement_events) == 1
+    close_enforcement = close_enforcement_events[0]
+    assert str(close_enforcement.get("status") or "").strip() == "blocked"
+    assert str(close_enforcement.get("execution_permission") or "").strip() == "blocked"
+    assert str(close_enforcement.get("autonomous_execution_allowed") or "").strip().lower() == "false"
+    assert (
+        str(close_enforcement.get("blocking_reason") or "").strip()
+        == "test_forced_foreign_close_permission_blocked"
+    )
+    assert (
+        str(close_enforcement.get("denial_reason") or "").strip()
+        == "test_forced_foreign_close_permission_blocked"
+    )
+    assert str(close_enforcement.get("autonomy_mode") or "").strip() == "paper_autonomous"
+    assert str(close_enforcement.get("proxy_correlation_key") or "").strip() == ""
+    assert str(close_enforcement.get("existing_open_correlation_key") or "").strip() == ""
+
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("reason") or "").strip()
+        == "restored_tracker_remaining_quantity_exhausted_suppressed"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == []
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ] == []
+
+    close_key_events = [
+        event
+        for event in events
+        if (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+            or str(event.get("existing_open_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert close_key_events
+    assert str(close_key_events[-1].get("event") or "").strip() == "opportunity_autonomy_enforcement"
+    assert {str(event.get("event") or "").strip() for event in close_key_events} <= {
+        "signal_received",
+        "opportunity_autonomy_enforcement",
+    }
+    assert all(
+        str(event.get("proxy_correlation_key") or "").strip() != close_target_key
+        for event in close_key_events
+    )
+    assert all(
+        str(event.get("existing_open_correlation_key") or "").strip() != close_target_key
+        for event in close_key_events
+    )
+
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, promoted_lower_key}
+    ] == []
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == promoted_lower_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            in {blocked_top_key, promoted_lower_key}
+            or str(event.get("proxy_correlation_key") or "").strip()
+            in {blocked_top_key, promoted_lower_key}
+        )
+    ] == []
+
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="0",
+        candidate_count="2",
+        selected_count="0",
+        loser_count="2",
+        selected_shadow_keys=[],
+        loser_shadow_keys=[blocked_top_key, promoted_lower_key],
+    )
+
+    active_open_keys = sorted(
+        row.correlation_key
+        for row in repository.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    if initial_closed_quantity < 1.0:
+        assert active_open_keys == sorted([active_local_key, close_target_key])
+    else:
+        assert active_open_keys == [active_local_key]
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity == initial_closed_quantity
+    assert promoted_lower_key not in active_open_keys
+
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=promoted_lower_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
+
+
 @pytest.mark.parametrize("open_partial_status", ["partially_filled", "partial"])
 def test_opportunity_autonomy_active_budget_ranked_mode_partial_open_then_close_without_mode_in_same_batch_promotes_deferred_loser_with_exact_proof_event(
     open_partial_status: str,


### PR DESCRIPTION
### Motivation

- Ensure that a permission-blocked `close_ranked` signal for a foreign-scoped opportunity does not unlock or promote `deferred_ranked` fallback candidates or attach outcomes accidentally.

### Description

- Add a new parametrized pytest `test_opportunity_autonomy_active_budget_ranked_close_ranked_foreign_scope_permission_blocked_future_close_does_not_unlock_deferred_fallback` covering combinations of tracker environment/portfolio, autonomy modes, and exhausted/active states.
- Set up a shadow repository and open outcomes, build `blocked_top`, `promoted_lower`, and `close_target` signals, and use `SequencedExecutionService` plus a controller configured with `enable_autonomous_open_ranked_selection_within_batch=True` and `signal_mode_priorities` to simulate ranked selection behavior.
- Monkeypatch `TradingController._evaluate_opportunity_execution_permission` to force permission denial for the `close_target` and `blocked_top` shadow keys and assert that no execution requests are sent and no unintended attachments or promotions occur.
- Assert presence and payload of `opportunity_autonomy_enforcement` events, selection/loser counts, repository open outcome states, and that no duplicate residue metadata or durable artifacts exist for tested shadow keys.

### Testing

- Executed the new test: `pytest tests/test_trading_controller.py::test_opportunity_autonomy_active_budget_ranked_close_ranked_foreign_scope_permission_blocked_future_close_does_not_unlock_deferred_fallback` and it passed.
- Ran the test file `pytest tests/test_trading_controller.py` and the suite completed successfully for the modified cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecedc38c24832a81be5fe88de45054)