### PR TITLE
Wzmocnienie asercji testu dla nullish portfolio proof

### DIFF
--- a/tests/runtime/test_opportunity_shadow_adapter_runtime.py
+++ b/tests/runtime/test_opportunity_shadow_adapter_runtime.py
@@ -403,6 +403,7 @@ def test_shadow_adapter_skips_empty_and_nullish_portfolio_proof_in_notes(tmp_pat
     notes_list = [record.context.notes for record in shadow_repository.load_shadow_records()]
     assert len(notes_list) == 3
     for notes in notes_list:
+        assert "portfolio" not in notes
         assert notes.get("portfolio") != "paper"
         assert notes.get("portfolio") != "None"
         assert notes.get("portfolio") != ""


### PR DESCRIPTION
### Motivation
- Zwiększyć pewność testu `test_shadow_adapter_skips_empty_and_nullish_portfolio_proof_in_notes` poprzez twardą asercję, że klucz `portfolio` nie pojawia się w `notes` dla wartości nullish.

### Description
- Dodano jedną linię w `tests/runtime/test_opportunity_shadow_adapter_runtime.py`: `assert "portfolio" not in notes`, bez zmian w kodzie produkcyjnym.

### Testing
- Uruchomione testy i wyniki: docelowy test przeszedł (`1 passed`), selekcja shadow-adapter runtime: `19 passed`, selekcja trading controller: `864 passed, 117 deselected`, lifecycle/controller selection: `706 passed, 314 deselected`, oraz `ruff check` dla zmodyfikowanego pliku: `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa09a57ef8832aafbd0e4f8d1c18b7)