### PR TITLE
Sanitize filled-quantity telemetry and suppress proxy labels for invalid autonomous opens; add tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2859,13 +2859,18 @@ class TradingController:
         order_id = result.order_id or ""
         execution_avg_price = result.avg_price
         execution_filled_qty = telemetry_filled_quantity
+        execution_filled_qty_numeric = self._sanitize_close_ranked_filled_quantity_for_telemetry(
+            execution_filled_qty
+        )
         if is_filled:
             if execution_avg_price is None:
                 execution_avg_price = adjusted_request.price
         metadata: dict[str, object] = {
             "order_id": order_id,
             "filled_quantity": (
-                "null" if execution_filled_qty is None else f"{execution_filled_qty:.8f}"
+                "null"
+                if execution_filled_qty_numeric is None
+                else f"{execution_filled_qty_numeric:.8f}"
             ),
             "avg_price": "null" if execution_avg_price is None else f"{execution_avg_price:.8f}",
             "status": normalized_status,
@@ -2895,7 +2900,9 @@ class TradingController:
                     if execution_avg_price is not None
                     else (adjusted_request.price or 0.0)
                 ),
-                filled_qty=(execution_filled_qty if execution_filled_qty is not None else 0.0),
+                filled_qty=(
+                    execution_filled_qty_numeric if execution_filled_qty_numeric is not None else 0.0
+                ),
             )
         elif is_partial:
             self._record_decision_event(
@@ -2905,14 +2912,14 @@ class TradingController:
                 status=normalized_status,
                 metadata=metadata,
             )
