### PR TITLE
Suppress autonomous open replay after final autonomous close and add test

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1144,6 +1144,105 @@ class TradingController:
             return False
         return False
 
+    def _is_duplicate_autonomous_open_replay_after_final_close(
+        self,
+        *,
+        request: OrderRequest,
+        correlation_key: str,
+        existing_open_tracker: _OpportunityOpenOutcomeTracker | None,
+    ) -> bool:
+        if not correlation_key or existing_open_tracker is not None:
+            return False
+        request_metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        local_mode = str(request_metadata.get("mode") or "").strip().lower()
+        if local_mode == "close_ranked":
+            return False
+        autonomy_mode = str(request_metadata.get("opportunity_autonomy_mode") or "").strip().lower()
+        decision_payload = request_metadata.get("opportunity_autonomy_decision")
+        payload_effective_mode = ""
+        if isinstance(decision_payload, Mapping):
+            payload_effective_mode = str(decision_payload.get("effective_mode") or "").strip().lower()
+        if autonomy_mode not in {"paper_autonomous", "live_autonomous"} and payload_effective_mode not in {
+            "paper_autonomous",
+            "live_autonomous",
+        }:
+            return False
+        side = str(request.side or "").upper()
+        if side not in (_BUY_SIDES | _SELL_SIDES):
+            return False
+        repository = self._opportunity_shadow_repository
+        if repository is None:
+            return False
+        try:
+            labels = repository.load_outcome_labels()
+            shadow_records = repository.load_shadow_records()
+        except Exception:  # pragma: no cover - diagnostics only
+            _LOGGER.debug(
+                "Nie udało się zweryfikować replay open po final close przed egzekucją",
+                exc_info=True,
+            )
+            return False
+        scope_environment = str(self.environment or "").strip()
+        scope_portfolio = str(self.portfolio_id or "").strip()
+        for row in labels:
+            if (
+                row.correlation_key != correlation_key
+                or str(row.symbol) != str(request.symbol)
+                or not str(row.label_quality).startswith("final")
+            ):
+                continue
+            final_provenance = row.provenance if isinstance(row.provenance, Mapping) else {}
+            final_mode = str(final_provenance.get("autonomy_final_mode") or "").strip().lower()
+            if final_mode not in {"paper_autonomous", "live_autonomous"}:
+                continue
+            final_environment = str(final_provenance.get("environment") or "").strip()
+            final_portfolio = str(
+                final_provenance.get("portfolio") or final_provenance.get("portfolio_id") or ""
+            ).strip()
+            if scope_environment and not final_environment:
+                continue
+            if scope_portfolio and not final_portfolio:
+                continue
+            if final_environment and scope_environment and final_environment != scope_environment:
+                continue
+            if final_portfolio and scope_portfolio and final_portfolio != scope_portfolio:
+                continue
+            for shadow_record in shadow_records:
+                if shadow_record.record_key != correlation_key:
+                    continue
+                if str(getattr(shadow_record, "symbol", "")) != str(request.symbol):
+                    continue
+                shadow_context = getattr(shadow_record, "context", None)
+                if isinstance(shadow_context, Mapping):
+                    shadow_environment_raw = shadow_context.get("environment")
+                else:
+                    shadow_environment_raw = getattr(shadow_context, "environment", None)
+                shadow_environment = (
+                    str(shadow_environment_raw).strip() if shadow_environment_raw is not None else ""
+                )
+                shadow_environment_normalized = shadow_environment.lower()
+                legacy_shadow_scope_missing = shadow_environment_normalized in {"", "shadow"}
+                if (
+                    scope_environment
+                    and shadow_environment
+                    and shadow_environment != scope_environment
+                    and not legacy_shadow_scope_missing
+                ):
+                    continue
+                proposed_direction = (
+                    str(getattr(shadow_record, "proposed_direction", "")).strip().lower()
+                )
+                expected_open_side = (
+                    "BUY"
+                    if proposed_direction in {"long", "buy"}
+                    else ("SELL" if proposed_direction in {"short", "sell"} else "")
+                )
+                if not expected_open_side:
+                    continue
+                if expected_open_side == side:
+                    return True
+        return False
+
     def _matches_current_open_tracker_scope(
         self,
         *,
@@ -2822,6 +2921,23 @@ class TradingController:
                 status="skipped",
                 metadata={
                     "reason": "duplicate_autonomous_close_replay_suppressed",
+                    "proxy_correlation_key": correlation_key,
+                },
+            )
+            return None
+        if self._is_duplicate_autonomous_open_replay_after_final_close(
+            request=request,
+            correlation_key=correlation_key,
+            existing_open_tracker=existing_open_tracker,
+        ):
+            self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+            self._record_decision_event(
+                "signal_skipped",
+                signal=signal,
+                request=request,
+                status="skipped",
+                metadata={
+                    "reason": "final_outcome_replay_open_suppressed",
                     "proxy_correlation_key": correlation_key,
                 },
             )

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -59473,6 +59473,233 @@ def test_opportunity_autonomy_open_replay_after_final_close_and_controller_resta
     assert alert_contexts_snapshot
 
 
