### PR TITLE
Dodaj test regresyjny: suppress replay CLOSE dla final provenance z jednym polem portfolio

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -42511,6 +42511,189 @@ def test_opportunity_autonomy_duplicate_close_guard_does_not_suppress_when_only_
 
 
 @pytest.mark.parametrize(
+    ("scope_portfolio_field", "portfolio_value", "portfolio_id_value"),
+    [
+        ("portfolio_only", "paper-1", ""),
+        ("portfolio_id_only", "", "paper-1"),
+    ],
+)
+def test_opportunity_autonomy_duplicate_close_guard_single_scope_portfolio_field_suppresses_replay_close(
+    scope_portfolio_field: str,
+    portfolio_value: str,
+    portfolio_id_value: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 12, 11, 47, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    shadow_repo = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-close-single-scope-"))
+    )
+    shadow_repo.append_shadow_records(
+        [
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=5.0,
+                success_probability=0.7,
+                confidence=0.3,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+            ),
+        ]
+    )
+    final_provenance = {
+        "environment": "paper",
+        "autonomy_final_mode": "paper_autonomous",
+    }
+    if portfolio_value:
+        final_provenance["portfolio"] = portfolio_value
+    if portfolio_id_value:
+        final_provenance["portfolio_id"] = portfolio_id_value
+    shadow_repo.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                correlation_key=correlation_key,
+                horizon_minutes=15,
+                realized_return_bps=3.0,
+                max_favorable_excursion_bps=3.0,
+                max_adverse_excursion_bps=-1.0,
+                provenance=final_provenance,
+                label_quality="final",
+            )
+        ]
+    )
+    labels_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in shadow_repo.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in shadow_repo.load_open_outcomes()]
+    final_labels = [
+        row
+        for row in shadow_repo.load_outcome_labels()
+        if row.correlation_key == correlation_key and str(row.label_quality).strip().lower() == "final"
+    ]
+    assert len(final_labels) == 1
+    final_label = final_labels[0]
+    final_provenance_after_write = dict(final_label.provenance or {})
+    assert str(final_label.label_quality).strip().lower() == "final"
+    assert (
+        str(final_provenance_after_write.get("autonomy_final_mode") or "").strip().lower()
+        == "paper_autonomous"
+    )
+    assert str(final_provenance_after_write.get("environment") or "").strip() == "paper"
+    final_portfolio = str(final_provenance_after_write.get("portfolio") or "").strip()
+    final_portfolio_id = str(final_provenance_after_write.get("portfolio_id") or "").strip()
+    assert bool(final_portfolio) ^ bool(final_portfolio_id)
+    if scope_portfolio_field == "portfolio_only":
+        assert final_portfolio == "paper-1"
+        assert not final_portfolio_id
+    elif scope_portfolio_field == "portfolio_id_only":
+        assert not final_portfolio
+        assert final_portfolio_id == "paper-1"
+    else:
+        raise AssertionError(f"Unexpected scope_portfolio_field: {scope_portfolio_field}")
+
+    replay_execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 106.0}]
+    )
+    replay_journal = CollectingDecisionJournal()
+    controller_replay = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=replay_execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=replay_journal,
+        opportunity_shadow_repository=shadow_repo,
+    )
+    replay_close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=False,
+    )
+    replay_close_signal.metadata = {**dict(replay_close_signal.metadata), "mode": "close_ranked"}
+    replay_results = controller_replay.process_signals([replay_close_signal])
+
+    assert replay_results == []
+    assert replay_execution.requests == []
+    journal_events = [dict(event) for event in replay_journal.export()]
+    replay_order_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ]
+    assert replay_order_events == []
+    replay_attach_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ]
+    assert replay_attach_events == []
+    replay_skip_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip_event = replay_skip_events[0]
+    assert (
+        str(replay_skip_event.get("reason") or replay_skip_event.get("decision_reason") or "").strip()
+        == "duplicate_autonomous_close_replay_suppressed"
+    )
+    assert str(replay_skip_event.get("proxy_correlation_key") or "").strip() == correlation_key
+    assert (
+        str(replay_skip_event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    )
+    assert [
+        event
+        for event in replay_skip_events
+        if str(event.get("reason") or event.get("decision_reason") or "").strip()
+        == "final_outcome_replay_open_suppressed"
+    ] == []
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in shadow_repo.load_outcome_labels()
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in shadow_repo.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in shadow_repo.load_outcome_labels()
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
+@pytest.mark.parametrize(
     ("conflict_variant", "portfolio_value", "portfolio_id_value"),
     [
         ("portfolio_matches_but_portfolio_id_conflicts", "paper-1", "live-1"),


### PR DESCRIPTION
### Motivation
- Doprecyzować kontrakt bezpieczeństwa: replay CLOSE powinien być tłumiony gdy istnieje poprawne, same-scope finalne oznaczenie zawierające dokładnie jedno legalne pole scope (tylko `portfolio` albo tylko `portfolio_id`).
- Brakowało pozytywnego testu pokrywającego ten przypadek dla duplicate CLOSE (OPEN replay już miał analogiczne pokrycie), dlatego dodano hardening testów bez modyfikacji runtime.

### Description
- Dodano parametryzowany test `test_opportunity_autonomy_duplicate_close_guard_single_scope_portfolio_field_suppresses_replay_close` w `tests/test_trading_controller.py` sprawdzający oba warianty: `portfolio_only` i `portfolio_id_only`.
- Test tworzy shadow repo i final label z `autonomy_final_mode == "paper_autonomous"` oraz `environment == "paper"`, zapewniając dokładnie jedno z pól `portfolio`/`portfolio_id` i weryfikuje, że replay CLOSE jest wyciszony z powodem `duplicate_autonomous_close_replay_suppressed`.
- Test dodatkowo asseruje brak efektów ubocznych (brak zleceń/execution requests, brak opportunity_outcome_attach, brak driftu labels/open_outcomes/partial_exit_unconfirmed oraz dokładnie jedno `signal_skipped` dla korelacji) i że nie pojawia się `final_outcome_replay_open_suppressed`.
- Nie zmieniano `bot_core/runtime/controller.py`; zmiana to tylko test-hardening w `tests/test_trading_controller.py`.

### Testing
- Zainstalowano zależności: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` (sukces).
- Uruchomiono wybrane testy: `pytest -q tests/test_trading_controller.py -k "duplicate_close_guard_single_scope_portfolio_field ..."` — wynik: 793 passed, 136 deselected.
- Uruchomiono rozszerzone zestawy: `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` — wynik: 663 passed, 305 deselected.
- Lint/static check: `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` — wszystkie checki przeszły.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d99303a0832a9fdd2c8cd399a060)