### PR TITLE
Add tests for ambiguity guard on same-symbol opposite-side correlations with restored trackers

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -10576,6 +10576,301 @@ def test_opportunity_autonomy_opposite_side_cross_correlation_ignores_foreign_sc
     assert execution_event["order_decision_authority"] != "foreign-scope-authority"
 
 
+def test_same_symbol_opposite_side_plain_different_correlation_restored_same_scope_is_blocked_by_ambiguity_guard(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 11, 12, 0, tzinfo=timezone.utc)
+    buy_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=1,
+    )
+    sell_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=2,
+    )
+    repository = OpportunityShadowRepository(tmp_path / "shadow")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(correlation_key=buy_key, decision_timestamp=decision_timestamp),
+            replace(
+                _shadow_record_for_key(correlation_key=sell_key, decision_timestamp=decision_timestamp),
+                proposed_direction="short",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=buy_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "restored_tracker",
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=99.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    opposite_sell = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=sell_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=False,
+        include_mode=True,
+    )
+
+    results = controller.process_signals([opposite_sell])
+
+    assert results == []
+    assert execution.requests == []
+    assert _order_path_events_with_shadow_key(journal, sell_key) == []
+    skipped = [
+        event
+        for event in journal.export()
+        if event.get("event") == "signal_skipped"
+        and event.get("order_opportunity_shadow_record_key") == sell_key
+    ]
+    assert len(skipped) == 1
+    assert skipped[0]["status"] == "skipped"
+    assert skipped[0]["reason"] == "same_symbol_opposite_side_close_correlation_ambiguous"
+    assert skipped[0]["proxy_correlation_key"] == sell_key
+    assert skipped[0]["order_opportunity_shadow_record_key"] == sell_key
+    assert skipped[0]["existing_open_correlation_key"] == buy_key
+    assert skipped[0]["existing_open_side"] == "BUY"
+    open_rows = repository.load_open_outcomes()
+    assert [row.correlation_key for row in open_rows] == [buy_key]
+    assert open_rows[0].closed_quantity == pytest.approx(0.0, rel=1e-6)
+    runtime_tracker = controller._opportunity_open_outcomes[buy_key]
+    assert runtime_tracker.restored_from_repository is True
+    assert runtime_tracker.entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert runtime_tracker.closed_quantity == pytest.approx(0.0, rel=1e-6)
+    assert [row for row in repository.load_outcome_labels() if row.correlation_key == sell_key] == []
+    assert not any(
+        row.correlation_key == sell_key and row.label_quality in {"final", "partial"}
+        for row in repository.load_outcome_labels()
+    )
+    non_skip_events = [event for event in journal.export() if event.get("event") != "signal_skipped"]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(non_skip_events, shadow_key=sell_key)
+
+
+def test_same_symbol_opposite_side_plain_different_correlation_foreign_scope_restored_tracker_does_not_trigger_ambiguity_guard(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 11, 12, 15, tzinfo=timezone.utc)
+    foreign_buy_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=1,
+    )
+    sell_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=2,
+    )
+    repository = OpportunityShadowRepository(tmp_path / "shadow")
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(correlation_key=sell_key, decision_timestamp=decision_timestamp),
+                proposed_direction="short",
+            )
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=foreign_buy_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "foreign_scope_tracker",
+                "environment": "live",
+                "portfolio": "foreign-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=99.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    opposite_sell = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=sell_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=False,
+        include_mode=True,
+    )
+
+    results = controller.process_signals([opposite_sell])
+
+    assert [result.status for result in results] == ["filled"]
+    assert _request_shadow_keys(execution.requests) == [sell_key]
+    assert len(execution.requests) == 1
+    assert [request.side for request in execution.requests] == ["SELL"]
+    assert _order_path_events_with_shadow_key(journal, sell_key)
+    ambiguous_skips = [
+        event
+        for event in journal.export()
+        if event.get("event") == "signal_skipped"
+        and event.get("order_opportunity_shadow_record_key") == sell_key
+        and event.get("reason") == "same_symbol_opposite_side_close_correlation_ambiguous"
+    ]
+    assert ambiguous_skips == []
+    skipped_for_sell = [
+        event
+        for event in journal.export()
+        if event.get("event") == "signal_skipped"
+        and event.get("order_opportunity_shadow_record_key") == sell_key
+    ]
+    assert skipped_for_sell == []
+    open_outcomes_by_key = {row.correlation_key: row for row in repository.load_open_outcomes()}
+    assert set(open_outcomes_by_key) == {foreign_buy_key, sell_key}
+    assert open_outcomes_by_key[foreign_buy_key].side == "BUY"
+    assert open_outcomes_by_key[foreign_buy_key].entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert open_outcomes_by_key[foreign_buy_key].closed_quantity == pytest.approx(0.0, rel=1e-6)
+    assert open_outcomes_by_key[sell_key].side == "SELL"
+    assert open_outcomes_by_key[sell_key].entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert open_outcomes_by_key[sell_key].closed_quantity == pytest.approx(0.0, rel=1e-6)
+    runtime_foreign_tracker = controller._opportunity_open_outcomes[foreign_buy_key]
+    assert runtime_foreign_tracker.restored_from_repository is True
+    assert runtime_foreign_tracker.entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert runtime_foreign_tracker.closed_quantity == pytest.approx(0.0, rel=1e-6)
+    assert not any(
+        row.correlation_key == foreign_buy_key and row.label_quality in {"final", "partial"}
+        for row in repository.load_outcome_labels()
+    )
+    assert not any(
+        row.correlation_key == sell_key and row.label_quality in {"final", "partial"}
+        for row in repository.load_outcome_labels()
+    )
+    non_skip_events = [event for event in journal.export() if event.get("event") != "signal_skipped"]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(non_skip_events, shadow_key=sell_key)
+
+
+def test_same_symbol_opposite_side_different_correlation_restored_same_scope_with_decision_payload_bypasses_plain_ambiguity_guard(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 11, 12, 30, tzinfo=timezone.utc)
+    buy_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=1,
+    )
+    sell_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=2,
+    )
+    repository = OpportunityShadowRepository(tmp_path / "shadow")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(correlation_key=buy_key, decision_timestamp=decision_timestamp),
+            replace(
+                _shadow_record_for_key(correlation_key=sell_key, decision_timestamp=decision_timestamp),
+                proposed_direction="short",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=buy_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "restored_tracker",
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=99.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    opposite_sell = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=sell_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        include_mode=True,
+    )
+
+    results = controller.process_signals([opposite_sell])
+
+    assert [result.status for result in results] == ["filled"]
+    assert _request_shadow_keys(execution.requests) == [sell_key]
+    assert len(execution.requests) == 1
+    assert [request.side for request in execution.requests] == ["SELL"]
+    assert _order_path_events_with_shadow_key(journal, sell_key)
+    ambiguous_skips = [
+        event
+        for event in journal.export()
+        if event.get("event") == "signal_skipped"
+        and event.get("order_opportunity_shadow_record_key") == sell_key
+        and event.get("reason") == "same_symbol_opposite_side_close_correlation_ambiguous"
+    ]
+    assert ambiguous_skips == []
+    skipped_for_sell = [
+        event
+        for event in journal.export()
+        if event.get("event") == "signal_skipped"
+        and event.get("order_opportunity_shadow_record_key") == sell_key
+    ]
+    assert skipped_for_sell == []
+    open_outcomes_by_key = {row.correlation_key: row for row in repository.load_open_outcomes()}
+    assert set(open_outcomes_by_key) == {buy_key, sell_key}
+    assert open_outcomes_by_key[buy_key].side == "BUY"
+    assert open_outcomes_by_key[buy_key].entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert open_outcomes_by_key[buy_key].closed_quantity == pytest.approx(0.0, rel=1e-6)
+    assert open_outcomes_by_key[sell_key].side == "SELL"
+    assert open_outcomes_by_key[sell_key].entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert open_outcomes_by_key[sell_key].closed_quantity == pytest.approx(0.0, rel=1e-6)
+    runtime_buy_tracker = controller._opportunity_open_outcomes[buy_key]
+    assert runtime_buy_tracker.restored_from_repository is True
+    assert runtime_buy_tracker.entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert runtime_buy_tracker.closed_quantity == pytest.approx(0.0, rel=1e-6)
+    assert not any(
+        row.correlation_key == sell_key and row.label_quality in {"final", "partial"}
+        for row in repository.load_outcome_labels()
+    )
+    non_skip_events = [event for event in journal.export() if event.get("event") != "signal_skipped"]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(non_skip_events, shadow_key=sell_key)
+
+
 def test_non_autonomous_opposite_side_cross_correlation_does_not_emit_autonomous_duplicate_skip() -> (
     None
 ):


