### PR TITLE
Sanitize and clamp close_ranked filled quantities for telemetry and outcome tracking

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2827,8 +2827,28 @@ class TradingController:
         normalized_status = _normalize_execution_status(result.status)
         is_partial = normalized_status in _PARTIAL_EXECUTION_STATUSES
         is_filled = normalized_status in _FILLED_EXECUTION_STATUSES
+        is_close_ranked = (
+            str((adjusted_request.metadata or {}).get("mode", "")).strip().lower() == "close_ranked"
+        )
+        telemetry_filled_quantity = result.filled_quantity
+        if is_close_ranked:
+            telemetry_filled_quantity = self._sanitize_close_ranked_filled_quantity_for_telemetry(
+                telemetry_filled_quantity
+            )
+            telemetry_filled_quantity = self._clamp_close_ranked_filled_quantity_to_remaining(
+                request=adjusted_request,
+                telemetry_filled_quantity=telemetry_filled_quantity,
+            )
+        telemetry_result = result
+        if telemetry_filled_quantity is not result.filled_quantity:
+            telemetry_result = replace(result, filled_quantity=telemetry_filled_quantity)
         if is_filled or is_partial:
-            self._emit_order_filled_alert(signal, adjusted_request, result, partial=is_partial)
+            self._emit_order_filled_alert(
+                signal,
+                adjusted_request,
+                telemetry_result,
+                partial=is_partial,
+            )
         else:
             self._emit_order_not_filled_alert(
                 signal,
@@ -2838,7 +2858,7 @@ class TradingController:
             )
         order_id = result.order_id or ""
         execution_avg_price = result.avg_price
-        execution_filled_qty = result.filled_quantity
+        execution_filled_qty = telemetry_filled_quantity
         if is_filled:
             if execution_avg_price is None:
                 execution_avg_price = adjusted_request.price
@@ -4264,8 +4284,13 @@ class TradingController:
                     int((timestamp_utc - tracked.decision_timestamp).total_seconds() / 60),
                 )
                 close_quantity = self._safe_float(result.filled_quantity)
+                if not math.isfinite(close_quantity) or close_quantity <= 0.0:
+                    effective_close_quantity = 0.0
+                else:
+                    remaining_quantity = max(0.0, tracked.entry_quantity - tracked.closed_quantity)
+                    effective_close_quantity = min(close_quantity, remaining_quantity)
                 cumulative_closed_quantity = max(
-                    0.0, tracked.closed_quantity + max(close_quantity, 0.0)
+                    0.0, tracked.closed_quantity + effective_close_quantity
                 )
                 tracked.closed_quantity = cumulative_closed_quantity
                 self._persist_open_outcome_tracker(tracked)
@@ -4793,6 +4818,40 @@ class TradingController:
             return float(value)
         except (TypeError, ValueError):
             return default
