### PR TITLE
Propagate portfolio scope to opportunity shadow records

### DIFF
--- a/bot_core/ai/opportunity_shadow_adapter.py
+++ b/bot_core/ai/opportunity_shadow_adapter.py
@@ -180,6 +180,7 @@ class OpportunityRuntimeShadowAdapter:
             schedule_name=schedule_name,
             risk_profile=risk_profile,
             environment=environment,
+            portfolio=portfolio,
         )
         provenance = dict(decision.provenance)
         provenance.update(
@@ -247,6 +248,7 @@ class OpportunityRuntimeShadowAdapter:
         schedule_name: str,
         risk_profile: str,
         environment: str,
+        portfolio: str,
     ) -> tuple[str | None, str, str | None]:
         if self.shadow_repository is None:
             return None, "disabled", None
@@ -262,7 +264,7 @@ class OpportunityRuntimeShadowAdapter:
                 },
                 context=OpportunityShadowContext(
                     environment=environment,
-                    notes={"adapter_mode": self.mode},
+                    notes={"adapter_mode": self.mode, "portfolio": str(portfolio)},
                 ),
             )
             self.shadow_repository.append_shadow_records(records)

--- a/tests/runtime/test_opportunity_shadow_adapter_runtime.py
+++ b/tests/runtime/test_opportunity_shadow_adapter_runtime.py
@@ -170,6 +170,8 @@ def test_shadow_adapter_persists_shadow_record_when_repository_is_configured(
     records = shadow_repository.load_shadow_records()
     assert len(records) == 1
     assert records[0].model_version
+    assert records[0].context.environment == "paper"
+    assert records[0].context.notes["portfolio"] == "paper-main"
     assert journal.events[-1].metadata["shadow_persistence_status"] == "persisted"
     assert journal.events[-1].metadata["shadow_record_key"] == records[0].record_key
 


### PR DESCRIPTION
### Motivation
- W runtime-adapterze shadow proposals (`OpportunityRuntimeShadowAdapter`) parametr `portfolio` nie był propagowany do tworzonego `OpportunityShadowContext.notes`, co powodowało brak "portfolio proof" w produkcyjnie zapisywanych rekordach shadow mimo, że producer znał `portfolio`.
- Należało dodać jedynie minimalne ustawienie scope proof bez zmiany semantyki hardeningu ani szerokich refaktorów.

### Description
- Do `emit_shadow_proposal` przekazano `portfolio` dalej do `_persist_shadow_record` i rozszerzono jego sygnaturę o `portfolio`.
- Przy budowaniu `OpportunityShadowContext` w `_persist_shadow_record` dodano `notes={"adapter_mode": self.mode, "portfolio": str(portfolio)}` aby zachować proof portfela w zapisywanym rekordzie.
- Dodano asercje w najbliższym teście runtime `tests/runtime/test_opportunity_shadow_adapter_runtime.py`, aby sprawdzić, że `records[0].context.environment` i `records[0].context.notes["portfolio"]` są zapisane.
- Zmiany ograniczono wyłącznie do `bot_core/ai/opportunity_shadow_adapter.py` i powiązanego testu runtime; nie modyfikowano innych obszarów produkcyjnych ani raportów/logów.

### Testing
- Uruchomiono dedykowany test: `PYENV_VERSION=3.11.14 python -m pytest -q tests/runtime/test_opportunity_shadow_adapter_runtime.py -k "persists_shadow_record_when_repository_is_configured" --tb=short` i zakończył się sukcesem (`1 passed, 16 deselected`). ✅
- Uruchomiono szerszy zestaw adapter tests: `PYENV_VERSION=3.11.14 python -m pytest -q tests/runtime/test_opportunity_shadow_adapter_runtime.py -k "shadow_adapter" --tb=short` i zakończył się sukcesem (`17 passed`). ✅
- Uruchomiono selektory kontrolera runtime: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "handoff or autonomous_open or duplicate_open_guard or duplicate_close_guard or open_close_classifier or scope_aware_resolution or restored_tracker_runtime_position or opposite_side or reentry or flip or opportunity_autonomy_ or runtime_lineage" --tb=short` i zakończył się sukcesem (`864 passed, 117 deselected`). ✅
- Uruchomiono krytyczne AI + controller selektory: `PYENV_VERSION=3.11.14 python -m pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source" --tb=short` i zakończył się sukcesem (`706 passed, 314 deselected`). ✅
- Sprawdzono formatowanie/linters: `PYENV_VERSION=3.11.14 python -m ruff check bot_core/ai/opportunity_shadow_adapter.py tests/runtime/test_opportunity_shadow_adapter_runtime.py` i wszystkie checki przeszły (`All checks passed!`). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f24621a4832a917cf9669350e769)