### PR TITLE
Block new autonomous opens when runtime manual kill-switch is active

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -2774,6 +2774,31 @@ class TradingController:
             existing_open_tracker = (
                 self._opportunity_open_outcomes.get(correlation_key) if correlation_key else None
             )
+            runtime_lineage = self._extract_opportunity_runtime_lineage_snapshot(request.metadata)
+            runtime_controls_disable_new_open = (
+                runtime_lineage.get("opportunity_ai_enabled") == "false"
+                and runtime_lineage.get("opportunity_ai_manual_kill_switch_active") == "true"
+                and runtime_lineage.get("ai_required_for_execution") == "true"
+            )
+            if runtime_controls_disable_new_open and existing_open_tracker is None:
+                blocked_metadata: dict[str, object] = {
+                    **metadata,
+                    "execution_permission": "blocked",
+                    "autonomous_execution_allowed": False,
+                    "autonomy_primary_reason": "autonomy_mode_denied",
+                    "blocking_reason": "autonomy_mode_denied",
+                    "autonomy_decisive_stage": "runtime_controls",
+                    "autonomy_decisive_reason": "autonomy_mode_denied",
+                }
+                self._record_decision_event(
+                    "opportunity_autonomy_enforcement",
+                    signal=signal,
+                    request=request,
+                    status="blocked",
+                    metadata=blocked_metadata,
+                )
+                self._metric_signals_total.inc(labels={**metric_labels, "status": "rejected"})
+                return None
             mode_raw = (request.metadata or {}).get("opportunity_autonomy_mode")
             duplicate_open_guard_enabled = str(mode_raw or "").strip().lower() in {
                 "paper_autonomous",

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -69082,6 +69082,248 @@ def test_ai_failover_blocked_open_replay_idempotent_without_risk_execution_or_tr
     )
 
 
