### PR TITLE
Dodaj test negatywny: replay OPEN nie tłumiony przez final label z innym symbolem

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -61863,6 +61863,159 @@ def test_opportunity_autonomy_exact_legacy_open_replay_after_final_close_does_no
 
 
 
+def test_opportunity_autonomy_exact_open_replay_after_same_key_different_symbol_final_label_with_missing_shadow_record_is_not_suppressed(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 13, 1, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.shadow_records_path.write_text("", encoding="utf-8")
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="ETH/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=110.0,
+                max_favorable_excursion_bps=110.0,
+                max_adverse_excursion_bps=-40.0,
+                label_quality="final",
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                },
+            )
+        ]
+    )
+
+    matching_shadow_records = [
+        row
+        for row in repository.load_shadow_records()
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert matching_shadow_records == []
+
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    assert len(labels) == 1
+    label = labels[0]
+    assert label.symbol == "ETH/USDT"
+    assert label.symbol != "BTC/USDT"
+    assert str(label.label_quality).strip().lower() == "final"
+    assert str((label.provenance or {}).get("autonomy_final_mode") or "").strip().lower() == (
+        "paper_autonomous"
+    )
+    assert str((label.provenance or {}).get("environment") or "").strip() == "paper"
+    assert str((label.provenance or {}).get("portfolio") or "").strip() == "paper-1"
+
+    labels_snapshot = [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    replay_results = controller.process_signals([replay_open_signal])
+
+    assert [result.status for result in replay_results] == ["filled"]
+    assert len(execution.requests) == 1
+    replay_request = execution.requests[0]
+    assert replay_request.side == "BUY"
+    assert replay_request.symbol == "BTC/USDT"
+    assert str(replay_request.metadata.get("opportunity_shadow_record_key") or "").strip() == correlation_key
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and str(event.get("reason") or event.get("decision_reason") or "").strip()
+        == "final_outcome_replay_open_suppressed"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ] == []
+
+    replay_order_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ]
+    assert replay_order_events
+
+    labels_after = repository.load_outcome_labels()
+    assert [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in labels_after
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in labels_after
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+
+    attach_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ]
+    assert [
+        event
+        for event in attach_events
+        if str(event.get("status") or "").strip() in {"final_upgraded", "quality_upgraded"}
+        and str(event.get("final_correlation_key") or "").strip() == correlation_key
+    ] == []
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
 @pytest.mark.parametrize("final_like_quality", ["final_candidate", "final_unconfirmed"])
 @pytest.mark.parametrize(
     "autonomy_marker_variant",


### PR DESCRIPTION
### Motivation
- Zamknięcie luki, gdzie final label o tym samym `correlation_key` ale innym `symbol` nie powinien być "durable proof" blokującym replay OPEN dla żądanego symbolu. 
- Audyt kodu wykazał, że obecny guard w `TradingController._is_duplicate_autonomous_open_replay_after_final_close` już filtruje po `symbol` i `correlation_key`, więc wymagane jest jedynie wzmocnienie testów regresyjnych. 
- Celem jest zapewnienie negatywnej kontroli, że final label `ETH/USDT` nie tłumi replay OPEN dla `BTC/USDT` przy pustym shadow storage.

### Description
- Dodano test `test_opportunity_autonomy_exact_open_replay_after_same_key_different_symbol_final_label_with_missing_shadow_record_is_not_suppressed` w pliku `tests/test_trading_controller.py` sprawdzający przypadek z tym samym `correlation_key` i różnym `symbol`. 
- Test ustawia pusty shadow storage, tworzy `OpportunityOutcomeLabel` z `symbol == "ETH/USDT"`, a następnie wysyła replay OPEN dla `symbol == "BTC/USDT"` i asseruje, że replay nie jest tłumiony i trafia do wykonania. 
- Nie wprowadzono żadnych zmian w `bot_core/runtime/controller.py`; logika guardu została poddana audytowi i uznana za poprawną.

### Testing
- Zainstalowano zależności uruchamiając `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` i instalacja zakończyła się sukcesem. 
- Uruchomiono ukierunkowane testy `PYENV_VERSION=3.11.14 pytest -q tests/test_trading_controller.py -k "different_symbol_final_label_with_missing_shadow_record or ..." --tb=short` i wynik to `798 passed, 136 deselected` (wszystkie wymagane testy zielone). 
- Uruchomiono szerszy podzbiór `PYENV_VERSION=3.11.14 pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source" --tb=short` i wynik to `668 passed, 305 deselected`. 
- Przeprowadzono statyczną kontrolę stylu `PYENV_VERSION=3.11.14 python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` i zakończono bez błędów.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6224c0328832a8a01979298347f14)