### PR TITLE
Dodaj test regresyjny: duplicate CLOSE guard — conflicting + valid shadow order

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -42732,6 +42732,216 @@ def test_opportunity_autonomy_duplicate_close_guard_mixed_scope_shadow_records_u
     )
 
 
+@pytest.mark.parametrize("shadow_scope_order_variant", ["conflicting_first", "valid_first"])
+def test_opportunity_autonomy_duplicate_close_guard_conflicting_and_valid_shadow_scope_context_uses_valid_shadow_for_suppression(
+    shadow_scope_order_variant: str,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 13, 9, 30, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="duplicate-close-conflicting-and-valid-shadow-context-"))
+    )
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                correlation_key=correlation_key,
+                horizon_minutes=15,
+                realized_return_bps=5.0,
+                max_favorable_excursion_bps=7.0,
+                max_adverse_excursion_bps=-3.0,
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                },
+                label_quality="final",
+            )
+        ]
+    )
+    conflicting_shadow = OpportunityShadowRecord(
+        record_key=correlation_key,
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        decision_source="opportunity_ai_shadow",
+        expected_edge_bps=6.0,
+        success_probability=0.7,
+        confidence=0.4,
+        proposed_direction="long",
+        accepted=True,
+        rejection_reason=None,
+        rank=1,
+        provenance={"probability_method": "test"},
+        threshold_config=OpportunityThresholdConfig(),
+        snapshot={},
+        context=OpportunityShadowContext(
+            environment="paper",
+            notes={"portfolio": "paper-1", "portfolio_id": "live-1"},
+        ),
+    )
+    valid_same_scope_shadow = OpportunityShadowRecord(
+        record_key=correlation_key,
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        decision_source="opportunity_ai_shadow",
+        expected_edge_bps=6.0,
+        success_probability=0.7,
+        confidence=0.4,
+        proposed_direction="long",
+        accepted=True,
+        rejection_reason=None,
+        rank=1,
+        provenance={"probability_method": "test"},
+        threshold_config=OpportunityThresholdConfig(),
+        snapshot={},
+        context=OpportunityShadowContext(
+            environment="paper",
+            notes={"portfolio": "paper-1", "portfolio_id": "paper-1"},
+        ),
+    )
+    if shadow_scope_order_variant == "conflicting_first":
+        ordered_shadow_records = [conflicting_shadow, valid_same_scope_shadow]
+    elif shadow_scope_order_variant == "valid_first":
+        ordered_shadow_records = [valid_same_scope_shadow, conflicting_shadow]
+    else:
+        raise AssertionError(f"Unexpected shadow_scope_order_variant: {shadow_scope_order_variant}")
+    repository.shadow_records_path.write_text(
+        "".join(json.dumps(row.to_dict()) + "\n" for row in ordered_shadow_records),
+        encoding="utf-8",
+    )
+
+    shadow_records_for_key_symbol = [
+        row
+        for row in repository.load_shadow_records()
+        if row.record_key == correlation_key and row.symbol == "BTC/USDT"
+    ]
+    assert len(shadow_records_for_key_symbol) == 2
+    conflicting_shadows = [
+        row
+        for row in shadow_records_for_key_symbol
+        if str(getattr(row.context, "environment", "") or "").strip() == "paper"
+        and str((getattr(row.context, "notes", {}) or {}).get("portfolio") or "").strip() == "paper-1"
+        and str((getattr(row.context, "notes", {}) or {}).get("portfolio_id") or "").strip() == "live-1"
+        and str((getattr(row.context, "notes", {}) or {}).get("portfolio") or "").strip()
+        != str((getattr(row.context, "notes", {}) or {}).get("portfolio_id") or "").strip()
+    ]
+    assert len(conflicting_shadows) == 1
+    valid_same_scope_shadows = [
+        row
+        for row in shadow_records_for_key_symbol
+        if str(getattr(row.context, "environment", "") or "").strip() == "paper"
+        and str((getattr(row.context, "notes", {}) or {}).get("portfolio") or "").strip() == "paper-1"
+        and str((getattr(row.context, "notes", {}) or {}).get("portfolio_id") or "").strip() == "paper-1"
+        and str(row.proposed_direction or "").strip().lower() == "long"
+    ]
+    assert len(valid_same_scope_shadows) == 1
+
+    final_labels = [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key
+        and str(row.symbol) == "BTC/USDT"
+        and str(row.label_quality).strip().lower() == "final"
+    ]
+    assert len(final_labels) == 1
+    final_provenance = dict(final_labels[0].provenance or {})
+    assert str(final_provenance.get("autonomy_final_mode") or "").strip().lower() == "paper_autonomous"
+    assert str(final_provenance.get("environment") or "").strip() == "paper"
+    assert str(final_provenance.get("portfolio") or "").strip() == "paper-1"
+
+    labels_snapshot = [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 222.0}])
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_close = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=False,
+    )
+    replay_close.metadata = {**dict(replay_close.metadata), "mode": "close_ranked"}
+    replay_results = controller.process_signals([replay_close])
+    assert replay_results == []
+    assert execution.requests == []
+
+    journal_events = [dict(event) for event in journal.export()]
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").startswith("order_")
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    assert [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "opportunity_outcome_attach"
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ] == []
+    replay_skip_events = [
+        event
+        for event in journal_events
+        if str(event.get("event") or "").strip() == "signal_skipped"
+        and (
+            str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+            or str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        )
+    ]
+    assert len(replay_skip_events) == 1
+    replay_skip_event = replay_skip_events[0]
+    assert (
+        str(replay_skip_event.get("reason") or replay_skip_event.get("decision_reason") or "").strip()
+        == "duplicate_autonomous_close_replay_suppressed"
+    )
+    assert str(replay_skip_event.get("proxy_correlation_key") or "").strip() == correlation_key
+    if "order_opportunity_shadow_record_key" in replay_skip_event:
+        assert str(replay_skip_event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    assert [
+        event
+        for event in replay_skip_events
+        if str(event.get("reason") or event.get("decision_reason") or "").strip()
+        == "final_outcome_replay_open_suppressed"
+    ] == []
+    assert [
+        (row.correlation_key, row.symbol, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+    replay_non_skip_events = [
+        event for event in journal_events if str(event.get("event") or "").strip() != "signal_skipped"
+    ]
+    _assert_no_duplicate_residue_metadata_for_shadow_key(
+        replay_non_skip_events, shadow_key=correlation_key
+    )
+
+
 def test_opportunity_autonomy_duplicate_close_guard_same_key_different_symbol_final_label_does_not_suppress_replay_close() -> (
     None
 ):


### PR DESCRIPTION
### Motivation
- Zapewnienie order-independence w walidacji shadow_records dla guardu duplicate CLOSE tak, żeby konfliktowy shadow (portfolio != portfolio_id) nie zablokował suppressu, gdy w storage istnieje poprawny same-scope shadow.
- Zakres zmiany ograniczony do hardeningu testów bez refaktoru kontrolera, zgodnie z wymaganym mini-scope.

### Description
- Dodano parametryzowany test `test_opportunity_autonomy_duplicate_close_guard_conflicting_and_valid_shadow_scope_context_uses_valid_shadow_for_suppression` w `tests/test_trading_controller.py`, sprawdzający scenariusze `conflicting_first` i `valid_first` oraz pełny zestaw twardych asercji kontraktowych (brak wykonania zlecenia, jeden `signal_skipped` z powodem `duplicate_autonomous_close_replay_suppressed`, brak attach/order/events/drift/partial_exit_unconfirmed itd.).
- Przeprowadzono audit funkcji `_is_duplicate_autonomous_close_replay(...)` w `bot_core/runtime/controller.py` i potwierdzono, że istniejąca pętla po `shadow_records` poprawnie `continue` przy wykryciu konfliktu i nie powoduje early-exit, więc nie wprowadzono zmian w `controller.py`.

### Testing
- Uruchomiono instalację dev dependencies przez `PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]` i zakończyła się sukcesem.
- Sprawdzono styl/type-check przez `python -m ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` i testy lintera przeszły (`All checks passed`).
- Uruchomiono krytyczny zestaw testów przez `PYENV_VERSION=3.11.14 pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source"` i zakończyło się sukcesem (`691 passed, 305 deselected`).
- Próba uruchomienia bardzo szerokiego, precyzyjnego selektora pytest (wymaganej komendy) napotkała błąd kolekcji związany z istniejącym circular import (`DecisionOrchestrator`) niezwiązanym z tą zmianą, więc pełny szeroki selector nie przeszedł zbioru kolekcji (błąd kolekcji).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74c6fd504832aaaaa9a9f745c6902)