### PR TITLE
Add negative-controls for conflicting final replay scope

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -68908,3 +68908,195 @@ def test_opportunity_autonomy_exact_open_replay_after_foreign_final_scope_does_n
         for row in repository.load_outcome_labels()
         if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
     ] == []
+
+
+def test_opportunity_autonomy_duplicate_close_guard_conflicting_final_scope_does_not_suppress_with_valid_shadow_scope() -> None:
+    decision_timestamp = datetime(2026, 1, 14, 13, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="close-replay-conflicting-final-valid-shadow-"))
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key,
+                    decision_timestamp=decision_timestamp,
+                ),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
+                proposed_direction="long",
+            ),
+        ]
+    )
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=91.0,
+                max_favorable_excursion_bps=91.0,
+                max_adverse_excursion_bps=-29.0,
+                label_quality="final",
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                    "portfolio_id": "paper-foreign",
+                },
+            )
+        ]
+    )
+    labels_snapshot = [(row.correlation_key, row.label_quality, dict(row.provenance)) for row in repository.load_outcome_labels()]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}])
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_mode=False,
+    )
+    replay_close_signal.metadata = {**dict(replay_close_signal.metadata), "mode": "close_ranked"}
+    results = controller.process_signals([replay_close_signal])
+    assert [result.status for result in results] == ["filled"]
+    assert [request.side for request in execution.requests] == ["SELL"]
+    assert _request_shadow_keys(execution.requests) == [correlation_key]
+    journal_events = [dict(event) for event in journal.export()]
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "duplicate_autonomous_close_replay_suppressed"
+        for event in journal_events
+    )
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "final_outcome_replay_open_suppressed"
+        for event in journal_events
+    )
+    attach_events = [event for event in journal_events if event.get("event") == "opportunity_outcome_attach"]
+    assert not any(str(event.get("status") or "").strip() == "upgrade_attached" for event in attach_events)
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []
+
+
+def test_opportunity_autonomy_exact_open_replay_after_conflicting_final_scope_does_not_suppress_with_valid_shadow_scope() -> None:
+    decision_timestamp = datetime(2026, 1, 14, 13, 30, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = OpportunityShadowRepository(
+        Path(tempfile.mkdtemp(prefix="open-replay-conflicting-final-valid-shadow-"))
+    )
+    repository.append_shadow_records(
+        [
+            replace(
+                _shadow_record_for_key(
+                    correlation_key=correlation_key,
+                    decision_timestamp=decision_timestamp,
+                ),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
+                proposed_direction="long",
+            ),
+        ]
+    )
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                correlation_key=correlation_key,
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp + timedelta(minutes=5),
+                horizon_minutes=60,
+                realized_return_bps=89.0,
+                max_favorable_excursion_bps=89.0,
+                max_adverse_excursion_bps=-22.0,
+                label_quality="final",
+                provenance={
+                    "autonomy_final_mode": "paper_autonomous",
+                    "environment": "paper",
+                    "portfolio": "paper-1",
+                    "portfolio_id": "paper-foreign",
+                },
+            )
+        ]
+    )
+    labels_snapshot = [(row.correlation_key, row.label_quality, dict(row.provenance)) for row in repository.load_outcome_labels()]
+    open_outcomes_snapshot = [row.model_dump(mode="json") for row in repository.load_open_outcomes()]
+    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 224.0}])
+    journal = CollectingDecisionJournal()
+    controller = TradingController(
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        alert_router=_router_with_channel()[0],
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="paper-1",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal,
+        opportunity_shadow_repository=repository,
+    )
+    replay_open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    results = controller.process_signals([replay_open_signal])
+    assert [result.status for result in results] == ["filled"]
+    assert [request.side for request in execution.requests] == ["BUY"]
+    assert _request_shadow_keys(execution.requests) == [correlation_key]
+    journal_events = [dict(event) for event in journal.export()]
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "final_outcome_replay_open_suppressed"
+        for event in journal_events
+    )
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "duplicate_autonomous_close_replay_suppressed"
+        for event in journal_events
+    )
+    attach_events = [event for event in journal_events if event.get("event") == "opportunity_outcome_attach"]
+    assert not any(str(event.get("status") or "").strip() == "upgrade_attached" for event in attach_events)
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+    ] == labels_snapshot
+    assert [row.model_dump(mode="json") for row in repository.load_open_outcomes()] == open_outcomes_snapshot
+    assert [
+        row
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+    ] == []


### PR DESCRIPTION
### Motivation
- Uzupełnić brakujące negative-controls dla scenariusza "single conflicting final label scope" (portfolio != portfolio_id) w dwóch ścieżkach replay: duplicate CLOSE oraz OPEN po final close, przy istnieniu poprawnego same-scope shadow proof.

### Description
- Dodano dwa testy w `tests/test_trading_controller.py`: `test_opportunity_autonomy_duplicate_close_guard_conflicting_final_scope_does_not_suppress_with_valid_shadow_scope` oraz `test_opportunity_autonomy_exact_open_replay_after_conflicting_final_scope_does_not_suppress_with_valid_shadow_scope`.
- Testy odtwarzają setup: final label z provenance zawierającym `autonomy_final_mode="paper_autonomous"`, `environment="paper"`, `portfolio="paper-1"`, `portfolio_id="paper-foreign"` oraz valid shadow record z `OpportunityShadowContext(environment="paper", notes={"portfolio":"paper-1"})` i `proposed_direction="long"`.
- Assercje w testach weryfikują, że replay NIE jest suppressowany (brak reasonów `duplicate_autonomous_close_replay_suppressed` / `final_outcome_replay_open_suppressed`), wykonanie idzie dalej z dokładnie jednym requestem (SELL/BUY), oraz brak side-effectów typu `upgrade_attached`, driftu labels/open_outcomes i `partial_exit_unconfirmed`.
- Żadne zmiany w runtime (`bot_core/runtime/controller.py`) ani w reasonach nie zostały wprowadzone — patch dotyczy wyłącznie testów.

### Testing
- Uruchomiono instalację dev dependencies (`PYENV_VERSION=3.11.14 python scripts/ci/pip_install.py -- .[dev]`) i potwierdzono środowisko (`numpy 2.4.4`, `cryptography 46.0.7`), instalacja zakończona sukcesem.
- Uruchomiono selektory i testy celowane: `-k "conflicting_final_scope_does_not_suppress_with_valid_shadow_scope ..."` zwróciło `63 passed, 907 deselected` oraz oba nowe testy uruchomione pojedynczo przeszły (`1 passed` każdy).
- Szersze selektory z replay/final/autonomy zwróciły `836 passed, 136 deselected`, a lifecycle suite z `opportunity_autonomy_` zwróciła `706 passed, 305 deselected`.
- `ruff check bot_core/runtime/controller.py tests/test_trading_controller.py` zakończony sukcesem (`All checks passed!`).
- Wszystkie uruchomione testy przeszły; zmiany zostały skomitowane (hash `e49159966ec66ad03155cdc62d2e3511e123376d`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91bdb955c832ab7be3e10a8d4fc82)