### PR TITLE
Ignoruj konfliktujący scope portfolio w shadow przy ochronie OPEN replay

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1241,6 +1241,7 @@ class TradingController:
             matching_shadow_scope_candidate_exists = False
             matching_shadow_with_usable_direction_exists = False
             matching_shadow_for_key_symbol_exists = False
+            conflicting_shadow_scope_context_exists = False
             for shadow_record in shadow_records:
                 if shadow_record.record_key != correlation_key:
                     continue
@@ -1250,13 +1251,26 @@ class TradingController:
                 shadow_context = getattr(shadow_record, "context", None)
                 if isinstance(shadow_context, Mapping):
                     shadow_environment_raw = shadow_context.get("environment")
+                    shadow_notes = shadow_context.get("notes")
                 else:
                     shadow_environment_raw = getattr(shadow_context, "environment", None)
+                    shadow_notes = getattr(shadow_context, "notes", None)
                 shadow_environment = (
                     str(shadow_environment_raw).strip()
                     if shadow_environment_raw is not None
                     else ""
                 )
+                shadow_notes_mapping = shadow_notes if isinstance(shadow_notes, Mapping) else {}
+                shadow_portfolio_raw = str(shadow_notes_mapping.get("portfolio") or "").strip()
+                shadow_portfolio_id_raw = str(shadow_notes_mapping.get("portfolio_id") or "").strip()
+                if (
+                    shadow_portfolio_raw
+                    and shadow_portfolio_id_raw
+                    and shadow_portfolio_raw != shadow_portfolio_id_raw
+                ):
+                    conflicting_shadow_scope_context_exists = True
+                    continue
+                shadow_portfolio = shadow_portfolio_raw or shadow_portfolio_id_raw
                 shadow_environment_normalized = shadow_environment.lower()
                 legacy_shadow_scope_missing = shadow_environment_normalized in {"", "shadow"}
                 if (
@@ -1265,6 +1279,10 @@ class TradingController:
                     and shadow_environment != scope_environment
                     and not legacy_shadow_scope_missing
                 ):
+                    continue
+                if scope_portfolio and not shadow_portfolio:
+                    continue
+                if shadow_portfolio and scope_portfolio and shadow_portfolio != scope_portfolio:
                     continue
                 matching_shadow_scope_candidate_exists = True
                 if has_autonomy_metadata:
@@ -1296,6 +1314,8 @@ class TradingController:
                 # chroni przed replay OPEN przy legacy/corrupt shadow bez direction.
                 return True
             if not matching_shadow_scope_candidate_exists:
+                if conflicting_shadow_scope_context_exists:
+                    return False
                 # Brak same-scope shadow (w tym: tylko foreign-scope shadow) nie obala
                 # dowodu final-label w tym samym scope dla replay OPEN.
                 if side == "BUY":

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -44044,6 +44044,193 @@ def test_opportunity_autonomy_exact_open_replay_after_final_label_with_mixed_sco
     _assert_no_duplicate_residue_metadata_for_shadow_key(
         replay_non_skip_events, shadow_key=correlation_key
     )
