### PR TITLE
Zabezpieczenie replay CLOSE przed konfliktowym shadow scope (portfolio vs portfolio_id)

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1119,11 +1119,23 @@ class TradingController:
             shadow_context = getattr(shadow_record, "context", None)
             if isinstance(shadow_context, Mapping):
                 shadow_environment_raw = shadow_context.get("environment")
+                shadow_notes = shadow_context.get("notes")
             else:
                 shadow_environment_raw = getattr(shadow_context, "environment", None)
+                shadow_notes = getattr(shadow_context, "notes", None)
             shadow_environment = (
                 str(shadow_environment_raw).strip() if shadow_environment_raw is not None else ""
             )
+            shadow_notes_mapping = shadow_notes if isinstance(shadow_notes, Mapping) else {}
+            shadow_portfolio_raw = str(shadow_notes_mapping.get("portfolio") or "").strip()
+            shadow_portfolio_id_raw = str(shadow_notes_mapping.get("portfolio_id") or "").strip()
+            if (
+                shadow_portfolio_raw
+                and shadow_portfolio_id_raw
+                and shadow_portfolio_raw != shadow_portfolio_id_raw
+            ):
+                continue
+            shadow_portfolio = shadow_portfolio_raw or shadow_portfolio_id_raw
             shadow_environment_normalized = shadow_environment.lower()
             legacy_shadow_scope_missing = shadow_environment_normalized in {"", "shadow"}
             if (
@@ -1132,6 +1144,8 @@ class TradingController:
                 and shadow_environment != scope_environment
                 and not legacy_shadow_scope_missing
             ):
+                continue
+            if scope_portfolio and shadow_portfolio and shadow_portfolio != scope_portfolio:
                 continue
             matching_shadow_scope_candidate_exists = True
             proposed_direction = (

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -44231,6 +44231,195 @@ def test_opportunity_autonomy_exact_open_replay_after_final_label_with_conflicti
     )
 
 