+def test_opportunity_autonomy_exact_open_replay_after_final_close_and_controller_restart_is_blocked_by_final_label_without_timestamp_mismatch(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 12, 50, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    execution_1 = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 200.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 210.0},
+        ]
+    )
+    journal_1 = CollectingDecisionJournal()
+    tco_reporter_1 = StubTCOReporter()
+    router_1, channel_1, _audit_1 = _router_with_channel()
+    controller_1 = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_1,
+        alert_router=router_1,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal_1,
+        opportunity_shadow_repository=repository,
+        tco_reporter=tco_reporter_1,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    assert replay_open_signal.side == "BUY"
+    assert str(replay_open_signal.metadata.get("mode") or "").strip().lower() != "close_ranked"
+
+    open_results = controller_1.process_signals([open_signal])
+    assert [result.status for result in open_results] == ["filled"]
+    close_results = controller_1.process_signals([close_signal])
+    assert [result.status for result in close_results] == ["filled"]
+    assert correlation_key not in controller_1._opportunity_open_outcomes
+    assert correlation_key not in [row.correlation_key for row in repository.load_open_outcomes()]
+    labels_after_close = [
+        row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key
+    ]
+    assert len([row for row in labels_after_close if row.label_quality == "final"]) == 1
+    assert [
+        row for row in labels_after_close if row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    assert [request.side for request in execution_1.requests] == ["BUY", "SELL"]
+    assert [call["side"] for call in tco_reporter_1.calls] == ["BUY", "SELL"]
+    assert [call["quantity"] for call in tco_reporter_1.calls] == [1.0, 1.0]
+    execution_alert_contexts_after_close = [
+        dict(message.context)
+        for message in channel_1.messages
+        if getattr(message, "category", "") == "execution"
+        and str(message.context.get("meta_opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+    ]
+    assert len(execution_alert_contexts_after_close) == 2
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+    labels_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    order_events_snapshot = [
+        dict(event) for event in _order_path_events_with_shadow_key(journal_1, correlation_key)
+    ]
+    attach_events_snapshot = [
+        dict(event)
+        for event in journal_1.export()
+        if event.get("event") == "opportunity_outcome_attach"
+        and event.get("order_opportunity_shadow_record_key") == correlation_key
+    ]
+    tco_calls_snapshot = [dict(call) for call in tco_reporter_1.calls]
+    alert_contexts_snapshot = [dict(ctx) for ctx in execution_alert_contexts_after_close]
+
+    execution_2 = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal_2 = CollectingDecisionJournal()
+    tco_reporter_2 = StubTCOReporter()
+    router_2, channel_2, _audit_2 = _router_with_channel()
+    controller_2 = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_2,
+        alert_router=router_2,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal_2,
+        opportunity_shadow_repository=repository,
+        tco_reporter=tco_reporter_2,
+    )
+    assert correlation_key not in controller_2._opportunity_open_outcomes
+
+    replay_results = controller_2.process_signals([replay_open_signal])
+
+    assert replay_results == []
+    assert execution_2.requests == []
+    assert correlation_key not in controller_2._opportunity_open_outcomes
+    assert correlation_key not in [row.correlation_key for row in repository.load_open_outcomes()]
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    labels_after_replay = repository.load_outcome_labels()
+    labels_after_replay_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance)) for row in labels_after_replay
+    ]
+    assert labels_after_replay_snapshot == labels_snapshot
+    assert len(
+        [
+            row
+            for row in labels_after_replay
+            if row.correlation_key == correlation_key and row.label_quality == "final"
+        ]
+    ) == 1
+    assert [
+        row
+        for row in labels_after_replay
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    order_path_events_after_replay = _order_path_events_with_shadow_key(journal_2, correlation_key)
+    assert order_path_events_after_replay == []
+    attach_events_after_replay = [
+        dict(event)
+        for event in journal_2.export()
+        if event.get("event") == "opportunity_outcome_attach"
+        and event.get("order_opportunity_shadow_record_key") == correlation_key
+    ]
+    assert attach_events_after_replay == []
+    assert tco_reporter_2.calls == []
+    execution_alert_contexts_after_replay = [
+        dict(message.context)
+        for message in channel_2.messages
+        if getattr(message, "category", "") == "execution"
+        and str(message.context.get("meta_opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+    ]
+    assert execution_alert_contexts_after_replay == []
+
+    journal_2_events = [dict(event) for event in journal_2.export()]
+    replay_skip_events = [
+        event
+        for event in journal_2_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip = replay_skip_events[0]
+    assert replay_skip.get("status") == "skipped"
+    assert str(replay_skip.get("reason") or replay_skip.get("decision_reason") or "").strip() == (
+        "final_outcome_replay_open_suppressed"
+    )
+    assert str(replay_skip.get("proxy_correlation_key") or "").strip() == correlation_key
+    if "order_opportunity_shadow_record_key" in replay_skip:
+        assert str(replay_skip.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+
+    replay_enforcement_events = [
+        event
+        for event in journal_2_events
+        if str(event.get("event") or "").strip() == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ]
+    if replay_enforcement_events:
+        assert len(replay_enforcement_events) == 1
+        replay_reason = str(
+            replay_enforcement_events[0].get("reason")
+            or replay_enforcement_events[0].get("decision_reason")
+            or replay_enforcement_events[0].get("autonomy_decisive_reason")
+            or ""
+        ).strip()
+        assert replay_reason != "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+    assert [
+        event
+        for event in journal_2_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert [
+        event
+        for event in journal_2_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    non_skip_events = [
+        event for event in journal_2_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        non_skip_events, shadow_key=correlation_key
+    )
+    assert order_events_snapshot
+    assert attach_events_snapshot
+    assert tco_calls_snapshot
+    assert alert_contexts_snapshot
+
+
 def test_same_symbol_opposite_side_different_correlation_key_with_decision_payload_bypasses_plain_ambiguity_guard(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation

- Prevent reopening an opportunity when an autonomous final close has already been recorded for the same shadow record and scope, to avoid duplicate autonomous open replays after controller restart. 
- Ensure autonomously-sourced replays honor environment/portfolio scoping and the existing final outcome provenance. 

### Description

- Added `_is_duplicate_autonomous_open_replay_after_final_close` to `TradingController` to detect and suppress autonomous open requests that match a previously recorded final autonomous outcome. 
- The new check validates `request.metadata` (including `opportunity_autonomy_mode` and `opportunity_autonomy_decision`), request side, repository presence, and matches final outcome labels and shadow records while respecting environment and portfolio scope. 
- Integrated the new guard into the signal processing flow to increment metrics and record a `signal_skipped` decision event with reason `final_outcome_replay_open_suppressed` when suppression occurs. 
- Added unit test `test_opportunity_autonomy_exact_open_replay_after_final_close_and_controller_restart_is_blocked_by_final_label_without_timestamp_mismatch` to cover the controller restart / replay scenario. 

### Testing

- Ran the unit test suite with `pytest`, including the new test `test_opportunity_autonomy_exact_open_replay_after_final_close_and_controller_restart_is_blocked_by_final_label_without_timestamp_mismatch`, and the tests completed successfully. 
- Verified the new behavior by asserting no execution requests, no TCO calls, and a single `signal_skipped` journal event with reason `final_outcome_replay_open_suppressed` in the replay scenario.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37a0591f8832a898febd1fa5243b6)