+
+
+@pytest.mark.parametrize(
+    ("shadow_notes",),
+    [
+        pytest.param(
+            {"portfolio": "paper-1", "portfolio_id": "live-1"},
+            id="portfolio_matches_but_portfolio_id_conflicts",
+        ),
+        pytest.param(
+            {"portfolio": "live-1", "portfolio_id": "paper-1"},
+            id="portfolio_conflicts_but_portfolio_id_matches",
+        ),
+    ],
+)
+def test_opportunity_autonomy_exact_open_replay_after_final_label_with_conflicting_shadow_scope_context_is_not_suppressed_by_shadow_candidate(
+    shadow_notes: dict[str, str],
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 13, 12, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.shadow_records_path.write_text("", encoding="utf-8")
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=110.0,
+                max_favorable_excursion_bps=110.0,
+                max_adverse_excursion_bps=-40.0,
+                label_quality="final",
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                },
+            )
+        ]
+    )
+    repository.shadow_records_path.write_text(
+        json.dumps(
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key, decision_timestamp=decision_timestamp
+                ),
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                proposed_direction="long",
+                accepted=True,
+                context=OpportunityShadowContext(environment="paper", notes=dict(shadow_notes)),
+            ).to_dict()
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    shadow_records_for_key_symbol = [
+        row
+        for row in repository.load_shadow_records()
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert len(shadow_records_for_key_symbol) == 1
+    shadow_record = shadow_records_for_key_symbol[0]
+    shadow_context = getattr(shadow_record, "context", None)
+    shadow_context_notes = getattr(shadow_context, "notes", {}) or {}
+    shadow_environment = str(getattr(shadow_context, "environment", "") or "").strip()
+    shadow_portfolio = str(shadow_context_notes.get("portfolio") or "").strip()
+    shadow_portfolio_id = str(shadow_context_notes.get("portfolio_id") or "").strip()
+    assert shadow_environment == "paper"
+    assert shadow_portfolio
+    assert shadow_portfolio_id
+    assert shadow_portfolio != shadow_portfolio_id
+    assert len([value for value in (shadow_portfolio, shadow_portfolio_id) if value == "paper-1"]) == 1
+    assert str(shadow_record.proposed_direction or "").strip().lower() == "long"
+
+    final_labels = [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key
+        and str(row.symbol) == "BTC/USDT"
+        and str(row.label_quality).strip().lower() == "final"
+    ]
+    assert len(final_labels) == 1
+    final_provenance = dict(final_labels[0].provenance or {})
+    assert str(final_provenance.get("autonomy_final_mode") or "").strip().lower() == "paper_autonomous"
+    assert str(final_provenance.get("environment") or "").strip() == "paper"
+    assert str(final_provenance.get("portfolio") or "").strip() == "paper-1"
+
+    labels_snapshot = [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    replay_results = controller.process_signals([replay_open_signal])
+
+    assert [result.status for result in replay_results] == ["filled"]
+    assert len(execution.requests) == 1
+    assert str(execution.requests[0].side).upper() == "BUY"
+    assert str(execution.requests[0].symbol) == "BTC/USDT"
+    assert (
+        str((execution.requests[0].metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+    )
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and str(event.get("reason") or event.get("decision_reason") or "").strip()
+        == "final_outcome_replay_open_suppressed"
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] != []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+        and (
+            str(event.get("opportunity_outcome_attach_quality_upgraded") or "").strip().lower() == "true"
+            or str(event.get("opportunity_outcome_attach_final_upgraded") or "").strip().lower() == "true"
+        )
+    ] == []
+    assert [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    assert [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
 @pytest.mark.parametrize("shadow_order_variant", ["invalid_symbol_first", "valid_symbol_first"])
 def test_opportunity_autonomy_duplicate_close_guard_mixed_symbol_shadow_records_uses_valid_same_symbol_shadow_for_suppression(
     shadow_order_variant: str,


### PR DESCRIPTION
### Motivation
- Domknąć kontrakt, że shadow record z konfliktowymi polami `notes["portfolio"]` vs `notes["portfolio_id"]` nie może być traktowany jako dowód same-scope dla guardu replay OPEN.
- Zapobiec sytuacji, w której rekord shadow z rozbieżnymi wartościami tych pól powoduje nieuzasadnione zablokowanie replay (reason `final_outcome_replay_open_suppressed`).

### Description
- W `bot_core/runtime/controller.py::_is_duplicate_autonomous_open_replay_after_final_close` dodano odczyt `shadow.context.notes` oraz zmienne `shadow_portfolio_raw` i `shadow_portfolio_id_raw` i prosty conflict-check: jeśli oba są obecne i różne, rekord shadow jest odrzucany jako kandydat (kontynuacja pętli) i zaznaczany jako konfliktowy.
- Po conflict-check wymuszono dalsze sprawdzenia scope portfolio (fallback tylko z pojedynczego pola lub zgodnych wartości) oraz gdy nie ma żadnego valid same-scope shadow, ale jedyny kandydat był konfliktowy, guard już nie zwraca suppressu (zwraca `False` zamiast traktować konflikt jako foreign/valid proof).
- Dodano parametrizowany test `test_opportunity_autonomy_exact_open_replay_after_final_label_with_conflicting_shadow_scope_context_is_not_suppressed_by_shadow_candidate` w `tests/test_trading_controller.py` obejmujący dwa warianty konfliktu: `portfolio_matches_but_portfolio_id_conflicts` i `portfolio_conflicts_but_portfolio_id_matches`.
- Zmiany ograniczone do plików: `bot_core/runtime/controller.py` i `tests/test_trading_controller.py` bez szerokich refaktorów i bez modyfikacji reasonów/provenance istniejącej logiki.

### Testing
- Zainstalowano dependencies: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` — zakończono OK.
- Uruchomiono zestaw testów selektywnych: `pytest -q tests/test_trading_controller.py -k "conflicting_shadow_scope_context_is_not_suppressed or ..."` — po poprawce wszystkie testy z tego selektora przeszły: 815 passed, 136 deselected.
- Uruchomiono dodatkowy filtr: `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` — 685 passed, 305 deselected.
- Static check: `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` — wszystkie checki przeszły.
- Nowy parametrizowany test potwierdza, że konfliktujący shadow nie wywołuje `final_outcome_replay_open_suppressed` i replay OPEN przechodzi do execution path (weryfikowane `filled`, pojedyncze żądanie BUY dla `BTC/USDT` i metadata z kluczem shadow).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f726cd3758832ab0366f537db40172)