### PR TITLE
Accept ruff-format formatter-only changes for controller and trading tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -3445,9 +3445,15 @@ class TradingController:
                 str(getattr(candidate_context, "environment", "")).strip().lower()
             )
             candidate_notes = getattr(candidate_context, "notes", None)
-            candidate_notes_mapping = candidate_notes if isinstance(candidate_notes, Mapping) else {}
-            candidate_portfolio_raw = str(candidate_notes_mapping.get("portfolio") or "").strip().lower()
-            candidate_portfolio_id_raw = str(candidate_notes_mapping.get("portfolio_id") or "").strip().lower()
+            candidate_notes_mapping = (
+                candidate_notes if isinstance(candidate_notes, Mapping) else {}
+            )
+            candidate_portfolio_raw = (
+                str(candidate_notes_mapping.get("portfolio") or "").strip().lower()
+            )
+            candidate_portfolio_id_raw = (
+                str(candidate_notes_mapping.get("portfolio_id") or "").strip().lower()
+            )
             if (
                 candidate_portfolio_raw
                 and candidate_portfolio_id_raw
@@ -3466,7 +3472,11 @@ class TradingController:
                 continue
             if runtime_portfolio and not legacy_scope_missing and not candidate_portfolio:
                 continue
-            if runtime_portfolio and candidate_portfolio and candidate_portfolio != runtime_portfolio:
+            if (
+                runtime_portfolio
+                and candidate_portfolio
+                and candidate_portfolio != runtime_portfolio
+            ):
                 continue
             scoped_candidates.append(candidate)
         if not scoped_candidates:

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -38685,7 +38685,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_positive_position_si
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -38869,7 +38871,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_positive_position_si
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -38980,7 +38984,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_negative_position_ke
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -39075,7 +39081,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_both_keys_conflictin
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -39186,7 +39194,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_both_keys_first_inva
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -39281,7 +39291,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_both_keys_first_vali
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -39376,7 +39388,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_zero_position_withou
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -39484,7 +39498,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_both_keys_zero_then_
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -39592,7 +39608,9 @@ def test_opportunity_autonomy_restored_sell_tracker_runtime_both_keys_positive_t
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             )
         ]
     )
@@ -50025,7 +50043,9 @@ def test_opportunity_autonomous_open_without_positive_finite_quantity_proof_does
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             ),
             OpportunityShadowRecord(
                 record_key=second_key,
@@ -50043,7 +50063,9 @@ def test_opportunity_autonomous_open_without_positive_finite_quantity_proof_does
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             ),
         ]
     )
@@ -50149,7 +50171,9 @@ def test_opportunity_autonomous_open_missing_filled_quantity_field_does_not_crea
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             ),
             OpportunityShadowRecord(
                 record_key=second_key,
@@ -50167,7 +50191,9 @@ def test_opportunity_autonomous_open_missing_filled_quantity_field_does_not_crea
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             ),
         ]
     )
@@ -50434,7 +50460,9 @@ def test_opportunity_autonomous_open_positive_quantity_creates_tracker_and_consu
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             ),
             OpportunityShadowRecord(
                 record_key=second_key,
@@ -50452,7 +50480,9 @@ def test_opportunity_autonomous_open_positive_quantity_creates_tracker_and_consu
                 provenance={"probability_method": "test"},
                 threshold_config=OpportunityThresholdConfig(),
                 snapshot={},
-                context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
+                context=OpportunityShadowContext(
+                    environment="paper", notes={"portfolio": "paper-1"}
+                ),
             ),
         ]
     )
@@ -59820,7 +59850,11 @@ def test_upstream_handoff_scope_aware_resolution_prefers_valid_same_scope_candid
         provenance={"probability_method": "valid"},
         context=OpportunityShadowContext(environment="paper", notes={"portfolio": "paper-1"}),
     )
-    first, second = (invalid_candidate, valid_candidate) if invalid_first else (valid_candidate, invalid_candidate)
+    first, second = (
+        (invalid_candidate, valid_candidate)
+        if invalid_first
+        else (valid_candidate, invalid_candidate)
+    )
     shadow_repo = OpportunityShadowRepository(tmp_path / "shadow")
     shadow_repo.append_shadow_records([first, second])
     controller, execution, journal = _build_autonomy_controller(


### PR DESCRIPTION
### Motivation

- Pre-commit was failing only due to `ruff format` making formatter-only modifications in two allowed files, so the intent is to accept those formatting edits and restore a green pre-commit. 

### Description

- Accepted formatter-only changes in `bot_core/runtime/controller.py` which wrap long expressions and `if` conditions (no logic change). 
- Accepted formatter-only changes in `tests/test_trading_controller.py` which wrap `OpportunityShadowContext(...)` calls and a conditional tuple assignment `first, second = ...` (no test semantics changed). 
- No production logic, test semantics, expected values, or assertions were modified outside of line-wrapping and reflow. 

### Testing

- Ran `python -m ruff format bot_core/runtime/controller.py tests/test_trading_controller.py` which reformatted the two files (success). 
- Ran `python -m pre_commit run --all-files --show-diff-on-failure` which completed and returned green (success). 
- Ran targeted pytest `python -m pytest -q tests/test_trading_controller.py -k "upstream_handoff_scope_aware_resolution or restored_sell_tracker_runtime or opportunity_autonomous_open" -xvv` which failed during collection due to an environment missing dependency (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fb57f080832a9c89f0aae03fa3c6)