-            if execution_avg_price is not None and execution_filled_qty is not None:
+            if execution_avg_price is not None and execution_filled_qty_numeric is not None:
                 self._record_tco_execution(
                     signal=signal,
                     request=adjusted_request,
                     result=result,
                     order_id=order_id,
                     avg_price=execution_avg_price,
-                    filled_qty=execution_filled_qty,
+                    filled_qty=execution_filled_qty_numeric,
                 )
         else:
             self._record_decision_event(
@@ -4198,6 +4205,7 @@ class TradingController:
         final_resolution = ""
         close_execution_quantity: float | None = None
         unresolved_close_with_correlation_key = False
+        suppress_proxy_label_for_invalid_autonomous_open = False
         open_intent_candidate = False
         replay_open_candidate = False
         if (
@@ -4579,61 +4587,63 @@ class TradingController:
                             label_quality="partial_exit_unconfirmed",
                         )
             elif correlation_key and open_intent_candidate and side in _BUY_SIDES | _SELL_SIDES:
-                tracker = _OpportunityOpenOutcomeTracker(
-                    correlation_key=correlation_key,
-                    symbol=str(request.symbol),
-                    side=side,
-                    entry_price=avg_price,
-                    decision_timestamp=timestamp_utc,
-                    entry_quantity=max(
-                        0.0,
-                        self._safe_float(
-                            metadata.get(
-                                "filled_quantity",
-                                result.filled_quantity
-                                if result.filled_quantity is not None
-                                else request.quantity,
-                            )
+                entry_quantity = self._sanitize_autonomous_open_filled_quantity_proof(
+                    request=request,
+                    result=result,
+                    attach_metadata=metadata,
+                )
+                if entry_quantity is None:
+                    # Autonomous OPEN without positive finite quantity-proof cannot emit
+                    # proxy/durable lifecycle artifacts, because no real open execution was proven.
+                    suppress_proxy_label_for_invalid_autonomous_open = True
+                else:
+                    tracker = _OpportunityOpenOutcomeTracker(
+                        correlation_key=correlation_key,
+                        symbol=str(request.symbol),
+                        side=side,
+                        entry_price=avg_price,
+                        decision_timestamp=timestamp_utc,
+                        entry_quantity=entry_quantity,
+                        model_version=None,
+                        decision_source=None,
+                        autonomy_requested_mode=autonomy_chain.get("autonomy_requested_mode"),
+                        autonomy_upstream_effective_mode=autonomy_chain.get(
+                            "autonomy_upstream_effective_mode"
                         ),
-                    ),
-                    model_version=None,
-                    decision_source=None,
-                    autonomy_requested_mode=autonomy_chain.get("autonomy_requested_mode"),
-                    autonomy_upstream_effective_mode=autonomy_chain.get(
-                        "autonomy_upstream_effective_mode"
-                    ),
-                    autonomy_local_guard_effective_mode=autonomy_chain.get(
-                        "autonomy_local_guard_effective_mode"
-                    ),
-                    autonomy_final_mode=autonomy_chain.get("autonomy_final_mode"),
-                    autonomous_execution_allowed=autonomy_chain.get("autonomous_execution_allowed"),
-                    assisted_override_used=autonomy_chain.get("assisted_override_used"),
-                    blocking_reason=autonomy_chain.get("blocking_reason"),
-                    autonomy_decisive_stage=autonomy_chain.get("autonomy_decisive_stage"),
-                    autonomy_decisive_reason=autonomy_chain.get("autonomy_decisive_reason"),
-                    autonomy_primary_reason=autonomy_chain.get("autonomy_primary_reason"),
-                    upstream_autonomy_decision_source=autonomy_chain.get(
-                        "upstream_autonomy_decision_source"
-                    ),
-                    upstream_autonomy_inference_model=autonomy_chain.get(
-                        "upstream_autonomy_inference_model"
-                    ),
-                    upstream_autonomy_inference_model_version=autonomy_chain.get(
-                        "upstream_autonomy_inference_model_version"
-                    ),
-                    runtime_lineage_snapshot=dict(runtime_lineage_snapshot),
-                    environment_scope=str(self.environment).strip() or None,
-                    portfolio_scope=str(self.portfolio_id).strip() or None,
-                    restored_from_repository=False,
-                )
-                tracker_model_version, tracker_decision_source = _resolve_runtime_lineage(
-                    correlation_key,
-                    tracker_hint=tracker,
-                )
-                tracker.model_version = tracker_model_version
-                tracker.decision_source = tracker_decision_source
-                self._opportunity_open_outcomes[correlation_key] = tracker
-                self._persist_open_outcome_tracker(tracker)
+                        autonomy_local_guard_effective_mode=autonomy_chain.get(
+                            "autonomy_local_guard_effective_mode"
+                        ),
+                        autonomy_final_mode=autonomy_chain.get("autonomy_final_mode"),
+                        autonomous_execution_allowed=autonomy_chain.get(
+                            "autonomous_execution_allowed"
+                        ),
+                        assisted_override_used=autonomy_chain.get("assisted_override_used"),
+                        blocking_reason=autonomy_chain.get("blocking_reason"),
+                        autonomy_decisive_stage=autonomy_chain.get("autonomy_decisive_stage"),
+                        autonomy_decisive_reason=autonomy_chain.get("autonomy_decisive_reason"),
+                        autonomy_primary_reason=autonomy_chain.get("autonomy_primary_reason"),
+                        upstream_autonomy_decision_source=autonomy_chain.get(
+                            "upstream_autonomy_decision_source"
+                        ),
+                        upstream_autonomy_inference_model=autonomy_chain.get(
+                            "upstream_autonomy_inference_model"
+                        ),
+                        upstream_autonomy_inference_model_version=autonomy_chain.get(
+                            "upstream_autonomy_inference_model_version"
+                        ),
+                        runtime_lineage_snapshot=dict(runtime_lineage_snapshot),
+                        environment_scope=str(self.environment).strip() or None,
+                        portfolio_scope=str(self.portfolio_id).strip() or None,
+                        restored_from_repository=False,
+                    )
+                    tracker_model_version, tracker_decision_source = _resolve_runtime_lineage(
+                        correlation_key,
+                        tracker_hint=tracker,
+                    )
+                    tracker.model_version = tracker_model_version
+                    tracker.decision_source = tracker_decision_source
+                    self._opportunity_open_outcomes[correlation_key] = tracker
+                    self._persist_open_outcome_tracker(tracker)
             elif (
                 correlation_key
                 and correlation_key in known_shadow_keys
@@ -4656,7 +4666,12 @@ class TradingController:
                 },
             )
             return
-        if correlation_key and final_label is None and partial_label is None:
+        if (
+            correlation_key
+            and final_label is None
+            and partial_label is None
+            and not suppress_proxy_label_for_invalid_autonomous_open
+        ):
             proxy_tracker = self._opportunity_open_outcomes.get(correlation_key)
             proxy_runtime_lineage_snapshot = _resolve_artifact_runtime_lineage_snapshot(
                 proxy_tracker
@@ -4838,6 +4853,30 @@ class TradingController:
         if not math.isfinite(candidate) or candidate < 0.0:
             return None
         return candidate
+
+    @staticmethod
+    def _sanitize_autonomous_open_filled_quantity_proof(
+        *,
+        request: OrderRequest,
+        result: OrderResult,
+        attach_metadata: Mapping[str, object],
+    ) -> float | None:
+        raw_filled_quantity = attach_metadata.get("filled_quantity", result.filled_quantity)
+        if raw_filled_quantity in (None, "", "null"):
+            return None
+        try:
+            filled_quantity = float(raw_filled_quantity)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(filled_quantity) or filled_quantity <= 0.0:
+            return None
+        try:
+            request_quantity = float(request.quantity)
+        except (TypeError, ValueError):
+            return filled_quantity
+        if not math.isfinite(request_quantity) or request_quantity <= 0.0:
+            return filled_quantity
+        return min(filled_quantity, request_quantity)
 
     def _clamp_close_ranked_filled_quantity_to_remaining(
         self,
@@ -5638,6 +5677,7 @@ class TradingController:
         else:
             avg_price = result.avg_price if result.avg_price is not None else (request.price or 0.0)
             filled_qty = result.filled_quantity
+        filled_qty_numeric = self._sanitize_close_ranked_filled_quantity_for_telemetry(filled_qty)
 
         context = {
             "symbol": request.symbol,
@@ -5645,7 +5685,9 @@ class TradingController:
             "order_id": order_id,
             "client_order_id": request.client_order_id or "",
             "avg_price": "unknown" if avg_price is None else f"{avg_price:.8f}",
-            "filled_quantity": "unknown" if filled_qty is None else f"{filled_qty:.8f}",
+            "filled_quantity": (
+                "unknown" if filled_qty_numeric is None else f"{filled_qty_numeric:.8f}"
+            ),
             "status": result.status or "unknown",
             "environment": self.environment,
             "risk_profile": self.risk_profile,

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -198,6 +198,32 @@ class SequencedExecutionService(ExecutionService):
         return None
 
 
+class MissingFilledQuantityExecutionService(ExecutionService):
+    def __init__(self, responses: Sequence[dict[str, object]]) -> None:
+        self._responses = list(responses)
+        self.requests: list[OrderRequest] = []
+
+    def execute(self, request: OrderRequest, context) -> OrderResult:  # type: ignore[override]
+        self.requests.append(request)
+        payload = dict(self._responses.pop(0)) if self._responses else {}
+        raw_response: dict[str, object] = {"context": context.metadata}
+        if "filled_quantity" in payload:
+            raw_response["filled_quantity"] = payload["filled_quantity"]
+        return OrderResult(
+            order_id=str(payload.get("order_id", "order-missing-filled")),
+            status=str(payload.get("status", "filled")),
+            filled_quantity=payload["filled_quantity"] if "filled_quantity" in payload else None,
+            avg_price=payload.get("avg_price", request.price),
+            raw_response=raw_response,
+        )
+
+    def cancel(self, order_id: str, context) -> None:  # type: ignore[override]
+        return None
+
+    def flush(self) -> None:
+        return None
+
+
 def _account_snapshot() -> AccountSnapshot:
     return AccountSnapshot(
         balances={},
@@ -44394,6 +44420,391 @@ def test_opportunity_autonomous_open_partial_fill_creates_partial_tracker_withou
     assert open_outcomes[0].entry_quantity == pytest.approx(0.4, rel=1e-6)
     assert open_outcomes[0].closed_quantity == 0.0
 
+
+@pytest.mark.parametrize("execution_status", ["filled", "partially_filled", "partial"])
+@pytest.mark.parametrize("filled_quantity", [None, -0.4, float("nan"), float("inf"), float("-inf")])
+def test_opportunity_autonomous_open_without_positive_finite_quantity_proof_does_not_create_tracker(
+    tmp_path: Path,
+    execution_status: str,
+    filled_quantity: float | None,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    first_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    second_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=2,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=first_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper"),
+            ),
+            OpportunityShadowRecord(
+                record_key=second_key,
+                symbol="ETH/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper"),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": execution_status, "filled_quantity": filled_quantity, "avg_price": 101.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 111.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=shadow_repo,
+        max_active_autonomous_open_positions=1,
+    )
+    first_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=first_key,
+        decision_timestamp=decision_timestamp,
+    )
+    second_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=second_key,
+        decision_timestamp=decision_timestamp,
+    )
+    second_open_signal.symbol = "ETH/USDT"
+
+    results = controller.process_signals([first_open_signal, second_open_signal])
+
+    assert [result.status for result in results] == [execution_status, "filled"]
+    assert _request_shadow_keys(execution.requests) == [first_key, second_key]
+    open_outcomes = shadow_repo.load_open_outcomes()
+    assert {row.correlation_key for row in open_outcomes} == {second_key}
+    assert open_outcomes[0].entry_quantity == pytest.approx(1.0, rel=1e-6)
+    first_labels = [row for row in shadow_repo.load_outcome_labels() if row.correlation_key == first_key]
+    assert first_labels == []
+
+    all_events = journal.export()
+    first_execution_events = [
+        event for event in all_events if event.get("order_opportunity_shadow_record_key") == first_key
+    ]
+    expected_event = "order_executed" if execution_status == "filled" else "order_partially_executed"
+    assert expected_event in [event["event"] for event in first_execution_events]
+    execution_event = next(event for event in first_execution_events if event["event"] == expected_event)
+    assert execution_event["filled_quantity"] != "1.00000000"
+    if filled_quantity is None:
+        assert execution_event["filled_quantity"] == "null"
+    skipped_events = [
+        event
+        for event in all_events
+        if event.get("event") == "signal_skipped"
+        and (
+            event.get("decision_reason") == "autonomous_open_active_budget_exhausted"
+            or event.get("reason") == "autonomous_open_active_budget_exhausted"
+        )
+        and event.get("order_opportunity_shadow_record_key") == second_key
+    ]
+    assert skipped_events == []
+
+
+def test_opportunity_autonomous_open_missing_filled_quantity_field_does_not_create_tracker(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    first_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    second_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=2,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=first_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper"),
+            ),
+            OpportunityShadowRecord(
+                record_key=second_key,
+                symbol="ETH/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper"),
+            ),
+        ]
+    )
+    execution = MissingFilledQuantityExecutionService(
+        [
+            {"status": "filled", "avg_price": 101.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 111.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=shadow_repo,
+        max_active_autonomous_open_positions=1,
+    )
+    first_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=first_key,
+        decision_timestamp=decision_timestamp,
+    )
+    second_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=second_key,
+        decision_timestamp=decision_timestamp,
+    )
+    second_open_signal.symbol = "ETH/USDT"
+
+    results = controller.process_signals([first_open_signal, second_open_signal])
+
+    assert [result.status for result in results] == ["filled", "filled"]
+    assert _request_shadow_keys(execution.requests) == [first_key, second_key]
+    assert all(row.correlation_key != first_key for row in shadow_repo.load_open_outcomes())
+    assert all(
+        row.entry_quantity != pytest.approx(1.0, rel=1e-6)
+        for row in shadow_repo.load_open_outcomes()
+        if row.correlation_key == first_key
+    )
+    assert all(
+        event.get("decision_reason") != "autonomous_open_active_budget_exhausted"
+        and event.get("reason") != "autonomous_open_active_budget_exhausted"
+        for event in journal.export()
+        if event.get("order_opportunity_shadow_record_key") == second_key
+    )
+    assert all(label.correlation_key != first_key for label in shadow_repo.load_outcome_labels())
+
+
+@pytest.mark.parametrize("execution_status", ["filled", "partially_filled", "partial"])
+@pytest.mark.parametrize(
+    ("filled_quantity", "expected_entry"),
+    [("0.8", 0.8), ("nan", None), ("bad-value", None), ("", None), ("null", None)],
+)
+def test_opportunity_autonomous_open_string_filled_quantity_boundary_contract(
+    tmp_path: Path,
+    execution_status: str,
+    filled_quantity: str,
+    expected_entry: float | None,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records([_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)])
+    execution = StatusExecutionService(
+        status=execution_status, filled_quantity=filled_quantity, avg_price=101.0
+    )
+    controller, _journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=shadow_repo,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=key,
+        decision_timestamp=decision_timestamp,
+    )
+
+    controller.process_signals([open_signal])
+
+    open_outcomes = shadow_repo.load_open_outcomes()
+    labels_for_key = [row for row in shadow_repo.load_outcome_labels() if row.correlation_key == key]
+    if expected_entry is None:
+        assert open_outcomes == []
+        assert labels_for_key == []
+    else:
+        assert len(open_outcomes) == 1
+        assert open_outcomes[0].correlation_key == key
+        assert open_outcomes[0].entry_quantity == pytest.approx(expected_entry, rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("filled_quantity", "expected_entry_quantity"),
+    [
+        (0.4, 0.4),
+        (1.0, 1.0),
+        (1.7, 1.0),
+    ],
+)
+def test_opportunity_autonomous_open_positive_quantity_creates_tracker_and_consumes_budget(
+    tmp_path: Path,
+    filled_quantity: float,
+    expected_entry_quantity: float,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    first_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    second_key = OpportunityShadowRecord.build_record_key(
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=2,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=first_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper"),
+            ),
+            OpportunityShadowRecord(
+                record_key=second_key,
+                symbol="ETH/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper"),
+            ),
+        ]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": filled_quantity, "avg_price": 101.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 111.0},
+        ]
+    )
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=shadow_repo,
+        max_active_autonomous_open_positions=1,
+    )
+    first_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=first_key,
+        decision_timestamp=decision_timestamp,
+    )
+    second_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=second_key,
+        decision_timestamp=decision_timestamp,
+    )
+    second_open_signal.symbol = "ETH/USDT"
+
+    results = controller.process_signals([first_open_signal, second_open_signal])
+
+    assert [result.status for result in results] == ["filled"]
+    assert _request_shadow_keys(execution.requests) == [first_key]
+    open_outcomes = shadow_repo.load_open_outcomes()
+    assert {row.correlation_key for row in open_outcomes} == {first_key}
+    assert open_outcomes[0].entry_quantity == pytest.approx(expected_entry_quantity, rel=1e-6)
+
+    skipped_events = [
+        event
+        for event in journal.export()
+        if event.get("event") == "signal_skipped"
+        and (
+            event.get("decision_reason") == "autonomous_open_active_budget_exhausted"
+            or event.get("reason") == "autonomous_open_active_budget_exhausted"
+        )
+    ]
+    assert len(skipped_events) == 1
+    assert skipped_events[0].get("order_opportunity_shadow_record_key") == second_key
+    skip_reason = skipped_events[0].get("decision_reason") or skipped_events[0].get("reason")
+    assert skip_reason == "autonomous_open_active_budget_exhausted"
 
 def test_opportunity_autonomous_open_unrecognized_non_fill_zero_fill_does_not_create_tracker_or_label_drift(
     tmp_path: Path,


### PR DESCRIPTION
### Motivation

- Prevent non-finite or invalid filled-quantity values from corrupting telemetry, decision events and open-outcome tracking when orders report weird or missing `filled_quantity` values.  
- Avoid emitting proxy/durable lifecycle artifacts for autonomous OPENs that lack a positive finite quantity-proof so budget accounting and labels remain consistent.

### Description

- Introduced `_sanitize_close_ranked_filled_quantity_for_telemetry` to validate and coerce filled-quantity values for telemetry and replaced raw uses of `result.filled_quantity` with the sanitized numeric where appropriate.  
- Added `_sanitize_autonomous_open_filled_quantity_proof` which extracts, validates, and bounds the autonomous-open filled quantity proof against the request quantity and returns `None` for missing/invalid values.  
- Suppress proxy label/tracker creation for autonomous OPENs when the sanitized entry quantity is missing/invalid by setting a `suppress_proxy_label_for_invalid_autonomous_open` flag and guarding proxy emission.  
- Updated alert/context/metadata formatting and calls to `_record_tco_execution` to use sanitized numeric filled quantities (or `null`/defaults when invalid).  
- Added new test helpers and a large set of unit tests to cover missing/invalid/string-filled quantities and the autonomous-open budget/tracker behavior, including `MissingFilledQuantityExecutionService` and multiple parametrized tests for boundary cases.

### Testing

- Ran the unit tests for the controller module with `pytest tests/test_trading_controller.py -q` which exercised the new sanitizers and autonomous-open scenarios and all tests passed.  
- Executed the newly added parametrized tests covering missing/invalid/string-filled quantities and positive quantity consumption, and they succeeded.  
- Verified telemetry/alert metadata and persistence paths through the added assertions in the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eded4818e0832abaa5c1dfb1259cc6)