### PR TITLE
Honor execution-filled proof for autonomous opportunity opens and prevent metadata spoofing

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2839,6 +2839,28 @@ class TradingController:
                 request=adjusted_request,
                 telemetry_filled_quantity=telemetry_filled_quantity,
             )
+        elif is_filled or is_partial:
+            request_metadata = (
+                adjusted_request.metadata if isinstance(adjusted_request.metadata, Mapping) else {}
+            )
+            correlation_key = str(request_metadata.get("opportunity_shadow_record_key", "")).strip()
+            is_autonomous_opportunity_signal = self._is_opportunity_autonomy_enforced(
+                signal,
+                adjusted_request,
+            )
+            has_existing_tracker = bool(
+                correlation_key and self._opportunity_open_outcomes.get(correlation_key) is not None
+            )
+            if correlation_key and is_autonomous_opportunity_signal and not has_existing_tracker:
+                # Request/signal metadata is intentionally excluded from autonomous OPEN
+                # quantity-proof; only execution result can prove filled quantity.
+                autonomous_open_quantity_proof = self._sanitize_autonomous_open_filled_quantity_proof(
+                    request=adjusted_request,
+                    result=result,
+                    attach_metadata={},
+                )
+                if autonomous_open_quantity_proof is not None:
+                    telemetry_filled_quantity = autonomous_open_quantity_proof
         telemetry_result = result
         if telemetry_filled_quantity is not result.filled_quantity:
             telemetry_result = replace(result, filled_quantity=telemetry_filled_quantity)

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -44806,6 +44806,277 @@ def test_opportunity_autonomous_open_positive_quantity_creates_tracker_and_consu
     skip_reason = skipped_events[0].get("decision_reason") or skipped_events[0].get("reason")
     assert skip_reason == "autonomous_open_active_budget_exhausted"
 
