### PR TITLE
Harden live incomplete autonomy enforcement assertions

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -58734,12 +58734,15 @@ def test_same_symbol_opposite_side_plain_different_correlation_live_restored_sam
     ]
     assert len(enforcement_blocked) == 1
     blocked_event = enforcement_blocked[0]
-    assert blocked_event["blocking_reason"] in {
-        "live_assisted_requires_explicit_approval",
-        "autonomy_permission_evaluation_failed",
-    }
+    assert blocked_event["blocking_reason"] == "live_assisted_requires_explicit_approval"
     assert blocked_event["execution_permission"] == "blocked"
+    assert blocked_event["autonomy_final_mode"] == "live_assisted"
     assert blocked_event["autonomy_requested_mode"] == "live_autonomous"
+    assert blocked_event["autonomous_execution_allowed"] == "false"
+    assert blocked_event["assisted_override_required"] == "true"
+    assert blocked_event["assisted_override_used"] == "false"
+    assert blocked_event.get("upstream_autonomy_payload_source") is None
+    assert blocked_event.get("upstream_autonomy_effective_mode") is None
     sell_attach_events = [
         event
         for event in journal.export()
@@ -58766,17 +58769,25 @@ def test_same_symbol_opposite_side_plain_different_correlation_live_restored_sam
 
 
 @pytest.mark.parametrize(
-    "decision_payload",
+    (
+        "decision_payload",
+        "expected_blocking_reason",
+        "expected_autonomy_final_mode",
+        "expected_upstream_effective_mode",
+    ),
     [
-        {},
-        {"unexpected": "value"},
-        {"effective_mode": ""},
-        {"effective_mode": None},
+        ({}, "live_assisted_requires_explicit_approval", "live_assisted", None),
+        ({"unexpected": "value"}, "live_assisted_requires_explicit_approval", "live_assisted", None),
+        ({"effective_mode": ""}, "autonomy_permission_evaluation_failed", "unavailable", None),
+        ({"effective_mode": None}, "live_assisted_requires_explicit_approval", "live_assisted", None),
     ],
 )
 def test_same_symbol_opposite_side_plain_different_correlation_live_restored_same_scope_incomplete_decision_payload_does_not_bypass_ambiguity_guard(
     tmp_path: Path,
     decision_payload: dict[str, object],
+    expected_blocking_reason: str,
+    expected_autonomy_final_mode: str,
+    expected_upstream_effective_mode: str | None,
 ) -> None:
     decision_timestamp = datetime(2026, 1, 3, 13, 25, tzinfo=timezone.utc)
     buy_key = OpportunityShadowRecord.build_record_key(
@@ -58855,12 +58866,19 @@ def test_same_symbol_opposite_side_plain_different_correlation_live_restored_sam
     ]
     assert len(enforcement_blocked) == 1
     blocked_event = enforcement_blocked[0]
-    assert blocked_event["blocking_reason"] in {
-        "live_assisted_requires_explicit_approval",
-        "autonomy_permission_evaluation_failed",
-    }
+    assert blocked_event["blocking_reason"] == expected_blocking_reason
     assert blocked_event["execution_permission"] == "blocked"
+    assert blocked_event["autonomy_final_mode"] == expected_autonomy_final_mode
     assert blocked_event["autonomy_requested_mode"] == "live_autonomous"
+    assert blocked_event["autonomous_execution_allowed"] == "false"
+    if expected_blocking_reason == "autonomy_permission_evaluation_failed":
+        assert blocked_event.get("assisted_override_required") is None
+        assert blocked_event.get("assisted_override_used") is None
+    else:
+        assert blocked_event["assisted_override_required"] == "true"
+        assert blocked_event["assisted_override_used"] == "false"
+    assert blocked_event.get("upstream_autonomy_payload_source") is None
+    assert blocked_event.get("upstream_autonomy_effective_mode") == expected_upstream_effective_mode
     sell_attach_events = [
         event
         for event in journal.export()
@@ -58884,6 +58902,8 @@ def test_same_symbol_opposite_side_plain_different_correlation_live_restored_sam
         row.correlation_key == sell_key and row.label_quality in {"final", "partial"}
         for row in shadow_repo.load_outcome_labels()
     )
+    non_skip_events = [event for event in journal.export() if event.get("event") != "signal_skipped"]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(non_skip_events, shadow_key=sell_key)
 
 
 def test_same_symbol_opposite_side_different_correlation_live_restored_same_scope_with_valid_decision_payload_bypass_contract(


### PR DESCRIPTION
### Motivation
- Tests allowed a soft set of `blocking_reason` values for live/incomplete autonomy payloads, masking per-payload enforcement shape regressions.
- The change pins exact enforcement event fields for specific incomplete payloads so the contract is strict and observable without altering runtime behavior.

### Description
- Tightened the live plain flow test to assert an exact `blocking_reason` and stable governance fields (`autonomy_final_mode`, `autonomous_execution_allowed`, assisted override flags, upstream payload fields) instead of a set membership.
- Re-parameterized the incomplete decision payload test to accept tuples `(decision_payload, expected_blocking_reason, expected_autonomy_final_mode, expected_upstream_effective_mode)` and added exact assertions per case for `{}`, `{"unexpected": "value"}`, `{"effective_mode": ""}`, and `{"effective_mode": None}`.
- Added a no-residue metadata assertion (`_assert_no_duplicate_residue_metadata_for_shadow_key`) for the live incomplete mapping test to ensure no duplicate/residual metadata remains after filtering skip events.
- Changes are test-only in `tests/test_trading_controller.py`; no changes were made to `bot_core/runtime/controller.py`.

### Testing
- Installed dev deps with `python scripts/ci/pip_install.py -- .[dev]` and ran focused tests with `pytest` as requested, all passing for the targeted selections.
- Ran `PYENV_VERSION=3.11.14 pytest -q tests/test_trading_controller.py -k "live_restored_same_scope or valid_decision_payload_bypass_contract or incomplete_decision_payload"` and got `9 passed, 878 deselected`.
- Ran broader targeted suites and lineage tests with `pytest` and `tests/ai/test_opportunity_lifecycle.py`, all selected tests passed (`702 passed` and `626 passed` runs respectively) and `ruff` checks passed on the touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f228f30e74832a87c1b35c57bb78a4)