### PR TITLE
Dodaj test regresyjny: mixed-symbol shadow suppression dla OPEN replay

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -63290,6 +63290,194 @@ def test_opportunity_autonomy_exact_open_replay_after_mixed_symbol_final_labels_
     )
 
 
+@pytest.mark.parametrize("shadow_order_variant", ["invalid_symbol_first", "valid_symbol_first"])
+def test_opportunity_autonomy_exact_open_replay_after_final_label_with_mixed_symbol_shadow_records_uses_valid_same_symbol_shadow_for_suppression(
+    tmp_path: Path,
+    shadow_order_variant: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 13, 11, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.shadow_records_path.write_text("", encoding="utf-8")
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=110.0,
+                max_favorable_excursion_bps=110.0,
+                max_adverse_excursion_bps=-40.0,
+                label_quality="final",
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                },
+            )
+        ]
+    )
+    invalid_foreign_symbol_shadow = replace(
+        _shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp),
+        symbol="ETH/USDT",
+        proposed_direction="short",
+        accepted=True,
+        context=OpportunityShadowContext(
+            environment="paper",
+            notes={"portfolio": "paper-1"},
+        ),
+    )
+    valid_same_symbol_shadow = replace(
+        _shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp),
+        symbol="BTC/USDT",
+        proposed_direction="long",
+        accepted=True,
+        context=OpportunityShadowContext(
+            environment="paper",
+            notes={"portfolio": "paper-1"},
+        ),
+    )
+    if shadow_order_variant == "invalid_symbol_first":
+        ordered_shadow_records = [invalid_foreign_symbol_shadow, valid_same_symbol_shadow]
+    elif shadow_order_variant == "valid_symbol_first":
+        ordered_shadow_records = [valid_same_symbol_shadow, invalid_foreign_symbol_shadow]
+    else:
+        raise AssertionError(f"Unexpected shadow_order_variant: {shadow_order_variant}")
+    repository.shadow_records_path.write_text(
+        "".join(json.dumps(row.to_dict()) + "\n" for row in ordered_shadow_records),
+        encoding="utf-8",
+    )
+
+    shadow_records_for_key = [
+        row for row in repository.load_shadow_records() if row.record_key == correlation_key
+    ]
+    assert len(shadow_records_for_key) == 2
+    assert len([row for row in shadow_records_for_key if row.symbol == "ETH/USDT"]) == 1
+    assert len([row for row in shadow_records_for_key if row.symbol == "BTC/USDT"]) == 1
+    matching_shadow_records = [row for row in shadow_records_for_key if row.symbol == "BTC/USDT"]
+    assert len(matching_shadow_records) == 1
+    assert str(matching_shadow_records[0].proposed_direction or "").strip().lower() == "long"
+    assert all(str(getattr(row.context, "environment", "") or "").strip() == "paper" for row in shadow_records_for_key)
+    assert all(
+        str((getattr(row.context, "notes", {}) or {}).get("portfolio") or "").strip() == "paper-1"
+        for row in shadow_records_for_key
+    )
+
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    same_symbol_final_labels = [
+        row
+        for row in labels
+        if row.symbol == "BTC/USDT" and str(row.label_quality).strip().lower() == "final"
+    ]
+    assert len(same_symbol_final_labels) == 1
+    final_label = same_symbol_final_labels[0]
+    assert str(final_label.label_quality).strip().lower() == "final"
+    assert str((final_label.provenance or {}).get("autonomy_final_mode") or "").strip().lower() == (
+        "paper_autonomous"
+    )
+    assert str((final_label.provenance or {}).get("environment") or "").strip() == "paper"
+    assert str((final_label.provenance or {}).get("portfolio") or "").strip() == "paper-1"
+
+    labels_snapshot = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    replay_results = controller.process_signals([replay_open_signal])
+    assert replay_results == []
+    assert execution.requests == []
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    replay_skip_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip_event = replay_skip_events[0]
+    assert str(replay_skip_event.get("reason") or replay_skip_event.get("decision_reason") or "").strip() == (
+        "final_outcome_replay_open_suppressed"
+    )
+    assert str(replay_skip_event.get("proxy_correlation_key") or "").strip() == correlation_key
+    if "order_opportunity_shadow_record_key" in replay_skip_event:
+        assert str(replay_skip_event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+
+    labels_after = repository.load_outcome_labels()
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in labels_after
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in labels_after
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
 
 
 @pytest.mark.parametrize("scope_gap_variant", ["missing_environment", "missing_portfolio"])


### PR DESCRIPTION
### Motivation
- Zabezpieczyć kontrakt, że foreign-symbol shadow record nie zablokuje suppression dla replay OPEN gdy istnieje poprawny same-symbol shadow record o tym samym `correlation_key` i w tym samym scope.
- Hardening scenariusza z dwoma kolejnościami shadow records (foreign-first / valid-first) jako pozytywny test kontrolny dla guardu replay OPEN po final close.

### Description
- Dodano parametryzowany test `test_opportunity_autonomy_exact_open_replay_after_final_label_with_mixed_symbol_shadow_records_uses_valid_same_symbol_shadow_for_suppression` w `tests/test_trading_controller.py` z wariantami `invalid_symbol_first` i `valid_symbol_first`.
- Test tworzy final `OpportunityOutcomeLabel` dla `BTC/USDT` i dwa shadow records (ETH/USDT oraz BTC/USDT) zapisywane w obu kolejnościach, sprawdzając, że valid same-symbol shadow powoduje suppression replay OPEN BUY.
- Nie wprowadzono zmian w `bot_core/runtime/controller.py` po audycie pętli `shadow_records`, ponieważ istniejąca logika już spełnia wymóg (foreign-symbol jest pomijany i nie blokuje późniejszego same-symbol match).

### Testing
- Zainstalowano zależności: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` (sukces).
- Uruchomiono celowane testy: `PYENV_VERSION=3.11.14 pytest -q tests/test_trading_controller.py -k "...mixed_symbol_shadow_records_uses_valid_same_symbol_shadow..."` — wszystkie testy przechodziły; finalny wynik dla wybranej selekcji: `807 passed, 136 deselected`.
- Dodatkowy przebieg: `PYENV_VERSION=3.11.14 pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` zakończony sukcesem (`677 passed, 305 deselected`).
- Lint/static check: `PYENV_VERSION=3.11.14 python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` — `All checks passed!`.
- Zmiany obejmują wyłącznie `tests/test_trading_controller.py` i zostały zatwierdzone po pełnym green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f7192498832ab71bdae5a5b0bb58)