### PR TITLE
Nie zapisywać `environment` jako portfolio proof w shadow persistence

### DIFF
--- a/bot_core/ai/opportunity_shadow_adapter.py
+++ b/bot_core/ai/opportunity_shadow_adapter.py
@@ -253,6 +253,10 @@ class OpportunityRuntimeShadowAdapter:
         if self.shadow_repository is None:
             return None, "disabled", None
         try:
+            normalized_portfolio = self._normalize_portfolio_note(portfolio)
+            notes = {"adapter_mode": self.mode}
+            if normalized_portfolio is not None:
+                notes["portfolio"] = normalized_portfolio
             records = self.engine.build_shadow_records(
                 [decision],
                 decision_timestamp=decision_timestamp,
@@ -264,7 +268,7 @@ class OpportunityRuntimeShadowAdapter:
                 },
                 context=OpportunityShadowContext(
                     environment=environment,
-                    notes={"adapter_mode": self.mode, "portfolio": str(portfolio)},
+                    notes=notes,
                 ),
             )
             self.shadow_repository.append_shadow_records(records)
@@ -284,6 +288,15 @@ class OpportunityRuntimeShadowAdapter:
             )
             _LOGGER.warning("Opportunity shadow persistence failed", exc_info=True)
             return None, "error", str(exc)
+
+    @staticmethod
+    def _normalize_portfolio_note(portfolio: object) -> str | None:
+        normalized = str(portfolio or "").strip()
+        if not normalized:
+            return None
+        if normalized.lower() in {"none", "null"}:
+            return None
+        return normalized
 
     @classmethod
     def _json_safe_payload(cls, payload: Mapping[str, object]) -> dict[str, object]:

--- a/bot_core/runtime/pipeline.py
+++ b/bot_core/runtime/pipeline.py
@@ -4024,7 +4024,7 @@ class DecisionAwareSignalSink(StrategySignalSink):
                 ai_shadow_persistence_status="disabled",
                 ai_shadow_persistence_error=None,
             )
-        portfolio = self._portfolio or self._environment
+        portfolio = self._portfolio.strip()
         probe = adapter.emit_shadow_proposal(
             evaluation=evaluation,
             candidate=candidate,
@@ -4034,7 +4034,7 @@ class DecisionAwareSignalSink(StrategySignalSink):
             risk_profile=risk_profile,
             timestamp=timestamp,
             environment=self._environment,
-            portfolio=str(portfolio),
+            portfolio=portfolio,
         )
         ai_accepted = probe.accepted if probe.decision_available else None
         final_accepted = base_accepted