+def test_runtime_controls_manual_kill_switch_blocks_new_autonomous_open_before_risk_and_execution() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    open_signal = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+    open_signal.metadata = {
+        **dict(open_signal.metadata),
+        "opportunity_ai_enabled": "false",
+        "opportunity_ai_manual_kill_switch_active": "true",
+        "ai_required_for_execution": "true",
+        "final_decision_accepted": "false",
+        "decision_authority": "decision_orchestrator",
+        "opportunity_ai_disabled_reason": "manual_kill_switch:runtime_control_plane",
+        "mode": "ai",
+    }
+
+    results = controller.process_signals([open_signal])
+    assert results == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert controller._opportunity_open_outcomes == {}
+    events = [dict(event) for event in journal.export()]
+    assert not any(
+        event.get("event") in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+        for event in events
+    )
+    blocked = [event for event in events if event.get("event") == "opportunity_autonomy_enforcement"]
+    assert blocked
+    assert blocked[-1]["status"] == "blocked"
+    assert blocked[-1]["blocking_reason"] == "autonomy_mode_denied"
+
+
+def test_runtime_controls_manual_kill_switch_allows_legal_autonomous_close_for_existing_tracker() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    correlation_key = "runtime-controls-legal-close"
+    controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+        correlation_key=correlation_key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        environment_scope="paper",
+        portfolio_scope="paper-1",
+    )
+    close_signal = _opportunity_autonomy_signal(
+        "paper_autonomous",
+        side="SELL",
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "opportunity_ai_enabled": "false",
+        "opportunity_ai_manual_kill_switch_active": "true",
+        "ai_required_for_execution": "true",
+        "final_decision_accepted": "false",
+        "opportunity_ai_disabled_reason": "manual_kill_switch:runtime_control_plane",
+        "opportunity_shadow_record_key": correlation_key,
+        "mode": "ai",
+    }
+
+    results = controller.process_signals([close_signal])
+    assert [result.status for result in results] == ["filled"]
+    assert len(risk_engine.last_checks) >= 1
+    assert execution.requests[-1].side == "SELL"
+    assert execution.requests[-1].symbol == "BTC/USDT"
+    assert execution.requests[-1].quantity == pytest.approx(1.0)
+    assert (
+        str((execution.requests[-1].metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+    )
+    close_events = [
+        dict(event)
+        for event in journal.export()
+        if str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+    ]
+    assert not any(
+        event.get("event") == "opportunity_autonomy_enforcement"
+        and str(event.get("blocking_reason") or "").strip() == "autonomy_mode_denied"
+        for event in close_events
+    )
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and str(event.get("reason") or "").strip() in {"ai_failover_active", "autonomy_mode_denied"}
+        for event in close_events
+    )
+
+
+def test_runtime_controls_invalid_same_side_close_preserves_close_contract_blocking_reason() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    correlation_key = "runtime-controls-invalid-close"
+    controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+        correlation_key=correlation_key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        environment_scope="paper",
+        portfolio_scope="paper-1",
+    )
+    invalid_close = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    invalid_close.metadata = {
+        **dict(invalid_close.metadata),
+        "opportunity_ai_enabled": "false",
+        "opportunity_ai_manual_kill_switch_active": "true",
+        "ai_required_for_execution": "true",
+        "final_decision_accepted": "false",
+        "opportunity_ai_disabled_reason": "manual_kill_switch:runtime_control_plane",
+        "mode": "ai",
+    }
+
+    results = controller.process_signals([invalid_close])
+    assert results == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    events = [dict(event) for event in journal.export()]
+    blocked = [event for event in events if event.get("event") == "opportunity_autonomy_enforcement"]
+    assert blocked
+    assert blocked[-1]["blocking_reason"] == "accepted_autonomous_handoff_shadow_reference_unresolved"
+    assert not any(
+        event.get("event") in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+        for event in events
+    )
+
+
+def test_runtime_controls_manual_kill_switch_blocked_open_replay_is_idempotent() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    open_signal = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+    open_signal.metadata = {
+        **dict(open_signal.metadata),
+        "opportunity_ai_enabled": "false",
+        "opportunity_ai_manual_kill_switch_active": "true",
+        "ai_required_for_execution": "true",
+        "final_decision_accepted": "false",
+        "opportunity_ai_disabled_reason": "manual_kill_switch:runtime_control_plane",
+        "mode": "ai",
+    }
+
+    assert controller.process_signals([open_signal]) == []
+    assert controller.process_signals([open_signal]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert controller._opportunity_open_outcomes == {}
+    blocked = [
+        dict(event)
+        for event in journal.export()
+        if event.get("event") == "opportunity_autonomy_enforcement" and event.get("status") == "blocked"
+    ]
+    assert len(blocked) == 2
+
+
+def test_runtime_controls_manual_kill_switch_disable_then_reenable_retry_open_reaches_execution() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    blocked_open = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+    blocked_open.metadata = {
+        **dict(blocked_open.metadata),
+        "opportunity_ai_enabled": "false",
+        "opportunity_ai_manual_kill_switch_active": "true",
+        "ai_required_for_execution": "true",
+        "final_decision_accepted": "false",
+        "opportunity_ai_disabled_reason": "manual_kill_switch:runtime_control_plane",
+        "mode": "ai",
+    }
+    allowed_open = _opportunity_autonomy_signal(
+        "paper_autonomous",
+        side="BUY",
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    allowed_open.metadata = {**dict(allowed_open.metadata), "mode": "ai"}
+
+    assert controller.process_signals([blocked_open]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+
+    retried = controller.process_signals([allowed_open])
+    assert [result.status for result in retried] == ["filled"]
+    assert len(risk_engine.last_checks) == 1
+    assert len(execution.requests) == 1
+
 def test_opportunity_autonomy_duplicate_close_guard_incomplete_final_scope_does_not_suppress_with_valid_shadow_scope() -> (
     None
 ):


### PR DESCRIPTION
### Motivation
- Prevent new autonomous open executions when runtime controls indicate AI is disabled and a manual kill-switch is active while AI is required for execution.
- Ensure that existing open trackers can still be legally closed even when the runtime kill-switch is engaged.
- Add coverage to validate idempotency and replay behavior for blocked opens under runtime controls.

### Description
- Added runtime lineage extraction via `_extract_opportunity_runtime_lineage_snapshot(request.metadata)` and evaluate `runtime_controls_disable_new_open` to detect the kill-switch state before risk and execution handling. 
- Short-circuit new autonomous opens by recording an `opportunity_autonomy_enforcement` event, incrementing the metrics counter, and returning `None` when `runtime_controls_disable_new_open` is true and there is no existing open tracker. 
- Preserved existing behavior for closes by allowing signals with a matching `_opportunity_open_outcomes` tracker to proceed, and kept duplicate-open guarding logic unchanged. 
- Added five unit tests in `tests/test_trading_controller.py` covering blocked opens, legal closes for existing trackers, invalid same-side close behavior, idempotent blocked replays, and disabled-then-reenabled retry flow.

### Testing
- Ran the new unit tests in `tests/test_trading_controller.py` including `test_runtime_controls_manual_kill_switch_blocks_new_autonomous_open_before_risk_and_execution`, `test_runtime_controls_manual_kill_switch_allows_legal_autonomous_close_for_existing_tracker`, `test_runtime_controls_invalid_same_side_close_preserves_close_contract_blocking_reason`, `test_runtime_controls_manual_kill_switch_blocked_open_replay_is_idempotent`, and `test_runtime_controls_manual_kill_switch_disable_then_reenable_retry_open_reaches_execution` with `pytest`, and they passed.
- Verified no existing autonomous execution events are produced when the runtime kill-switch blocks opens by asserting `risk_engine.last_checks == []` and `execution.requests == []` in the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa203becf8832a92726979e65cf9cd)