### PR TITLE
Dodaj parametryzowany test order-independence dla SUPPRESS OPEN replay przy conflicting + valid shadow scope

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -44231,6 +44231,204 @@ def test_opportunity_autonomy_exact_open_replay_after_final_label_with_conflicti
     )
 
 
+@pytest.mark.parametrize("shadow_scope_order_variant", ["conflicting_first", "valid_first"])
+def test_opportunity_autonomy_exact_open_replay_after_final_label_with_conflicting_and_valid_shadow_scope_context_uses_valid_shadow_for_suppression(
+    shadow_scope_order_variant: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 3, 13, 12, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = _autonomy_shadow_repository_with_final_outcomes(
+        [9.0, 8.0, 7.0], environment="paper", portfolio_id="paper-1"
+    )
+    repository.shadow_records_path.write_text("", encoding="utf-8")
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=110.0,
+                max_favorable_excursion_bps=110.0,
+                max_adverse_excursion_bps=-40.0,
+                label_quality="final",
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                },
+            )
+        ]
+    )
+    conflicting_shadow = replace(
+        _shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp),
+        symbol="BTC/USDT",
+        proposed_direction="long",
+        accepted=True,
+        context=OpportunityShadowContext(
+            environment="paper",
+            notes={"portfolio": "paper-1", "portfolio_id": "live-1"},
+        ),
+    )
+    valid_same_scope_shadow = replace(
+        _shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp),
+        symbol="BTC/USDT",
+        proposed_direction="long",
+        accepted=True,
+        context=OpportunityShadowContext(
+            environment="paper",
+            notes={"portfolio": "paper-1", "portfolio_id": "paper-1"},
+        ),
+    )
+    if shadow_scope_order_variant == "conflicting_first":
+        ordered_shadow_records = [conflicting_shadow, valid_same_scope_shadow]
+    elif shadow_scope_order_variant == "valid_first":
+        ordered_shadow_records = [valid_same_scope_shadow, conflicting_shadow]
+    else:
+        raise AssertionError(f"Unexpected shadow_scope_order_variant: {shadow_scope_order_variant}")
+    repository.shadow_records_path.write_text(
+        "".join(json.dumps(row.to_dict()) + "\n" for row in ordered_shadow_records),
+        encoding="utf-8",
+    )
+
+    shadow_records_for_key_symbol = [
+        row
+        for row in repository.load_shadow_records()
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert len(shadow_records_for_key_symbol) == 2
+    conflicting_shadows = [
+        row
+        for row in shadow_records_for_key_symbol
+        if str(getattr(row.context, "environment", "") or "").strip() == "paper"
+        and str((getattr(row.context, "notes", {}) or {}).get("portfolio") or "").strip()
+        != str((getattr(row.context, "notes", {}) or {}).get("portfolio_id") or "").strip()
+    ]
+    assert len(conflicting_shadows) == 1
+    conflicting_notes = getattr(conflicting_shadows[0].context, "notes", {}) or {}
+    assert str(conflicting_notes.get("portfolio") or "").strip() == "paper-1"
+    assert str(conflicting_notes.get("portfolio_id") or "").strip() == "live-1"
+    valid_same_scope_shadows = [
+        row
+        for row in shadow_records_for_key_symbol
+        if str(getattr(row.context, "environment", "") or "").strip() == "paper"
+        and str((getattr(row.context, "notes", {}) or {}).get("portfolio") or "").strip()
+        == "paper-1"
+        and str((getattr(row.context, "notes", {}) or {}).get("portfolio_id") or "").strip()
+        == "paper-1"
+    ]
+    assert len(valid_same_scope_shadows) == 1
+    assert str(valid_same_scope_shadows[0].proposed_direction or "").strip().lower() == "long"
+
+    final_labels = [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key
+        and str(row.symbol) == "BTC/USDT"
+        and str(row.label_quality).strip().lower() == "final"
+    ]
+    assert len(final_labels) == 1
+    final_provenance = dict(final_labels[0].provenance or {})
+    assert str(final_provenance.get("autonomy_final_mode") or "").strip().lower() == "paper_autonomous"
+    assert str(final_provenance.get("environment") or "").strip() == "paper"
+    assert str(final_provenance.get("portfolio") or "").strip() == "paper-1"
+
+    labels_snapshot = [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+    execution = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 333.0}]
+    )
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    replay_metadata = dict(replay_open_signal.metadata)
+    replay_metadata.pop("opportunity_autonomy_mode", None)
+    replay_decision = replay_metadata.get("opportunity_autonomy_decision")
+    if isinstance(replay_decision, dict):
+        replay_decision = dict(replay_decision)
+        replay_decision.pop("effective_mode", None)
+        replay_metadata["opportunity_autonomy_decision"] = replay_decision
+    else:
+        replay_metadata.pop("opportunity_autonomy_decision", None)
+    replay_open_signal.metadata = replay_metadata
+
+    replay_results = controller.process_signals([replay_open_signal])
+    assert replay_results == []
+    assert execution.requests == []
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    replay_skip_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip_event = replay_skip_events[0]
+    assert str(replay_skip_event.get("reason") or replay_skip_event.get("decision_reason") or "").strip() == (
+        "final_outcome_replay_open_suppressed"
+    )
+    assert str(replay_skip_event.get("proxy_correlation_key") or "").strip() == correlation_key
+    if "order_opportunity_shadow_record_key" in replay_skip_event:
+        assert str(replay_skip_event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+
+    labels_after = repository.load_outcome_labels()
+    assert [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in labels_after
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in labels_after
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
 @pytest.mark.parametrize(
     ("shadow_notes",),
     [


### PR DESCRIPTION
### Motivation
- Zabezpieczyć kontrakt, że konfliktowy shadow (portfolio != portfolio_id) jest ignorowany w pętli `shadow_records`, a poprawny same‑scope shadow nadal umożliwia suppress OPEN replay niezależnie od kolejności rekordów.
- Hardening testowy zamiast zmiany runtime: audit wykazał, że istniejąca logika w `controller.py` już realizuje wymagany zachowanie, więc dodano tylko test porządku niezależnego.

### Description
- Dodano nowy parametryzowany test `test_opportunity_autonomy_exact_open_replay_after_final_label_with_conflicting_and_valid_shadow_scope_context_uses_valid_shadow_for_suppression` sprawdzający oba porządki zapisów (`conflicting_first`, `valid_first`).
- Test tworzy dokładnie dwa shadow records (1 konfliktowy: `portfolio==paper-1` / `portfolio_id==live-1`, 1 valid same‑scope: oba `paper-1`), dopisuje final label z provenance `paper_autonomous` i uruchamia replay OPEN BUY w runtime scope `environment=paper`, `portfolio_id=paper-1`.
- Test asercje obejmują: brak execution/requests, brak `opportunity_outcome_attach`, dokładnie 1 `signal_skipped` z `reason == final_outcome_replay_open_suppressed`, brak driftu snapshotów labels/open_outcomes oraz brak `partial_exit_unconfirmed` i duplikatów residue metadata.
- Żadne zmiany w `bot_core/runtime/controller.py` nie były konieczne; modyfikacja ograniczona wyłącznie do `tests/test_trading_controller.py`.

### Testing
- `ruff` check dla scoped files przeszedł (`bot_core/runtime/controller.py` i `tests/test_trading_controller.py`).
- Uruchomienie zestawu testów selekcji: `pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` zakończyło się sukcesem (689 passed, 305 deselected).
- Uruchomienie bardziej rozbudowanej selekcji skierowanej w poleceniach kolekcjonowało błąd importu podczas kolekcji (`ImportError` z powodu istniejącego circular importu w `bot_core.decision.orchestrator`), co jest problemem niezwiązanym z dodanym testem i poza zakresem tej zmiany.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7450af110832aa773d1b8f9981e17)