+
+@pytest.mark.parametrize(
+    ("execution_status", "expected_event"),
+    [
+        ("filled", "order_executed"),
+        ("partially_filled", "order_partially_executed"),
+        ("partial", "order_partially_executed"),
+    ],
+)
+def test_opportunity_autonomous_open_overfill_quantity_proof_clamps_downstream_telemetry(
+    tmp_path: Path,
+    execution_status: str,
+    expected_event: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)]
+    )
+    execution = StatusExecutionService(
+        status=execution_status,
+        filled_quantity=1.7,
+        avg_price=101.0,
+    )
+    router, channel, _audit = _router_with_channel()
+    journal = CollectingDecisionJournal()
+    tco_reporter = StubTCOReporter()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=shadow_repo,
+        tco_reporter=tco_reporter,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=key,
+        decision_timestamp=decision_timestamp,
+    )
+
+    controller.process_signals([signal])
+
+    open_outcomes = shadow_repo.load_open_outcomes()
+    assert len(open_outcomes) == 1
+    assert open_outcomes[0].entry_quantity == pytest.approx(1.0, rel=1e-6)
+
+    execution_events = [
+        event
+        for event in journal.export()
+        if event.get("event") == expected_event
+        and event.get("order_opportunity_shadow_record_key") == key
+    ]
+    assert len(execution_events) == 1
+    execution_event = execution_events[0]
+    assert execution_event["side"] == "BUY"
+    assert execution_event["status"] == execution_status
+    assert execution_event["filled_quantity"] == "1.00000000"
+
+    execution_alert = channel.messages[-1]
+    assert execution_alert.category == "execution"
+    assert execution_alert.context["side"] == "BUY"
+    assert execution_alert.context["status"] == execution_status
+    assert execution_alert.context["filled_quantity"] == "1.00000000"
+
+    assert len(tco_reporter.calls) == 1
+    assert tco_reporter.calls[0]["quantity"] == pytest.approx(1.0, rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("execution_status", "expected_event", "execution_filled_quantity", "expected_tco_quantity"),
+    [
+        ("filled", "order_executed", None, 0.0),
+        ("filled", "order_executed", "bad-value", 0.0),
+        ("partially_filled", "order_partially_executed", None, None),
+        ("partially_filled", "order_partially_executed", "bad-value", None),
+        ("partial", "order_partially_executed", None, None),
+        ("partial", "order_partially_executed", "bad-value", None),
+    ],
+)
+def test_opportunity_autonomous_open_metadata_filled_quantity_does_not_spoof_missing_result_proof(
+    tmp_path: Path,
+    execution_status: str,
+    expected_event: str,
+    execution_filled_quantity: object | None,
+    expected_tco_quantity: float | None,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)]
+    )
+    execution = StatusExecutionService(
+        status=execution_status,
+        filled_quantity=execution_filled_quantity,
+        avg_price=101.0,
+    )
+    router, channel, _audit = _router_with_channel()
+    journal = CollectingDecisionJournal()
+    tco_reporter = StubTCOReporter()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=shadow_repo,
+        tco_reporter=tco_reporter,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=key,
+        decision_timestamp=decision_timestamp,
+    )
+    signal.metadata["filled_quantity"] = "1.0"
+
+    controller.process_signals([signal])
+
+    open_outcomes = [row for row in shadow_repo.load_open_outcomes() if row.correlation_key == key]
+    assert open_outcomes == []
+    labels = [row for row in shadow_repo.load_outcome_labels() if row.correlation_key == key]
+    assert labels == []
+
+    execution_events = [
+        event
+        for event in journal.export()
+        if event.get("event") == expected_event
+        and event.get("order_opportunity_shadow_record_key") == key
+    ]
+    assert len(execution_events) == 1
+    execution_event = execution_events[0]
+    assert execution_event["side"] == "BUY"
+    assert execution_event["status"] == execution_status
+    assert execution_event["filled_quantity"] == "null"
+    assert execution_event["filled_quantity"] != "1.00000000"
+
+    execution_alerts = [
+        message
+        for message in channel.messages
+        if message.category == "execution"
+        and str(message.context.get("symbol") or "").strip() == "BTC/USDT"
+        and str(message.context.get("side") or "").strip() == "BUY"
+        and str(message.context.get("meta_opportunity_shadow_record_key") or "").strip() == key
+    ]
+    assert len(execution_alerts) == 1
+    execution_alert = execution_alerts[0]
+    assert execution_alert.context["status"] == execution_status
+    assert execution_alert.context["filled_quantity"] == "unknown"
+    assert execution_alert.context["filled_quantity"] != "1.00000000"
+
+    if expected_tco_quantity is None:
+        assert tco_reporter.calls == []
+    else:
+        assert len(tco_reporter.calls) == 1
+        assert tco_reporter.calls[0]["quantity"] == pytest.approx(expected_tco_quantity, rel=1e-6)
+        assert tco_reporter.calls[0]["quantity"] != pytest.approx(1.0, rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("execution_status", "expected_event"),
+    [
+        ("filled", "order_executed"),
+        ("partially_filled", "order_partially_executed"),
+        ("partial", "order_partially_executed"),
+    ],
+)
+def test_opportunity_autonomous_open_metadata_filled_quantity_result_proof_wins_in_downstream_telemetry(
+    tmp_path: Path,
+    execution_status: str,
+    expected_event: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    shadow_repo.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)]
+    )
+    execution = StatusExecutionService(
+        status=execution_status,
+        filled_quantity=0.4,
+        avg_price=101.0,
+    )
+    router, channel, _audit = _router_with_channel()
+    journal = CollectingDecisionJournal()
+    tco_reporter = StubTCOReporter()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=router,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=shadow_repo,
+        tco_reporter=tco_reporter,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=key,
+        decision_timestamp=decision_timestamp,
+    )
+    signal.metadata["filled_quantity"] = "1.0"
+
+    controller.process_signals([signal])
+
+    open_outcomes = [row for row in shadow_repo.load_open_outcomes() if row.correlation_key == key]
+    assert len(open_outcomes) == 1
+    assert open_outcomes[0].entry_quantity == pytest.approx(0.4, rel=1e-6)
+
+    execution_events = [
+        event
+        for event in journal.export()
+        if event.get("event") == expected_event
+        and event.get("order_opportunity_shadow_record_key") == key
+    ]
+    assert len(execution_events) == 1
+    execution_event = execution_events[0]
+    assert execution_event["side"] == "BUY"
+    assert execution_event["status"] == execution_status
+    assert execution_event["filled_quantity"] == "0.40000000"
+    assert execution_event["filled_quantity"] != "1.00000000"
+
+    execution_alerts = [
+        message
+        for message in channel.messages
+        if message.category == "execution"
+        and str(message.context.get("symbol") or "").strip() == "BTC/USDT"
+        and str(message.context.get("side") or "").strip() == "BUY"
+        and str(message.context.get("meta_opportunity_shadow_record_key") or "").strip() == key
+    ]
+    assert len(execution_alerts) == 1
+    execution_alert = execution_alerts[0]
+    assert execution_alert.context["status"] == execution_status
+    assert execution_alert.context["filled_quantity"] == "0.40000000"
+    assert execution_alert.context["filled_quantity"] != "1.00000000"
+
+    assert len(tco_reporter.calls) == 1
+    assert tco_reporter.calls[0]["instrument"] == "BTC/USDT"
+    assert tco_reporter.calls[0]["side"] == "BUY"
+    assert tco_reporter.calls[0]["quantity"] == pytest.approx(0.4, rel=1e-6)
+    assert tco_reporter.calls[0]["quantity"] != pytest.approx(1.0, rel=1e-6)
+
+
 def test_opportunity_autonomous_open_unrecognized_non_fill_zero_fill_does_not_create_tracker_or_label_drift(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation

- Ensure autonomous "open" signals rely on actual execution results as proof of filled quantity rather than request metadata.
- Prevent signal/request metadata from spoofing downstream telemetry or trade accounting when no execution proof exists.
- Clamp or sanitize autonomous-open filled quantities so telemetry and downstream systems receive a trustworthy quantity.

### Description

- Added logic in `TradingController` to, for `is_filled` or `is_partial` executions (non-`close_ranked`), extract `opportunity_shadow_record_key` from `adjusted_request.metadata` and detect autonomous opportunity signals via `_is_opportunity_autonomy_enforced`.
- If the signal is an autonomous open and no existing tracker exists in `_opportunity_open_outcomes`, call `_sanitize_autonomous_open_filled_quantity_proof` and, when it returns a value, override `telemetry_filled_quantity` with that execution-derived proof.
- Preserved existing telemetry replacement and alerting behavior (using `replace(result, filled_quantity=...)` and emitting execution alerts) while preventing metadata-only filled quantities from being treated as proof.
- Introduced guarding checks for metadata type (`Mapping`) and presence of an existing tracker to avoid duplicating proofs or admitting spoofed metadata.

### Testing

- Added and ran unit tests `test_opportunity_autonomous_open_overfill_quantity_proof_clamps_downstream_telemetry`, `test_opportunity_autonomous_open_metadata_filled_quantity_does_not_spoof_missing_result_proof`, and `test_opportunity_autonomous_open_metadata_filled_quantity_result_proof_wins_in_downstream_telemetry` in `tests/test_trading_controller.py` using `pytest`.
- Ran the related `test_trading_controller` suite to validate alerting, shadow repository updates, and TCO reporter interactions, and all new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f4ce0634832aba7f81ace9e2da46)