### PR TITLE
Add batch-level test: earlier permission-blocked close_ranked does not unlock deferred fallback

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -14774,6 +14774,284 @@ def test_opportunity_autonomy_active_budget_ranked_close_ranked_same_scope_activ
     _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
 
 
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_earlier_permission_blocked_close_does_not_unlock_deferred_fallback_batch_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 20, 11, 14, tzinfo=timezone.utc)
+    active_local_key = "same-scope-active-anchor-close-blocked-earlier"
+    close_target_key = "same-scope-active-close-target-blocked-earlier"
+    blocked_top_key = "same-scope-active-close-blocked-top-earlier"
+    promoted_lower_key = "same-scope-active-close-promoted-lower-earlier"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_local_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            ),
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp,
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=promoted_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+        ]
+    )
+    autonomous_provenance = {
+        "environment": "paper",
+        "portfolio": "paper-1",
+        "autonomy_final_mode": "paper_autonomous",
+    }
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_local_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=3),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance=dict(autonomous_provenance),
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=101.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance=dict(autonomous_provenance),
+        )
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 2.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=2,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+    )
+
+    close_target_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+    )
+    close_target_signal.metadata = {**dict(close_target_signal.metadata), "mode": "close_ranked"}
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    promoted_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=promoted_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    promoted_lower_signal.symbol = "SOL/USDT"
+    promoted_lower_signal.metadata = {
+        **dict(promoted_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if shadow_key == close_target_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="test_forced_earlier_close_permission_blocked",
+            ), {"autonomy_mode": "paper_autonomous"}
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+
+    results = controller.process_signals(
+        [close_target_signal, blocked_top_signal, promoted_lower_signal]
+    )
+
+    assert results == []
+    assert execution.requests == []
+    events = list(journal.export())
+    assert _order_path_events_with_shadow_key(journal, close_target_key) == []
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, promoted_lower_key) == []
+    close_enforcement_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ]
+    assert len(close_enforcement_events) == 1
+    close_enforcement = close_enforcement_events[0]
+    assert str(close_enforcement.get("status") or "").strip() == "blocked"
+    assert str(close_enforcement.get("execution_permission") or "").strip() == "blocked"
+    assert str(close_enforcement.get("autonomous_execution_allowed") or "").strip().lower() == "false"
+    assert (
+        str(close_enforcement.get("blocking_reason") or "").strip()
+        == "test_forced_earlier_close_permission_blocked"
+    )
+    assert (
+        str(close_enforcement.get("denial_reason") or "").strip()
+        == "test_forced_earlier_close_permission_blocked"
+    )
+    assert str(close_enforcement.get("autonomy_mode") or "").strip() == "paper_autonomous"
+    assert str(close_enforcement.get("proxy_correlation_key") or "").strip() == ""
+    assert str(close_enforcement.get("existing_open_correlation_key") or "").strip() == ""
+    assert [
+        event
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ] == []
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ] == []
+    close_key_events = [
+        event
+        for event in events
+        if (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+            or str(event.get("existing_open_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert close_key_events
+    assert {str(event.get("event") or "").strip() for event in close_key_events} <= {
+        "signal_received",
+        "opportunity_autonomy_enforcement",
+    }
+    assert str(close_key_events[-1].get("event") or "").strip() == "opportunity_autonomy_enforcement"
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, promoted_lower_key}
+    ] == []
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == promoted_lower_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            in {blocked_top_key, promoted_lower_key}
+            or str(event.get("proxy_correlation_key") or "").strip()
+            in {blocked_top_key, promoted_lower_key}
+        )
+    ] == []
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=promoted_lower_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=promoted_lower_key)
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="0",
+        candidate_count="2",
+        selected_count="0",
+        loser_count="2",
+        selected_shadow_keys=[],
+        loser_shadow_keys=[blocked_top_key, promoted_lower_key],
+    )
+    active_open_keys = sorted(
+        row.correlation_key
+        for row in repository.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == sorted([active_local_key, close_target_key])
+    close_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == close_target_key
+    ]
+    assert len(close_rows) == 1
+    assert close_rows[0].closed_quantity == 0.0
+
+
 @pytest.mark.parametrize(
     ("target_variant", "initial_closed_quantity", "target_autonomy_mode"),
     [


### PR DESCRIPTION
### Motivation
- Close-ranked permission-blocked contracts were covered for cases where deferred candidates precede close, but not for the variant where `close_ranked` appears earlier in the same batch, so the ordering contract needed to be locked down. 
- The intent is a test-only hardening to ensure an earlier permission-blocked close does not release a slot or promote deferred fallback candidates.

### Description
- Added a single narrow runtime-level test `test_opportunity_autonomy_active_budget_ranked_close_ranked_earlier_permission_blocked_close_does_not_unlock_deferred_fallback_batch_level` to `tests/test_trading_controller.py` that exercises an earlier `close_ranked` (permission-blocked) followed by two `deferred_ranked` BUY candidates. 
- The test forces permission responses via a monkeypatch of `TradingController._evaluate_opportunity_execution_permission` to make the close blocked, the top deferred blocked, and the lower deferred allowed, and then asserts no unlock/promotion and proper enforcement events. 
- No production code was modified; `bot_core/runtime/controller.py` was not changed and the change is strictly test-only with one small assertion relaxation to avoid an over-strict event-order assumption.

### Testing
- Ran dependency install: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` which completed successfully. 
- Ran focused pytest for the controller tests; initial run failed once due to an overly strict assertion in the new test, then the assertion was relaxed and the final run succeeded with `568 passed, 150 deselected` for the targeted invocation. 
- Ran combined pytest set: `PYENV_VERSION=3.11.14 pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` which completed with `533 passed, 224 deselected`. 
- Static checks: `PYENV_VERSION=3.11.14 python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` returned `All checks passed!`. 
- Commit hash for the change: `b5f89db`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf266bdec832abe17e6f11a8da507)