+@pytest.mark.parametrize(
+    ("shadow_notes",),
+    [
+        pytest.param(
+            {"portfolio": "paper-1", "portfolio_id": "live-1"},
+            id="portfolio_matches_but_portfolio_id_conflicts",
+        ),
+        pytest.param(
+            {"portfolio": "live-1", "portfolio_id": "paper-1"},
+            id="portfolio_conflicts_but_portfolio_id_matches",
+        ),
+    ],
+)
+def test_opportunity_autonomy_duplicate_close_guard_conflicting_shadow_scope_context_does_not_suppress_replay_close(
+    shadow_notes: dict[str, str],
+) -> None:
+    decision_timestamp = datetime(2026, 1, 13, 9, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-close-conflicting-shadow-context-"))
+    )
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                correlation_key=correlation_key,
+                horizon_minutes=15,
+                realized_return_bps=5.0,
+                max_favorable_excursion_bps=7.0,
+                max_adverse_excursion_bps=-3.0,
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                },
+                label_quality="final",
+            )
+        ]
+    )
+    repository.shadow_records_path.write_text(
+        json.dumps(
+            OpportunityShadowRecord(
+                record_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                model_version="opportunity-v1",
+                decision_source="opportunity_ai_shadow",
+                expected_edge_bps=6.0,
+                success_probability=0.7,
+                confidence=0.4,
+                proposed_direction="long",
+                accepted=True,
+                rejection_reason=None,
+                rank=1,
+                provenance={"probability_method": "test"},
+                threshold_config=OpportunityThresholdConfig(),
+                snapshot={},
+                context=OpportunityShadowContext(environment="paper", notes=dict(shadow_notes)),
+            ).to_dict()
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    shadow_records_for_key_symbol = [
+        row
+        for row in repository.load_shadow_records()
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert len(shadow_records_for_key_symbol) == 1
+    shadow_record = shadow_records_for_key_symbol[0]
+    shadow_context = getattr(shadow_record, "context", None)
+    shadow_notes_loaded = getattr(shadow_context, "notes", {}) or {}
+    shadow_environment = str(getattr(shadow_context, "environment", "") or "").strip()
+    shadow_portfolio = str(shadow_notes_loaded.get("portfolio") or "").strip()
+    shadow_portfolio_id = str(shadow_notes_loaded.get("portfolio_id") or "").strip()
+    assert shadow_environment == "paper"
+    assert shadow_portfolio
+    assert shadow_portfolio_id
+    assert shadow_portfolio != shadow_portfolio_id
+    assert len([value for value in (shadow_portfolio, shadow_portfolio_id) if value == "paper-1"]) == 1
+    assert str(shadow_record.proposed_direction or "").strip().lower() == "long"
+
+    final_labels = [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key
+        and str(row.symbol) == "BTC/USDT"
+        and str(row.label_quality).strip().lower() == "final"
+    ]
+    assert len(final_labels) == 1
+    final_provenance = dict(final_labels[0].provenance or {})
+    assert str(final_provenance.get("autonomy_final_mode") or "").strip().lower() == "paper_autonomous"
+    assert str(final_provenance.get("environment") or "").strip() == "paper"
+    assert str(final_provenance.get("portfolio") or "").strip() == "paper-1"
+
+    labels_snapshot = [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 222.0}])
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_close = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=False,
+    )
+    replay_close.metadata = {**dict(replay_close.metadata), "mode": "close_ranked"}
+    replay_results = controller.process_signals([replay_close])
+
+    assert [result.status for result in replay_results] == ["filled"]
+    assert len(execution.requests) == 1
+    execution_request = execution.requests[0]
+    assert str(execution_request.side).upper() == "SELL"
+    assert str(execution_request.symbol) == "BTC/USDT"
+    assert str((execution_request.metadata or {}).get("mode") or "").strip().lower() == "close_ranked"
+    assert (
+        str((execution_request.metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+    )
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and str(event.get("reason") or event.get("decision_reason") or "").strip()
+        == "duplicate_autonomous_close_replay_suppressed"
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and str(event.get("reason") or event.get("decision_reason") or "").strip()
+        == "final_outcome_replay_open_suppressed"
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] != []
+    assert [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+        and (
+            str(event.get("opportunity_outcome_attach_quality_upgraded") or "").strip().lower() == "true"
+            or str(event.get("opportunity_outcome_attach_final_upgraded") or "").strip().lower() == "true"
+        )
+    ] == []
+    assert [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
 @pytest.mark.parametrize("shadow_order_variant", ["invalid_symbol_first", "valid_symbol_first"])
 def test_opportunity_autonomy_duplicate_close_guard_mixed_symbol_shadow_records_uses_valid_same_symbol_shadow_for_suppression(
     shadow_order_variant: str,


### PR DESCRIPTION
### Motivation
- Naprawić lukę w `_is_duplicate_autonomous_close_replay(...)`, gdzie shadow record z konfliktowym `notes` (oba pola `portfolio` i `portfolio_id` obecne, ale różne) mógł być błędnie traktowany jako same-scope kandydat do suppressu dla replay CLOSE.
- Zapewnić, że konfliktowe shadow context nie blokuje wykonania CLOSE SELL tylko dlatego, że jedno z pól pasuje do runtime scope.

### Description
- W `bot_core/runtime/controller.py` odczytuję `shadow_record.context.notes` i wprowadzam minimalny conflict-check: jeśli oba pola `portfolio` i `portfolio_id` są niepuste i różne, rekord shadow jest pomijany (`continue`).
- Po conflict-check stosuję fallback `shadow_portfolio = portfolio or portfolio_id` i dopasowuję go do runtime `scope_portfolio`, pozostawiając dotychczasowe warunki środowiskowe bez zmian.
- Dodano nowy parametryzowany test w `tests/test_trading_controller.py`: `test_opportunity_autonomy_duplicate_close_guard_conflicting_shadow_scope_context_does_not_suppress_replay_close` obejmujący obie warianty konfliktu (`portfolio_matches_but_portfolio_id_conflicts` i `portfolio_conflicts_but_portfolio_id_matches`).

### Testing
- Uruchomione instalacje i sprawdzenia: `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` zakończyło się pomyślnie.
- Testy jednostkowe uruchomione poleceniami `pytest` przeszły pomyślnie dla docelowych zestawów: `pytest -q tests/test_trading_controller.py -k "...duplicate_close_guard_conflicting_shadow_scope_context_does_not_suppress..."` (ostatnie uruchomienie: `817 passed, 136 deselected`) oraz `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` (ostatnie uruchomienie: `687 passed, 305 deselected`).
- `ruff` linter dla zmienionych plików przeszedł bez błędów: `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py`.
- Zmiany ograniczone wyłącznie do `bot_core/runtime/controller.py` i `tests/test_trading_controller.py` i zostały zacommitowane (hash: `abf8d32`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72bb212c4832a99d144ca4f500461)