### PR TITLE
Dodaj test regresyjny: mixed-symbol final-label OPEN replay suppression

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -62938,6 +62938,174 @@ def test_opportunity_autonomy_exact_open_replay_after_mixed_final_labels_uses_va
     )
 
 
+@pytest.mark.parametrize("label_order_variant", ["invalid_symbol_first", "valid_symbol_first"])
+def test_opportunity_autonomy_exact_open_replay_after_mixed_symbol_final_labels_uses_valid_same_symbol_label_for_suppression(
+    tmp_path: Path,
+    label_order_variant: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 13, 5, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.shadow_records_path.write_text("", encoding="utf-8")
+
+    invalid_foreign_symbol_label = OpportunityOutcomeLabel(
+        correlation_key=correlation_key,
+        symbol="ETH/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=5),
+        horizon_minutes=60,
+        realized_return_bps=110.0,
+        max_favorable_excursion_bps=110.0,
+        max_adverse_excursion_bps=-40.0,
+        label_quality="final",
+        provenance={
+            "autonomy_final_mode": "paper_autonomous",
+            "environment": "paper",
+            "portfolio": "paper-1",
+        },
+    )
+    valid_same_symbol_label = OpportunityOutcomeLabel(
+        correlation_key=correlation_key,
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp + timedelta(minutes=6),
+        horizon_minutes=60,
+        realized_return_bps=105.0,
+        max_favorable_excursion_bps=105.0,
+        max_adverse_excursion_bps=-45.0,
+        label_quality="final",
+        provenance={
+            "autonomy_final_mode": "paper_autonomous",
+            "environment": "paper",
+            "portfolio": "paper-1",
+        },
+    )
+    if label_order_variant == "invalid_symbol_first":
+        repository.append_outcome_labels([invalid_foreign_symbol_label, valid_same_symbol_label])
+    elif label_order_variant == "valid_symbol_first":
+        repository.append_outcome_labels([valid_same_symbol_label, invalid_foreign_symbol_label])
+    else:
+        raise AssertionError(f"Unexpected label_order_variant: {label_order_variant}")
+
+    matching_shadow_records = [
+        row
+        for row in repository.load_shadow_records()
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert matching_shadow_records == []
+
+    labels_before = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    final_labels = [row for row in labels_before if str(row.label_quality).strip().lower() == "final"]
+    assert len(final_labels) == 2
+    assert len([row for row in final_labels if str(row.symbol).strip() == "ETH/USDT"]) == 1
+    assert len([row for row in final_labels if str(row.symbol).strip() == "BTC/USDT"]) == 1
+    assert all(str(row.label_quality).strip().lower() == "final" for row in final_labels)
+    assert all(
+        str((row.provenance or {}).get("autonomy_final_mode") or "").strip().lower()
+        == "paper_autonomous"
+        for row in final_labels
+    )
+    assert all(str((row.provenance or {}).get("environment") or "").strip() == "paper" for row in final_labels)
+    assert all(str((row.provenance or {}).get("portfolio") or "").strip() == "paper-1" for row in final_labels)
+
+    labels_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    replay_results = controller.process_signals([replay_open_signal])
+    assert replay_results == []
+    assert execution.requests == []
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    replay_skip_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip_event = replay_skip_events[0]
+    assert str(replay_skip_event.get("reason") or replay_skip_event.get("decision_reason") or "").strip() == (
+        "final_outcome_replay_open_suppressed"
+    )
+    assert str(replay_skip_event.get("proxy_correlation_key") or "").strip() == correlation_key
+    if "order_opportunity_shadow_record_key" in replay_skip_event:
+        assert str(replay_skip_event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+
+    labels_after = repository.load_outcome_labels()
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in labels_after
+    ] == labels_snapshot
+    assert [
+        row
+        for row in labels_after
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
 
 
 @pytest.mark.parametrize("scope_gap_variant", ["missing_environment", "missing_portfolio"])


### PR DESCRIPTION
### Motivation
- Domknąć kontrakt, że finalny label dla innego symbolu (ten sam `correlation_key`) nie „zatruje” decyzji suppress gdy istnieje poprawny finalny label dla tego samego symbolu i scope, poprzez dodanie testu hardeningowego.

### Description
- Dodano parametryzowany test `test_opportunity_autonomy_exact_open_replay_after_mixed_symbol_final_labels_uses_valid_same_symbol_label_for_suppression` z wariantami `invalid_symbol_first` i `valid_symbol_first` w `tests/test_trading_controller.py` sprawdzający zachowanie przy mieszanych final-labels (ETH vs BTC) dla tego samego `correlation_key`.
- Po audycie pętli w `_is_duplicate_autonomous_open_replay_after_final_close(...)` nie wprowadzono zmian w `bot_core/runtime/controller.py`, ponieważ istniejąca logika już pomija foreign-symbol (`continue`) i pozwala późniejszemu same-symbol final label sprowokować suppress.

### Testing
- Uruchomiono instalację deweloperskich zależności: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` — zakończone pomyślnie.
- Uruchomiono testy: `pytest -q tests/test_trading_controller.py -k "mixed_symbol_final_labels_uses_valid_same_symbol_label or ..."` — wynik: `803 passed, 136 deselected`.
- Uruchomiono wybrane testy autonomy/lifecycle: `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` — wynik: `673 passed, 305 deselected`, oraz `ruff` dla zmodyfikowanych plików — wszystkie checki przeszły.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6eee047ac832ab176d521939341ad)