### PR TITLE
Dodaj test: suppress OPEN replay gdy istnieje tylko foreign-symbol shadow przy same-scope final label

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -62194,6 +62194,176 @@ def test_opportunity_autonomy_exact_open_replay_after_same_key_different_symbol_
     )
 
 
+def test_opportunity_autonomy_exact_open_replay_after_final_label_with_only_different_symbol_shadow_record_is_suppressed(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 13, 9, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.shadow_records_path.write_text("", encoding="utf-8")
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=110.0,
+                max_favorable_excursion_bps=110.0,
+                max_adverse_excursion_bps=-40.0,
+                label_quality="final",
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                },
+            )
+        ]
+    )
+    repository.shadow_records_path.write_text(
+        json.dumps(
+            replace(
+                _shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp),
+                symbol="ETH/USDT",
+                proposed_direction="short",
+                accepted=True,
+                context=OpportunityShadowContext(
+                    environment="paper",
+                    notes={"portfolio": "paper-1"},
+                ),
+            ).to_dict()
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    shadow_records_for_key = [
+        row for row in repository.load_shadow_records() if row.record_key == correlation_key
+    ]
+    assert len(shadow_records_for_key) == 1
+    assert shadow_records_for_key[0].symbol == "ETH/USDT"
+    assert str(shadow_records_for_key[0].proposed_direction or "").strip().lower() == "short"
+    matching_shadow_records = [
+        row
+        for row in shadow_records_for_key
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert matching_shadow_records == []
+
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    same_scope_final_labels = [
+        row
+        for row in labels
+        if row.symbol == "BTC/USDT" and str(row.label_quality).strip().lower() == "final"
+    ]
+    assert len(same_scope_final_labels) == 1
+    final_label = same_scope_final_labels[0]
+    assert str(final_label.label_quality).strip().lower() == "final"
+    assert str((final_label.provenance or {}).get("autonomy_final_mode") or "").strip().lower() == (
+        "paper_autonomous"
+    )
+    assert str((final_label.provenance or {}).get("environment") or "").strip() == "paper"
+    assert str((final_label.provenance or {}).get("portfolio") or "").strip() == "paper-1"
+
+    labels_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    replay_results = controller.process_signals([replay_open_signal])
+    assert replay_results == []
+    assert execution.requests == []
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    replay_skip_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip_event = replay_skip_events[0]
+    assert str(replay_skip_event.get("reason") or replay_skip_event.get("decision_reason") or "").strip() == (
+        "final_outcome_replay_open_suppressed"
+    )
+    assert str(replay_skip_event.get("proxy_correlation_key") or "").strip() == correlation_key
+    if "order_opportunity_shadow_record_key" in replay_skip_event:
+        assert str(replay_skip_event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+
+    labels_after = repository.load_outcome_labels()
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in labels_after
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in labels_after
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
 @pytest.mark.parametrize("final_like_quality", ["final_candidate", "final_unconfirmed"])
 @pytest.mark.parametrize(
     "autonomy_marker_variant",


### PR DESCRIPTION
### Motivation
- Zamknięcie positive control: upewnić się, że shadow record z tym samym `correlation_key` ale obcym `symbol` nie unieważnia suppressu replay OPEN, jeśli istnieje poprawny same-scope final label dla żądanego symbolu.

### Description
- Dodano nowy test `test_opportunity_autonomy_exact_open_replay_after_final_label_with_only_different_symbol_shadow_record_is_suppressed` w `tests/test_trading_controller.py` odwzorowujący scenariusz: final label dla `BTC/USDT` + jedyny shadow record dla tego klucza ma `symbol == "ETH/USDT"` + replay OPEN BUY z legacy metadata.
- Test asercjami weryfikuje: brak `order_*`, brak `opportunity_outcome_attach`, brak requestów do execution, dokładnie jeden `signal_skipped` z `reason == final_outcome_replay_open_suppressed`, brak driftu w snapshotach labels/open_outcomes oraz brak `partial_exit_unconfirmed`.
- Przeprowadzono audit `_is_duplicate_autonomous_open_replay_after_final_close(...)` w `bot_core/runtime/controller.py` i potwierdzono, że logika już spełnia kontrakt (foreign-symbol shadow jest filtrowany i nie wpływa na flagę matching dla symbolu requestu), więc runtime nie został zmieniony.
- Commit obejmuje wyłącznie `tests/test_trading_controller.py` (brak zmian w `controller.py`).

### Testing
- Uruchomiono dependency/install: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` i zakończono pomyślnie.
- Uruchomiono selektywne testy: `pytest -q tests/test_trading_controller.py -k "..."` — wynik: 800 passed, 136 deselected.
- Uruchomiono kombinację: `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` — wynik: 670 passed, 305 deselected.
- Statyczna kontrola: `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` — wszystkie checki przeszły.
- Nowy test i reguły są zielone; runtime audit wykazał brak potrzeby zmian.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6d4e34ca0832aa682ec85309334c9)