### PR TITLE
Dodaj negatywny test dla niekompletnego provenance final-label (replay OPEN)

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -61504,6 +61504,174 @@ def test_opportunity_autonomy_exact_open_replay_after_final_like_non_final_label
     )
 
 
+
+
+@pytest.mark.parametrize("scope_gap_variant", ["missing_environment", "missing_portfolio"])
+def test_opportunity_autonomy_exact_open_replay_after_final_label_with_incomplete_scope_provenance_and_missing_shadow_record_is_not_suppressed(
+    tmp_path: Path,
+    scope_gap_variant: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 13, 3, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.shadow_records_path.write_text("", encoding="utf-8")
+
+    final_provenance: dict[str, object] = {"autonomy_final_mode": "paper_autonomous"}
+    if scope_gap_variant == "missing_environment":
+        final_provenance["portfolio"] = "paper-1"
+    elif scope_gap_variant == "missing_portfolio":
+        final_provenance["environment"] = "paper"
+    else:
+        raise AssertionError(f"Unexpected scope_gap_variant: {scope_gap_variant}")
+
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=110.0,
+                max_favorable_excursion_bps=110.0,
+                max_adverse_excursion_bps=-40.0,
+                label_quality="final",
+                provenance=final_provenance,
+            )
+        ]
+    )
+
+    matching_shadow_records = [
+        row
+        for row in repository.load_shadow_records()
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert matching_shadow_records == []
+
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    assert len(labels) == 1
+    final_label = labels[0]
+    assert str(final_label.label_quality).strip().lower() == "final"
+    assert str((final_label.provenance or {}).get("autonomy_final_mode") or "").strip().lower() == (
+        "paper_autonomous"
+    )
+    if scope_gap_variant == "missing_environment":
+        assert not str((final_label.provenance or {}).get("environment") or "").strip()
+        assert str((final_label.provenance or {}).get("portfolio") or "").strip() == "paper-1"
+    elif scope_gap_variant == "missing_portfolio":
+        assert str((final_label.provenance or {}).get("environment") or "").strip() == "paper"
+        assert not str((final_label.provenance or {}).get("portfolio") or "").strip()
+        assert not str((final_label.provenance or {}).get("portfolio_id") or "").strip()
+
+    labels_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    replay_results = controller.process_signals([replay_open_signal])
+
+    assert [result.status for result in replay_results] == ["filled"]
+    assert len(execution.requests) == 1
+    replay_request = execution.requests[0]
+    assert replay_request.side == "BUY"
+    assert str(replay_request.metadata.get("opportunity_shadow_record_key") or "").strip() == correlation_key
+
+    journal_events = [dict(event) for event in journal.export()]
+    replay_skip_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert [
+        event
+        for event in replay_skip_events
+        if str(event.get("reason") or event.get("decision_reason") or "").strip()
+        == "final_outcome_replay_open_suppressed"
+    ] == []
+
+    labels_after = repository.load_outcome_labels()
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in labels_after
+    ] == labels_snapshot
+    assert (
+        len(
+            [
+                row
+                for row in labels_after
+                if row.correlation_key == correlation_key and row.label_quality == "final"
+            ]
+        )
+        == 1
+    )
+    assert [
+        row
+        for row in labels_after
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+
+    attach_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ]
+    assert [
+        event
+        for event in attach_events
+        if str(event.get("status") or "").strip() in {"final_upgraded", "quality_upgraded"}
+        and str(event.get("final_correlation_key") or "").strip() == correlation_key
+    ] == []
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
 @pytest.mark.parametrize("autonomy_final_mode", [None, "rules"])
 def test_opportunity_autonomy_exact_open_replay_after_same_scope_non_autonomous_final_label_with_missing_shadow_record_is_not_suppressed(
     tmp_path: Path,


### PR DESCRIPTION
### Motivation
- Upewnić się, że suppress replay OPEN przez `final_outcome_replay_open_suppressed` następuje tylko gdy final-label ma kompletne same-scope proof (autonomy_final_mode + environment + portfolio/portfolio_id).

### Description
- Dodano parametryzowany test `test_opportunity_autonomy_exact_open_replay_after_final_label_with_incomplete_scope_provenance_and_missing_shadow_record_is_not_suppressed` z wariantami `missing_environment` i `missing_portfolio` w `tests/test_trading_controller.py`.
- Test twardo assertuje brak matching shadow records, obecność label_quality == `final` z `autonomy_final_mode == paper_autonomous`, wykrycie scope-incompleteness oraz że replay OPEN nie jest pomijany (ścieżka wykonania `filled`, request metadata, snapshots labels/open_outcomes bez driftu itp.).
- Żadne zmiany w runtime/guardzie (`bot_core/runtime/controller.py`) nie były potrzebne — to hardening testów tylko w dozwolonym pliku testowym.

### Testing
- Zainstalowano zależności: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` (sukces).
- Uruchomiono konkretne testy: `PYENV_VERSION=3.11.14 pytest -q tests/test_trading_controller.py -k "incomplete_scope_provenance_and_missing_shadow_record ..."` które zakończyły się sukcesem: `785 passed, 136 deselected`.
- Uruchomiono również szersze sprawdzenie: `PYENV_VERSION=3.11.14 pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` zakończone sukcesem: `655 passed, 305 deselected`.
- Linter: `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` — wszystkie kontrole przeszły.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ae060220832a8daa86d2214baa5a)