--- a/tests/runtime/test_opportunity_shadow_adapter_runtime.py
+++ b/tests/runtime/test_opportunity_shadow_adapter_runtime.py
@@ -330,6 +330,84 @@ def test_decision_sink_execution_path_unchanged_with_shadow_adapter(tmp_path: Pa
     assert any(event.event_type == "opportunity_shadow_proposal" for event in journal.events)
 
 
+def test_decision_sink_missing_portfolio_does_not_persist_environment_as_portfolio_proof(
+    tmp_path: Path,
+) -> None:
+    journal = _CollectingJournal()
+    shadow_repository = OpportunityShadowRepository(tmp_path / "shadow-runtime-no-portfolio")
+    adapter = OpportunityRuntimeShadowAdapter(
+        journal=journal,
+        engine=_train_model(tmp_path / "repo-no-portfolio"),
+        shadow_repository=shadow_repository,
+    )
+    sink = DecisionAwareSignalSink(
+        base_sink=InMemoryStrategySignalSink(),
+        orchestrator=_AcceptingOrchestrator(),
+        risk_engine=_RiskEngine(),
+        default_notional=1000.0,
+        environment="paper",
+        exchange="BINANCE",
+        min_probability=0.6,
+        journal=journal,
+        opportunity_shadow_adapter=adapter,
+        portfolio=None,
+    )
+    signal = StrategySignal(
+        symbol="BTCUSDT",
+        side="BUY",
+        confidence=0.9,
+        metadata={"expected_probability": 0.9, "expected_return_bps": 12.0, **_candidate_metadata()},
+    )
+
+    sink.submit(
+        strategy_name="trend-d1",
+        schedule_name="trend-d1",
+        risk_profile="balanced",
+        timestamp=datetime(2024, 1, 1, 12, 5, tzinfo=timezone.utc),
+        signals=(signal,),
+    )
+
+    records = shadow_repository.load_shadow_records()
+    assert len(records) == 1
+    context = records[0].context
+    assert context.environment == "paper"
+    assert "portfolio" not in context.notes
+
+
+def test_shadow_adapter_skips_empty_and_nullish_portfolio_proof_in_notes(tmp_path: Path) -> None:
+    shadow_repository = OpportunityShadowRepository(tmp_path / "shadow-nullish")
+    engine = _train_model(tmp_path / "repo-nullish")
+    adapter = OpportunityRuntimeShadowAdapter(
+        journal=_CollectingJournal(),
+        engine=engine,
+        shadow_repository=shadow_repository,
+    )
+
+    for value in ("", "None", "null"):
+        adapter.emit_shadow_proposal(
+            candidate=SimpleNamespace(
+                symbol="BTCUSDT",
+                action="enter",
+                metadata=_candidate_metadata(),
+            ),
+            signal=SimpleNamespace(side="BUY"),
+            evaluation=SimpleNamespace(accepted=True),
+            timestamp=datetime(2024, 1, 1, 12, 5, tzinfo=timezone.utc),
+            strategy_name="trend-d1",
+            schedule_name="trend-d1",
+            risk_profile="balanced",
+            environment="paper",
+            portfolio=value,
+        )
+
+    notes_list = [record.context.notes for record in shadow_repository.load_shadow_records()]
+    assert len(notes_list) == 3
+    for notes in notes_list:
+        assert notes.get("portfolio") != "paper"
+        assert notes.get("portfolio") != "None"
+        assert notes.get("portfolio") != ""
+
+
 def test_decision_sink_without_shadow_adapter_still_works() -> None:
     sink = DecisionAwareSignalSink(
         base_sink=InMemoryStrategySignalSink(),


### PR DESCRIPTION
### Motivation
- W produkcyjnym callsite `DecisionAwareSignalSink` brak portfolio był fallbackowany na `self._environment`, co powodowało zapisanie wartości typu `"paper"` jako dowodu portfolio, co jest błędną semantyką.
- Adapter `OpportunityRuntimeShadowAdapter` bezwarunkowo zapisywał `notes["portfolio"] = str(portfolio)`, co pozwalało na zapis pustych lub nullish wartości (`""`, `"None"`, `"null"`).

### Description
- Usunięto fallback w `bot_core/runtime/pipeline.py`: teraz do `emit_shadow_proposal` przekazywane jest tylko znormalizowane `self._portfolio.strip()` bez zastępowania `environment`.
- W `bot_core/ai/opportunity_shadow_adapter.py` dodano metodę `_normalize_portfolio_note` i budowę `notes` tak, by `portfolio` był dopisywany tylko gdy jest rzeczywistą (niepustą i nie-nullish) wartością.
- Zaktualizowano wywołanie persistence, aby używać `notes=notes` zamiast bezwarunkowego `{"adapter_mode": self.mode, "portfolio": str(portfolio)}`.
- Dodano dwa testy w `tests/runtime/test_opportunity_shadow_adapter_runtime.py` sprawdzające callsite i adapter dla brakującego oraz nullish portfolio.

### Testing
- Uruchomiono pojedynczy test callsite: `PYENV_VERSION=3.11.14 python -m pytest -q tests/runtime/test_opportunity_shadow_adapter_runtime.py::test_decision_sink_missing_portfolio_does_not_persist_environment_as_portfolio_proof -vv --tb=short` — rezultat: `PASSED`.
- Uruchomiono testy adaptera: `PYENV_VERSION=3.11.14 python -m pytest -q tests/runtime/test_opportunity_shadow_adapter_runtime.py -k "shadow_adapter" --tb=short` — rezultat: `19 passed`.
- Uruchomiono szersze selektory regresji: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "handoff or autonomous_open or duplicate_open_guard or duplicate_close_guard or open_close_classifier or scope_aware_resolution or restored_tracker_runtime_position or opposite_side or reentry or flip or opportunity_autonomy_ or runtime_lineage" --tb=short` — rezultat: `864 passed, 117 deselected`.
- Dodatkowe integracyjne selektory: `PYENV_VERSION=3.11.14 python -m pytest -q tests/ai/test_opportunity_lifecycle.py tests/test_trading_controller.py -k "opportunity_autonomy_ or runtime_lineage or decision_source" --tb=short` — rezultat: `706 passed, 314 deselected`.
- Statyczne sprawdzenie kodu: `PYENV_VERSION=3.11.14 python -m ruff check bot_core/runtime/pipeline.py bot_core/ai/opportunity_shadow_adapter.py tests/runtime/test_opportunity_shadow_adapter_runtime.py` — rezultat: `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa062ae8f0832a8bf684f661967072)