+
+    @staticmethod
+    def _sanitize_close_ranked_filled_quantity_for_telemetry(
+        value: object | None,
+    ) -> float | None:
+        if value is None:
+            return None
+        try:
+            candidate = float(value)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(candidate) or candidate < 0.0:
+            return None
+        return candidate
+
+    def _clamp_close_ranked_filled_quantity_to_remaining(
+        self,
+        *,
+        request: OrderRequest,
+        telemetry_filled_quantity: float | None,
+    ) -> float | None:
+        if telemetry_filled_quantity is None:
+            return None
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        correlation_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if not correlation_key:
+            return telemetry_filled_quantity
+        tracked = self._opportunity_open_outcomes.get(correlation_key)
+        if tracked is None:
+            return telemetry_filled_quantity
+        if not self._is_closing_side(tracked.side, str(request.side).upper()):
+            return telemetry_filled_quantity
+        remaining_quantity = max(0.0, tracked.entry_quantity - tracked.closed_quantity)
+        return min(telemetry_filled_quantity, remaining_quantity)
 
     def _maybe_reverse_position(
         self,

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -29116,6 +29116,494 @@ def test_opportunity_autonomy_active_budget_ranked_close_ranked_filled_like_with
 
 
 @pytest.mark.parametrize(
+    "invalid_filled_quantity",
+    [
+        -0.4,
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+    ],
+)
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_invalid_numeric_filled_quantity_does_not_unlock_deferred_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_filled_quantity: float,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 12, 16, 30, tzinfo=timezone.utc)
+    active_anchor_key = "invalid-numeric-close-anchor-open"
+    close_target_key = "invalid-numeric-close-target-open"
+    blocked_top_key = "invalid-numeric-close-deferred-blocked-top"
+    allowed_lower_key = "invalid-numeric-close-deferred-allowed-lower"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_anchor_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            ),
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=allowed_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_anchor_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=4),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="ETH/USDT",
+            side="BUY",
+            entry_price=200.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=3),
+            entry_quantity=1.0,
+            closed_quantity=0.2,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": invalid_filled_quantity, "avg_price": 195.0}]
+    )
+    reporter = StubTCOReporter()
+    router, channel, _audit = _router_with_channel()
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=2,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+        tco_reporter=reporter,
+    )
+
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    allowed_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=allowed_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    allowed_lower_signal.symbol = "SOL/USDT"
+    allowed_lower_signal.metadata = {
+        **dict(allowed_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+    )
+    close_signal.symbol = "ETH/USDT"
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    permission_checks: list[str] = []
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        del signal
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        permission_checks.append(shadow_key)
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+
+    results = controller.process_signals([blocked_top_signal, allowed_lower_signal, close_signal])
+
+    assert len(results) == 1
+    assert str(results[0].status).strip().lower() == "filled"
+    assert _request_shadow_keys(execution.requests) == [close_target_key]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    assert _order_path_events_with_shadow_key(journal, close_target_key)
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, allowed_lower_key) == []
+    assert permission_checks == [close_target_key]
+
+    events = list(journal.export())
+    close_enforcement_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ]
+    assert len(close_enforcement_events) == 1
+    assert str(close_enforcement_events[0].get("status") or "").strip() == "allowed"
+    assert str(close_enforcement_events[0].get("execution_permission") or "").strip() == "allowed"
+
+    close_order_events = [
+        event
+        for event in events
+        if event.get("event") == "order_executed"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ]
+    assert len(close_order_events) == 1
+    assert str(close_order_events[0].get("filled_quantity") or "").strip() == "null"
+    assert str(close_order_events[0].get("filled_quantity") or "").strip() != "0.80000000"
+    assert str(close_order_events[0].get("filled_quantity") or "").strip() != "1.00000000"
+
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == allowed_lower_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="0",
+        candidate_count="2",
+        selected_count="0",
+        loser_count="2",
+        selected_shadow_keys=[],
+        loser_shadow_keys=[blocked_top_key, allowed_lower_key],
+    )
+    open_rows = repository.load_open_outcomes()
+    open_rows_by_key = {row.correlation_key: row for row in open_rows}
+    active_open_keys = sorted(
+        row.correlation_key for row in open_rows if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == [active_anchor_key, close_target_key]
+    assert open_rows_by_key[close_target_key].closed_quantity == 0.2
+
+    execution_alerts = [
+        message
+        for message in channel.messages
+        if message.category == "execution"
+        and str(message.context.get("symbol") or "").strip() == "ETH/USDT"
+        and str(message.context.get("side") or "").strip() == "SELL"
+        and str(message.context.get("meta_opportunity_shadow_record_key") or "").strip()
+        == close_target_key
+    ]
+    assert len(execution_alerts) == 1
+    alert_context = execution_alerts[0].context
+    assert alert_context.get("status") == "filled"
+    assert alert_context.get("filled_quantity") == "unknown"
+    assert alert_context.get("filled_quantity") != "0.80000000"
+    assert alert_context.get("filled_quantity") != "1.00000000"
+
+    assert len(reporter.calls) == 1
+    assert reporter.calls[0]["quantity"] == 0.0
+
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=allowed_lower_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=allowed_lower_key)
+
+
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_overfill_is_clamped_and_unlocks_only_one_deferred_fallback_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 12, 16, 55, tzinfo=timezone.utc)
+    active_anchor_key = "overfill-close-anchor-open"
+    close_target_key = "overfill-close-target-open"
+    blocked_top_key = "overfill-close-deferred-blocked-top"
+    allowed_lower_key = "overfill-close-deferred-allowed-lower"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_anchor_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            ),
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=allowed_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_anchor_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=4),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=close_target_key,
+            symbol="ETH/USDT",
+            side="BUY",
+            entry_price=200.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=3),
+            entry_quantity=1.0,
+            closed_quantity=0.2,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 2.0, "avg_price": 195.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 30.0},
+        ]
+    )
+    reporter = StubTCOReporter()
+    router, _channel, _audit = _router_with_channel()
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=2,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+        tco_reporter=reporter,
+    )
+
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    allowed_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=allowed_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    allowed_lower_signal.symbol = "SOL/USDT"
+    allowed_lower_signal.metadata = {
+        **dict(allowed_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=close_target_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=3),
+    )
+    close_signal.symbol = "ETH/USDT"
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+
+    class _ForcedPermission:
+        def __init__(self, *, allowed: bool, denial_reason: str | None = None) -> None:
+            self.autonomous_execution_allowed = allowed
+            self.primary_reason = "test_forced_permission"
+            self.denial_reason = denial_reason
+
+        def to_dict(self) -> Mapping[str, object]:
+            return {
+                "autonomy_mode": "paper_autonomous",
+                "autonomous_execution_allowed": self.autonomous_execution_allowed,
+                "assisted_override_used": False,
+                "primary_reason": self.primary_reason,
+                "denial_reason": self.denial_reason,
+            }
+
+    def _forced_permission_evaluation(
+        self: TradingController,
+        *,
+        signal: StrategySignal,
+        request: OrderRequest,
+    ):
+        del signal
+        metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        shadow_key = str(metadata.get("opportunity_shadow_record_key") or "").strip()
+        if shadow_key == blocked_top_key:
+            return _ForcedPermission(
+                allowed=False,
+                denial_reason="autonomous_mode_requires_assisted_execution",
+            ), {"autonomy_mode": "paper_autonomous"}
+        return _ForcedPermission(allowed=True), {"autonomy_mode": "paper_autonomous"}
+
+    monkeypatch.setattr(
+        TradingController,
+        "_evaluate_opportunity_execution_permission",
+        _forced_permission_evaluation,
+    )
+
+    controller.process_signals([blocked_top_signal, allowed_lower_signal, close_signal])
+
+    assert _request_shadow_keys(execution.requests) == [close_target_key, allowed_lower_key]
+    assert [request.side for request in execution.requests] == ["SELL", "BUY"]
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, allowed_lower_key)
+
+    events = list(journal.export())
+    blocked_enforcement_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ]
+    assert len(blocked_enforcement_events) == 1
+    assert blocked_enforcement_events[0]["status"] == "blocked"
+    assert blocked_enforcement_events[0]["execution_permission"] == "blocked"
+    assert (
+        blocked_enforcement_events[0]["blocking_reason"]
+        == "autonomous_mode_requires_assisted_execution"
+    )
+    lower_enforcement_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == allowed_lower_key
+    ]
+    assert len(lower_enforcement_events) == 1
+    assert lower_enforcement_events[0]["status"] == "allowed"
+    assert lower_enforcement_events[0]["execution_permission"] == "allowed"
+
+    open_rows = repository.load_open_outcomes()
+    open_rows_by_key = {row.correlation_key: row for row in open_rows}
+    active_open_keys = sorted(
+        row.correlation_key for row in open_rows if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == [active_anchor_key, allowed_lower_key]
+    assert open_rows_by_key[close_target_key].closed_quantity == 1.0
+    assert open_rows_by_key[allowed_lower_key].closed_quantity == 0.0
+    assert len(reporter.calls) == 2
+    close_tco_call = reporter.calls[0]
+    assert close_tco_call["side"] == "SELL"
+    assert close_tco_call["instrument"] == "ETH/USDT"
+    assert close_tco_call["quantity"] == 0.8
+
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=allowed_lower_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+
+
+@pytest.mark.parametrize(
     ("close_status", "close_payload"),
     [
         ("partially_filled", {"status": "partially_filled", "filled_quantity": None, "avg_price": 195.0}),


### PR DESCRIPTION
### Motivation
- Prevent invalid or oversized execution `filled_quantity` values from corrupting telemetry, alerts, and open-outcome accounting for `close_ranked` signals.
- Ensure downstream decision events, alerts, and TCO reporting reflect a sane filled quantity that never exceeds the remaining open quantity.

### Description
- Add `_sanitize_close_ranked_filled_quantity_for_telemetry` to coerce numeric `filled_quantity` into a finite non-negative float or `None` for telemetry.
- Add `_clamp_close_ranked_filled_quantity_to_remaining` to bound the telemetry `filled_quantity` by the remaining `entry_quantity - closed_quantity` for the matching open outcome when the request `metadata` includes `opportunity_shadow_record_key` and the sides are closing.
- Use sanitized/clamped `telemetry_filled_quantity` (via a `telemetry_result` copy) when emitting filled alerts and when recording `filled_quantity` in decision metadata and metrics for `close_ranked` requests.
- Guard open-outcome tracking to ignore non-finite or non-positive close quantities and to accumulate only the clamped effective close amount when updating `closed_quantity`.

### Testing
- Added `test_opportunity_autonomy_active_budget_ranked_close_ranked_invalid_numeric_filled_quantity_does_not_unlock_deferred_fallback` which verifies invalid numeric filled quantities (`-0.4`, `nan`, `inf`, `-inf`) are treated as unknown and do not unlock deferred fallback slots; the test passed.
- Added `test_opportunity_autonomy_active_budget_ranked_close_ranked_overfill_is_clamped_and_unlocks_only_one_deferred_fallback_slot` which verifies overfilled execution quantities are clamped to the remaining quantity and only the correct fallback slots are unlocked; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4d20bda4832aaaa8547bf4057c06)