### PR TITLE
Harden legacy autonomous final-label replay guard after restart

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1230,6 +1230,8 @@ class TradingController:
                     continue
                 if has_autonomy_metadata:
                     shadow_accepted = True
+                elif final_mode in {"paper_autonomous", "live_autonomous"}:
+                    shadow_accepted = True
                 else:
                     shadow_accepted = bool(getattr(shadow_record, "accepted", False))
                 if not shadow_accepted:

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -59700,7 +59700,7 @@ def test_opportunity_autonomy_exact_open_replay_after_final_close_and_controller
     assert alert_contexts_snapshot
 
 
-def test_opportunity_autonomy_exact_legacy_open_replay_after_final_close_and_controller_restart_is_blocked_by_final_label_without_autonomy_metadata(
+def test_opportunity_autonomy_exact_legacy_open_replay_after_final_close_and_controller_restart_is_blocked_by_final_label_even_when_shadow_record_is_not_accepted(
     tmp_path: Path,
 ) -> None:
     decision_timestamp = datetime(2026, 1, 3, 12, 55, tzinfo=timezone.utc)
@@ -59715,9 +59715,12 @@ def test_opportunity_autonomy_exact_legacy_open_replay_after_final_close_and_con
     )
     repository.append_shadow_records(
         [
-            _shadow_record_for_key(
-                correlation_key=correlation_key,
-                decision_timestamp=decision_timestamp,
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key,
+                    decision_timestamp=decision_timestamp,
+                ),
+                accepted=False,
             )
         ]
     )
@@ -59780,6 +59783,10 @@ def test_opportunity_autonomy_exact_legacy_open_replay_after_final_close_and_con
         assert not str(replay_decision_payload.get("effective_mode") or "").strip()
     else:
         assert replay_decision_payload in (None, "", {})
+    shadow_record_after_setup = next(
+        row for row in repository.load_shadow_records() if row.record_key == correlation_key
+    )
+    assert getattr(shadow_record_after_setup, "accepted", None) is not True
 
     open_results = controller_1.process_signals([open_signal])
     assert [result.status for result in open_results] == ["filled"]


### PR DESCRIPTION
### Motivation
- Naprawić lukę w guardzie replay OPEN po final CLOSE (legacy path) gdzie brak `opportunity_autonomy_mode` i `opportunity_autonomy_decision.effective_mode` oraz `shadow_record.accepted != True` pozwalał na niepożądane odtworzenie OPEN po restarcie pomimo istnienia finalnego labela autonomicznego.
- Zachować dotychczasowy reason `final_outcome_replay_open_suppressed` i nie osłabiać normalnego przepływu CLOSE/close_ranked ani manual/rules flow.

### Description
- W `TradingController._is_duplicate_autonomous_open_replay_after_final_close(...)` dodałem warunek legacy: jeśli `final_provenance["autonomy_final_mode"]` jest jedną z wartości `{"paper_autonomous", "live_autonomous"}`, traktujemy shadow jako zaakceptowany (`shadow_accepted = True`) nawet gdy `shadow_record.accepted` nie jest `True`.
- Dodałem / zmodyfikowałem test integracyjny: `test_opportunity_autonomy_exact_legacy_open_replay_after_final_close_and_controller_restart_is_blocked_by_final_label_even_when_shadow_record_is_not_accepted`, który ustawia shadow record z `accepted=False`, usuwa autonomy metadata z sygnału replay i asercją potwierdza, że replay zostaje zablokowany.
- Zmiany ograniczone tylko do plików ze scope: `bot_core/runtime/controller.py` oraz `tests/test_trading_controller.py`.

### Testing
- Uruchomiono instalację deweloperską: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` i zakończyło się sukcesem.
- Uruchomiono selektywne testy: `pytest -q tests/test_trading_controller.py -k "...replay..."` oraz `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` i oba zestawy testów przeszły (targetowane testy zielone).
- Statyczna kontrola stylu: `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` zakończona sukcesem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38cdd4ffc832ab04b68e672c52ec5)