### PR TITLE
Return None when runtime-tracked open outcome is missing for close-ranked filled-quantity clamp

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -4847,7 +4847,7 @@ class TradingController:
             return telemetry_filled_quantity
         tracked = self._opportunity_open_outcomes.get(correlation_key)
         if tracked is None:
-            return telemetry_filled_quantity
+            return None
         if not self._is_closing_side(tracked.side, str(request.side).upper()):
             return telemetry_filled_quantity
         remaining_quantity = max(0.0, tracked.entry_quantity - tracked.closed_quantity)

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -29688,6 +29688,236 @@ def test_opportunity_autonomy_active_budget_ranked_close_ranked_overfill_is_clam
     _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
 
 
+def test_opportunity_autonomy_active_budget_ranked_close_ranked_runtime_map_missing_does_not_emit_unverified_filled_quantity_or_unlock(
+) -> None:
+    decision_timestamp = datetime(2026, 1, 12, 17, 10, tzinfo=timezone.utc)
+    active_anchor_key = "runtime-map-missing-close-anchor-open"
+    close_target_key = "runtime-map-missing-close-target-open"
+    blocked_top_key = "runtime-map-missing-close-deferred-blocked-top"
+    allowed_lower_key = "runtime-map-missing-close-deferred-allowed-lower"
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=active_anchor_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=2),
+            ),
+            _shadow_record_for_key(
+                correlation_key=close_target_key,
+                decision_timestamp=decision_timestamp - timedelta(minutes=1),
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=blocked_top_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=1),
+                ),
+                symbol="XRP/USDT",
+            ),
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=allowed_lower_key,
+                    decision_timestamp=decision_timestamp + timedelta(minutes=2),
+                ),
+                symbol="SOL/USDT",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=active_anchor_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp - timedelta(minutes=4),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 2.0, "avg_price": 195.0}]
+    )
+    reporter = StubTCOReporter()
+    router, channel, _audit = _router_with_channel()
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+        max_active_autonomous_open_positions=1,
+        enable_autonomous_open_ranked_selection_within_batch=True,
+        signal_mode_priorities={"close_ranked": 30, "deferred_ranked": 20},
+        tco_reporter=reporter,
+    )
+    blocked_top_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=blocked_top_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    blocked_top_signal.symbol = "XRP/USDT"
+    blocked_top_signal.metadata = {
+        **dict(blocked_top_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 9.0,
+    }
+    allowed_lower_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=allowed_lower_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    allowed_lower_signal.symbol = "SOL/USDT"
+    allowed_lower_signal.metadata = {
+        **dict(allowed_lower_signal.metadata),
+        "mode": "deferred_ranked",
+        "expected_return_bps": 3.0,
+    }
+    # Celowo używamy tutaj zwykłego _signal dla close:
+    # test izoluje kontrakt runtime-map-missing clamp/attach/no-unlock bez pełnej ścieżki
+    # autonomy-enforcement dla close target.
+    close_signal = _signal("SELL", price=195.0)
+    close_signal.symbol = "ETH/USDT"
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "close_ranked",
+        "opportunity_shadow_record_key": close_target_key,
+    }
+
+    results = controller.process_signals([blocked_top_signal, allowed_lower_signal, close_signal])
+
+    assert len(results) == 1
+    assert str(results[0].status).strip().lower() == "filled"
+
+    assert _request_shadow_keys(execution.requests) == [close_target_key]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    assert _order_path_events_with_shadow_key(journal, close_target_key)
+    assert _order_path_events_with_shadow_key(journal, blocked_top_key) == []
+    assert _order_path_events_with_shadow_key(journal, allowed_lower_key) == []
+
+    events = list(journal.export())
+    close_order_events = [
+        event
+        for event in events
+        if event.get("event") == "order_executed"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+    ]
+    assert len(close_order_events) == 1
+    assert str(close_order_events[0].get("filled_quantity") or "").strip() == "null"
+    assert str(close_order_events[0].get("filled_quantity") or "").strip() != "2.00000000"
+
+    execution_alerts = [
+        message
+        for message in channel.messages
+        if message.category == "execution"
+        and str(message.context.get("symbol") or "").strip() == "ETH/USDT"
+        and str(message.context.get("side") or "").strip() == "SELL"
+        and str(message.context.get("meta_opportunity_shadow_record_key") or "").strip()
+        == close_target_key
+    ]
+    assert len(execution_alerts) == 1
+    assert execution_alerts[0].context.get("filled_quantity") == "unknown"
+
+    close_tco_calls = [
+        call
+        for call in reporter.calls
+        if str(call.get("side") or "").strip() == "SELL"
+        and str(call.get("instrument") or "").strip() == "ETH/USDT"
+    ]
+    assert len(close_tco_calls) == 1
+    assert close_tco_calls[0]["quantity"] == 0.0
+
+    close_attach_events = [
+        event for event in events if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == close_target_key
+            or str(event.get("proxy_correlation_key") or "").strip() == close_target_key
+        )
+    ]
+    assert len(close_attach_events) == 1
+    close_attach_event = close_attach_events[0]
+    assert str(close_attach_event.get("status") or "").strip() == "close_correlation_unresolved"
+    assert str(close_attach_event.get("proxy_correlation_key") or "").strip() == close_target_key
+    assert (
+        str(close_attach_event.get("order_opportunity_shadow_record_key") or "").strip()
+        == close_target_key
+    )
+
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == blocked_top_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+    assert [
+        event.get("reason")
+        for event in events
+        if event.get("event") == "signal_skipped"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == allowed_lower_key
+    ] == ["autonomous_open_active_budget_ranked_loser"]
+
+    deferred_enforcement_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        in {blocked_top_key, allowed_lower_key}
+    ]
+    assert deferred_enforcement_events == []
+    deferred_attach_events = [
+        event
+        for event in events
+        if event.get("event") == "opportunity_outcome_attach"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip()
+            in {blocked_top_key, allowed_lower_key}
+            or str(event.get("proxy_correlation_key") or "").strip()
+            in {blocked_top_key, allowed_lower_key}
+        )
+    ]
+    assert deferred_attach_events == []
+
+    _assert_single_ranked_selection_event_payload(
+        journal,
+        remaining_slots="0",
+        candidate_count="2",
+        selected_count="0",
+        loser_count="2",
+        selected_shadow_keys=[],
+        loser_shadow_keys=[blocked_top_key, allowed_lower_key],
+    )
+
+    active_open_keys = sorted(
+        row.correlation_key
+        for row in repository.load_open_outcomes()
+        if row.closed_quantity < row.entry_quantity
+    )
+    assert active_open_keys == [active_anchor_key]
+
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=blocked_top_key)
+    _assert_no_durable_artifacts_for_shadow_key(repository, shadow_key=allowed_lower_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=close_target_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=blocked_top_key)
+    _assert_no_duplicate_residue_metadata_for_shadow_key(events, shadow_key=allowed_lower_key)
+
+
 @pytest.mark.parametrize(
     ("filled_quantity_payload", "expected_order_filled_qty", "expected_tco_quantity", "expect_unlock"),
     [


### PR DESCRIPTION
### Motivation
- Avoid trusting telemetry filled quantities when there is no corresponding runtime-tracked open outcome, to prevent emitting unverified filled quantities and accidental unlocks.
- Ensure close-ranked flows treat missing runtime map entries as "unknown" rather than clamping to a numeric telemetry value.

### Description
- Change `TradingController._clamp_close_ranked_filled_quantity_to_remaining` to return `None` when the runtime tracked outcome is missing instead of returning the raw telemetry filled quantity.
- Add `test_opportunity_autonomy_active_budget_ranked_close_ranked_runtime_map_missing_does_not_emit_unverified_filled_quantity_or_unlock` to verify that missing runtime mappings result in `null`/unknown filled quantities in order events and alerts, a `0.0` TCO reporter quantity, a `close_correlation_unresolved` attach status, and no deferred enforcement/attach events.

### Testing
- Added and ran `pytest tests/test_trading_controller.py::test_opportunity_autonomy_active_budget_ranked_close_ranked_runtime_map_missing_does_not_emit_unverified_filled_quantity_or_unlock`, which passed.
- Ran the relevant controller tests in `tests/test_trading_controller.py` covering close-ranked clamp behavior and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edcd0846c4832a867a552a52dffd88)