### PR TITLE
Add positive replay-guard test for single portfolio provenance field

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -61879,6 +61879,171 @@ def test_opportunity_autonomy_exact_open_replay_after_final_label_with_incomplet
 
 
 @pytest.mark.parametrize(
+    ("scope_portfolio_field", "portfolio_value", "portfolio_id_value"),
+    [
+        ("portfolio_only", "paper-1", ""),
+        ("portfolio_id_only", "", "paper-1"),
+    ],
+)
+def test_opportunity_autonomy_exact_open_replay_after_final_label_with_single_scope_portfolio_field_and_missing_shadow_record_is_suppressed(
+    tmp_path: Path,
+    scope_portfolio_field: str,
+    portfolio_value: str,
+    portfolio_id_value: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 13, 3, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.shadow_records_path.write_text("", encoding="utf-8")
+
+    final_provenance: dict[str, object] = {
+        "autonomy_final_mode": "paper_autonomous",
+        "environment": "paper",
+    }
+    if portfolio_value:
+        final_provenance["portfolio"] = portfolio_value
+    if portfolio_id_value:
+        final_provenance["portfolio_id"] = portfolio_id_value
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=110.0,
+                max_favorable_excursion_bps=110.0,
+                max_adverse_excursion_bps=-40.0,
+                label_quality="final",
+                provenance=final_provenance,
+            )
+        ]
+    )
+
+    matching_shadow_records = [
+        row
+        for row in repository.load_shadow_records()
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert matching_shadow_records == []
+
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    assert len(labels) == 1
+    final_label = labels[0]
+    assert str(final_label.label_quality).strip().lower() == "final"
+    assert str((final_label.provenance or {}).get("autonomy_final_mode") or "").strip().lower() == (
+        "paper_autonomous"
+    )
+    assert str((final_label.provenance or {}).get("environment") or "").strip() == "paper"
+    final_portfolio = str((final_label.provenance or {}).get("portfolio") or "").strip()
+    final_portfolio_id = str((final_label.provenance or {}).get("portfolio_id") or "").strip()
+    assert bool(final_portfolio) ^ bool(final_portfolio_id)
+    if scope_portfolio_field == "portfolio_only":
+        assert final_portfolio == "paper-1"
+        assert not final_portfolio_id
+    elif scope_portfolio_field == "portfolio_id_only":
+        assert not final_portfolio
+        assert final_portfolio_id == "paper-1"
+    else:
+        raise AssertionError(f"Unexpected scope_portfolio_field: {scope_portfolio_field}")
+
+    labels_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    replay_results = controller.process_signals([replay_open_signal])
+    assert replay_results == []
+    assert execution.requests == []
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    replay_skip_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and str(event.get("reason") or event.get("decision_reason") or "").strip()
+        == "final_outcome_replay_open_suppressed"
+        and str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip_event = replay_skip_events[0]
+    shadow_record_key = str(replay_skip_event.get("order_opportunity_shadow_record_key") or "").strip()
+    if shadow_record_key:
+        assert shadow_record_key == correlation_key
+    assert str(replay_skip_event.get("proxy_correlation_key") or "").strip() == correlation_key
+
+    labels_after = repository.load_outcome_labels()
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in labels_after
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in labels_after
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
+@pytest.mark.parametrize(
     ("conflict_variant", "portfolio_value", "portfolio_id_value"),
     [
         ("portfolio_matches_but_portfolio_id_conflicts", "paper-1", "live-1"),


### PR DESCRIPTION
### Motivation
- Uzupełnić brakujący pozytywny kontrakt dla replay-guard OPEN po final CLOSE gdy final label ma dokładnie jedno legalne pole scope portfolio (`portfolio` lub `portfolio_id`) przy pełnym scope (`environment` + jedno portfolio proof). 

### Description
- Dodano parametryzowany test `test_opportunity_autonomy_exact_open_replay_after_final_label_with_single_scope_portfolio_field_and_missing_shadow_record_is_suppressed` w `tests/test_trading_controller.py` który sprawdza oba warianty: `portfolio` only i `portfolio_id` only. 
- Test twardo asercjonuje brak shadow record, obecność `label_quality == "final"`, `autonomy_final_mode`, `environment` oraz że dokładnie jedno z pól `portfolio`/`portfolio_id` istnieje i pasuje do runtime `portfolio_id`. 
- Test weryfikuje, że replay OPEN jest tłumiony (brak `execution.requests`, brak `order_*`, brak `opportunity_outcome_attach`), oraz występuje dokładnie jedno `signal_skipped` z powodem `final_outcome_replay_open_suppressed`, a snapshoty labels/open_outcomes pozostają niezmienione. 
- Nie wprowadzono zmian w `bot_core/runtime/controller.py` ani w logice negative controls; zmiana dotyczy wyłącznie testu. 

### Testing
- Zainstalowano dependencies przez `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` i uruchomiono odpowiednie testy jednostkowe; uruchomienia zakończyły się powodzeniem. 
- Uruchomiono `pytest -q tests/test_trading_controller.py -k "single_scope_portfolio_field_and_missing_shadow_record or ..."` które przeszło (wynik: wszystkie wybrane testy zakończone pomyślnie). 
- Uruchomiono `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` które przeszło. 
- Statyczne sprawdzenie `ruff` przez `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` zakończone powodzeniem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d258baa4832ab6f2ef8bfd1db648)