### PR DESCRIPTION
### Motivation

- Add coverage for ambiguity handling when a restored open outcome exists for the same symbol but different correlation key and opposite side, to ensure the controller blocks ambiguous autonomous signals.
- Verify that restored trackers from a foreign scope do not trigger the same-scope ambiguity guard and that providing a decision payload bypasses the plain ambiguity guard.

### Description

- Added three unit tests to `tests/test_trading_controller.py`: `test_same_symbol_opposite_side_plain_different_correlation_restored_same_scope_is_blocked_by_ambiguity_guard`, `test_same_symbol_opposite_side_plain_different_correlation_foreign_scope_restored_tracker_does_not_trigger_ambiguity_guard`, and `test_same_symbol_opposite_side_different_correlation_restored_same_scope_with_decision_payload_bypasses_plain_ambiguity_guard`.
- Each test constructs an `OpportunityShadowRepository` with shadow records and an upserted open outcome, builds an autonomy controller via `_build_autonomy_controller_with_execution`, sends an opposing-side signal, and asserts expected `execution` requests, journal `signal_skipped` events, and repository open outcome state.
- Tests assert specific journal metadata including `reason` values such as `same_symbol_opposite_side_close_correlation_ambiguous`, the presence or absence of skip events, and that no duplicate residue metadata exists using `_assert_no_duplicate_residue_metadata_for_shadow_key`.
- These are test-only changes that exercise restored tracker behavior, scope provenance handling, and decision-payload bypass logic.

### Testing

- Ran the new tests via `pytest tests/test_trading_controller.py -k same_symbol_opposite_side` and confirmed they completed successfully.
- The assertions validate execution request contents, journal events, and repository state and all checks passed for the added cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b813c410832a85cff2488517003c)