### PR TITLE
Add test: ambiguity guard rejects non-mapping autonomy decision payloads

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -11042,6 +11042,118 @@ def test_same_symbol_opposite_side_plain_different_correlation_foreign_scope_res
     _assert_no_duplicate_residue_metadata_for_shadow_key(non_skip_events, shadow_key=sell_key)
 
 
+@pytest.mark.parametrize(
+    "decision_payload",
+    [
+        pytest.param("not-a-mapping", id="string"),
+        pytest.param(["not", "a", "mapping"], id="list"),
+        pytest.param(None, id="none"),
+    ],
+)
+def test_same_symbol_opposite_side_plain_different_correlation_restored_same_scope_non_mapping_decision_payload_does_not_bypass_ambiguity_guard(
+    tmp_path: Path, decision_payload: object
+) -> None:
+    decision_timestamp = datetime(2026, 1, 11, 12, 30, tzinfo=timezone.utc)
+    buy_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=1,
+    )
+    sell_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v5",
+        rank=2,
+    )
+    repository = OpportunityShadowRepository(tmp_path / "shadow")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(correlation_key=buy_key, decision_timestamp=decision_timestamp),
+            replace(
+                _shadow_record_for_key(correlation_key=sell_key, decision_timestamp=decision_timestamp),
+                proposed_direction="short",
+            ),
+        ]
+    )
+    repository.upsert_open_outcome(
+        repository.OpenOutcomeState(
+            correlation_key=buy_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={
+                "source": "restored_tracker",
+                "environment": "paper",
+                "portfolio": "paper-1",
+                "autonomy_final_mode": "paper_autonomous",
+            },
+        )
+    )
+    execution = StatusExecutionService(status="filled", filled_quantity=1.0, avg_price=99.0)
+    controller, journal = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    opposite_sell = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=sell_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=False,
+        include_mode=True,
+    )
+    opposite_sell.metadata["opportunity_autonomy_decision"] = decision_payload
+
+    results = controller.process_signals([opposite_sell])
+
+    assert results == []
+    assert execution.requests == []
+    assert _order_path_events_with_shadow_key(journal, sell_key) == []
+    skipped = [
+        event
+        for event in journal.export()
+        if event.get("event") == "signal_skipped"
+        and event.get("order_opportunity_shadow_record_key") == sell_key
+    ]
+    assert len(skipped) == 1
+    assert skipped[0]["status"] == "skipped"
+    assert skipped[0]["reason"] == "same_symbol_opposite_side_close_correlation_ambiguous"
+    assert skipped[0]["proxy_correlation_key"] == sell_key
+    assert skipped[0]["order_opportunity_shadow_record_key"] == sell_key
+    assert skipped[0]["existing_open_correlation_key"] == buy_key
+    assert skipped[0]["existing_open_side"] == "BUY"
+    open_rows = repository.load_open_outcomes()
+    assert [row.correlation_key for row in open_rows] == [buy_key]
+    assert open_rows[0].entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert open_rows[0].closed_quantity == pytest.approx(0.0, rel=1e-6)
+    runtime_tracker = controller._opportunity_open_outcomes[buy_key]
+    assert runtime_tracker.restored_from_repository is True
+    assert runtime_tracker.entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert runtime_tracker.closed_quantity == pytest.approx(0.0, rel=1e-6)
+    assert not any(
+        row.correlation_key == buy_key and row.label_quality in {"final", "partial"}
+        for row in repository.load_outcome_labels()
+    )
+    assert not any(
+        row.correlation_key == sell_key and row.label_quality in {"final", "partial"}
+        for row in repository.load_outcome_labels()
+    )
+    sell_attach_events = [
+        event
+        for event in journal.export()
+        if event.get("event") == "opportunity_outcome_attach"
+        and event.get("order_opportunity_shadow_record_key") == sell_key
+    ]
+    assert sell_attach_events == []
+    non_skip_events = [event for event in journal.export() if event.get("event") != "signal_skipped"]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(non_skip_events, shadow_key=sell_key)
+
+
 def test_same_symbol_opposite_side_different_correlation_restored_same_scope_with_decision_payload_bypasses_plain_ambiguity_guard(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Ensure the close-correlation ambiguity guard is not bypassed when `opportunity_autonomy_decision` is present but not a mapping (e.g. `str`, `list`, or `None`).
- Cover a regression where malformed decision payloads might incorrectly allow opposite-side closes against a restored open outcome.

### Description
- Added a new parametrized test `test_same_symbol_opposite_side_plain_different_correlation_restored_same_scope_non_mapping_decision_payload_does_not_bypass_ambiguity_guard` to `tests/test_trading_controller.py` that exercises three non-mapping payload variants (`"not-a-mapping"`, list, and `None`).
- The test sets up a restored `BUY` open outcome and an incoming `SELL` signal with the non-mapping `opportunity_autonomy_decision` metadata and asserts the signal is skipped by the ambiguity guard.
- The test verifies no execution requests were made, open outcomes remain unchanged, no outcome labels were created for either correlation key, and no duplicate residue metadata is produced in the journal.

### Testing
- Ran `pytest -q tests/test_trading_controller.py -k non_mapping_decision_payload_does_not_bypass_ambiguity_guard`, which attempted to collect and execute the new test but collection failed due to a missing dependency: `ModuleNotFoundError: No module named 'numpy'`.
- No successful test run result is available in this environment because of the missing `numpy` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f210347d10832aadf176f19d9e95a0)