### PR TITLE
Zablokuj legacy replay autonomous OPEN po final CLOSE (fix guard + test)

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1162,11 +1162,10 @@ class TradingController:
         payload_effective_mode = ""
         if isinstance(decision_payload, Mapping):
             payload_effective_mode = str(decision_payload.get("effective_mode") or "").strip().lower()
-        if autonomy_mode not in {"paper_autonomous", "live_autonomous"} and payload_effective_mode not in {
+        has_autonomy_metadata = autonomy_mode in {"paper_autonomous", "live_autonomous"} or payload_effective_mode in {
             "paper_autonomous",
             "live_autonomous",
-        }:
-            return False
+        }
         side = str(request.side or "").upper()
         if side not in (_BUY_SIDES | _SELL_SIDES):
             return False
@@ -1228,6 +1227,12 @@ class TradingController:
                     and shadow_environment != scope_environment
                     and not legacy_shadow_scope_missing
                 ):
+                    continue
+                if has_autonomy_metadata:
+                    shadow_accepted = True
+                else:
+                    shadow_accepted = bool(getattr(shadow_record, "accepted", False))
+                if not shadow_accepted:
                     continue
                 proposed_direction = (
                     str(getattr(shadow_record, "proposed_direction", "")).strip().lower()

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -59700,6 +59700,233 @@ def test_opportunity_autonomy_exact_open_replay_after_final_close_and_controller
     assert alert_contexts_snapshot
 
 
+def test_opportunity_autonomy_exact_legacy_open_replay_after_final_close_and_controller_restart_is_blocked_by_final_label_without_autonomy_metadata(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 12, 55, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key,
+                decision_timestamp=decision_timestamp,
+            )
+        ]
+    )
+    execution_1 = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 200.0},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 210.0},
+        ]
+    )
+    journal_1 = CollectingDecisionJournal()
+    tco_reporter_1 = StubTCOReporter()
+    router_1, channel_1, _audit_1 = _router_with_channel()
+    controller_1 = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_1,
+        alert_router=router_1,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal_1,
+        opportunity_shadow_repository=repository,
+        tco_reporter=tco_reporter_1,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "close_ranked"}
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    assert replay_open_signal.side == "BUY"
+    assert str(replay_open_signal.metadata.get("mode") or "").strip().lower() != "close_ranked"
+    assert not str(replay_open_signal.metadata.get("opportunity_autonomy_mode") or "").strip()
+    replay_decision_payload = replay_open_signal.metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision_payload, Mapping):
+        assert not str(replay_decision_payload.get("effective_mode") or "").strip()
+    else:
+        assert replay_decision_payload in (None, "", {})
+
+    open_results = controller_1.process_signals([open_signal])
+    assert [result.status for result in open_results] == ["filled"]
+    close_results = controller_1.process_signals([close_signal])
+    assert [result.status for result in close_results] == ["filled"]
+    assert correlation_key not in controller_1._opportunity_open_outcomes
+    assert correlation_key not in [row.correlation_key for row in repository.load_open_outcomes()]
+    labels_after_close = [
+        row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key
+    ]
+    assert len([row for row in labels_after_close if row.label_quality == "final"]) == 1
+    assert [
+        row for row in labels_after_close if row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+    labels_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    order_events_snapshot = [
+        dict(event) for event in _order_path_events_with_shadow_key(journal_1, correlation_key)
+    ]
+    attach_events_snapshot = [
+        dict(event)
+        for event in journal_1.export()
+        if event.get("event") == "opportunity_outcome_attach"
+        and event.get("order_opportunity_shadow_record_key") == correlation_key
+    ]
+    tco_calls_snapshot = [dict(call) for call in tco_reporter_1.calls]
+    alert_contexts_snapshot = [
+        dict(message.context)
+        for message in channel_1.messages
+        if getattr(message, "category", "") == "execution"
+        and str(message.context.get("meta_opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+    ]
+
+    execution_2 = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal_2 = CollectingDecisionJournal()
+    tco_reporter_2 = StubTCOReporter()
+    router_2, channel_2, _audit_2 = _router_with_channel()
+    controller_2 = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_2,
+        alert_router=router_2,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal_2,
+        opportunity_shadow_repository=repository,
+        tco_reporter=tco_reporter_2,
+    )
+
+    replay_results = controller_2.process_signals([replay_open_signal])
+
+    assert replay_results == []
+    assert execution_2.requests == []
+    assert correlation_key not in controller_2._opportunity_open_outcomes
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    labels_after_replay = repository.load_outcome_labels()
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance)) for row in labels_after_replay
+    ] == labels_snapshot
+    assert len(
+        [
+            row
+            for row in labels_after_replay
+            if row.correlation_key == correlation_key and row.label_quality == "final"
+        ]
+    ) == 1
+    assert [
+        row
+        for row in labels_after_replay
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    journal_2_events = [dict(event) for event in journal_2.export()]
+    assert [
+        event
+        for event in journal_2_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert [
+        event
+        for event in journal_2_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert tco_reporter_2.calls == []
+    assert [
+        dict(message.context)
+        for message in channel_2.messages
+        if getattr(message, "category", "") == "execution"
+        and str(message.context.get("meta_opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+    ] == []
+
+    replay_skip_events = [
+        event
+        for event in journal_2_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip = replay_skip_events[0]
+    assert replay_skip.get("status") == "skipped"
+    assert str(replay_skip.get("reason") or replay_skip.get("decision_reason") or "").strip() == (
+        "final_outcome_replay_open_suppressed"
+    )
+    assert str(replay_skip.get("proxy_correlation_key") or "").strip() == correlation_key
+    if "order_opportunity_shadow_record_key" in replay_skip:
+        assert str(replay_skip.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+
+    replay_enforcement_events = [
+        event
+        for event in journal_2_events
+        if str(event.get("event") or "").strip() == "opportunity_autonomy_enforcement"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ]
+    if replay_enforcement_events:
+        assert len(replay_enforcement_events) == 1
+        replay_reason = str(
+            replay_enforcement_events[0].get("reason")
+            or replay_enforcement_events[0].get("decision_reason")
+            or replay_enforcement_events[0].get("autonomy_decisive_reason")
+            or ""
+        ).strip()
+        assert replay_reason != "accepted_autonomous_handoff_shadow_reference_timestamp_mismatch"
+
+    non_skip_events = [
+        event for event in journal_2_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        non_skip_events, shadow_key=correlation_key
+    )
+    assert order_events_snapshot
+    assert attach_events_snapshot
+    assert tco_calls_snapshot
+    assert alert_contexts_snapshot
+
+
 def test_same_symbol_opposite_side_different_correlation_key_with_decision_payload_bypasses_plain_ambiguity_guard(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation

- Naprawić lukę, w której exact replay starego autonomous OPEN po final CLOSE mógł zostać wykonany, ponieważ guard wymagał obecności `opportunity_autonomy_mode` lub `opportunity_autonomy_decision.effective_mode` w metadata sygnału.

### Description

- Zmieniono `_is_duplicate_autonomous_open_replay_after_final_close(...)` w `bot_core/runtime/controller.py`, dodając rozpoznanie `has_autonomy_metadata` oraz konserwatywny warunek dla legacy: gdy brak metadata autonomii, uwzględniany jest tylko shadow record z `accepted == True` przed użyciem `proposed_direction` do dopasowania strony i zablokowania replayu.
- Dodano regresyjny test `test_opportunity_autonomy_exact_legacy_open_replay_after_final_close_and_controller_restart_is_blocked_by_final_label_without_autonomy_metadata` w `tests/test_trading_controller.py`, który usuwa autonomy-polę z replay sygnału i sprawdza, że replay jest suppressed (`final_outcome_replay_open_suppressed`) oraz że nie powstają zamówienia/attach/tco/alerty.
- Nie zmieniono reasonu `final_outcome_replay_open_suppressed` ani innych pozazakresowych modułów; zmiany ograniczone do `bot_core/runtime/controller.py` i `tests/test_trading_controller.py`.

### Testing

- Zainstalowano zależności: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` (sukces).
- Uruchomiono selekcyjny test run dla scenariuszy replay/final/close_ranked: początkowy fail-first potwierdził problem (replay wykonywał się zamiast skipować), wprowadzono fix i ponownie uruchomiono; finalny wynik: `761 passed, 136 deselected` dla selekcji testów (sukces).
- Dodatkowe uruchomienie: `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` zakończone sukcesem (`631 passed, 305 deselected`).
- Lint: `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` — wszystkie checki przeszły.
- Wszystkie zmodyfikowane pliki przeszły testy i lint; zmiany są minimalne i scoped do wskazanych plików.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3893c3e50832a8a540227447518a0)