### PR TITLE
Add hard-stop `execution_disabled` runtime control and enforcement

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -223,6 +223,8 @@ _OPPORTUNITY_RUNTIME_LINEAGE_PROVENANCE_KEYS = (
     "opportunity_policy_mode",
     "opportunity_ai_enabled",
     "opportunity_ai_manual_kill_switch_active",
+    "opportunity_execution_disabled",
+    "opportunity_runtime_controls_revision",
     "ai_required_for_execution",
     "ai_decision_available",
     "ai_decision_status",
@@ -2673,6 +2675,27 @@ class TradingController:
                 sanitized_request_metadata["opportunity_autonomy_decision"] = {}
                 request = replace(request, metadata=sanitized_request_metadata)
         if self._is_opportunity_autonomy_enforced(signal, request):
+            runtime_lineage = self._extract_opportunity_runtime_lineage_snapshot(request.metadata)
+            if runtime_lineage.get("opportunity_execution_disabled") == "true":
+                hard_stop_metadata: dict[str, object] = {
+                    "environment": self.environment,
+                    **runtime_lineage,
+                    "execution_permission": "blocked",
+                    "autonomous_execution_allowed": False,
+                    "autonomy_primary_reason": "emergency_stop_active",
+                    "blocking_reason": "emergency_stop_active",
+                    "autonomy_decisive_stage": "runtime_controls",
+                    "autonomy_decisive_reason": "emergency_stop_active",
+                }
+                self._record_decision_event(
+                    "opportunity_autonomy_enforcement",
+                    signal=signal,
+                    request=request,
+                    status="blocked",
+                    metadata=hard_stop_metadata,
+                )
+                self._metric_signals_total.inc(labels={**metric_labels, "status": "rejected"})
+                return None
             if self._is_autonomous_open_handoff_path(request):
                 contract_valid, missing_fields, mode, blocking_reason = (
                     self._validate_autonomous_open_handoff_contract(
@@ -2774,7 +2797,6 @@ class TradingController:
             existing_open_tracker = (
                 self._opportunity_open_outcomes.get(correlation_key) if correlation_key else None
             )
-            runtime_lineage = self._extract_opportunity_runtime_lineage_snapshot(request.metadata)
             runtime_controls_disable_new_open = (
                 runtime_lineage.get("opportunity_ai_enabled") == "false"
                 and runtime_lineage.get("opportunity_ai_manual_kill_switch_active") == "true"

--- a/bot_core/runtime/opportunity_runtime_controls.py
+++ b/bot_core/runtime/opportunity_runtime_controls.py
@@ -12,6 +12,7 @@ class OpportunityRuntimeControlsSnapshot:
 
     opportunity_ai_enabled: bool
     manual_kill_switch: bool
+    execution_disabled: bool
     policy_mode: str
     revision: int
 
@@ -26,11 +27,13 @@ class OpportunityRuntimeControls:
         *,
         opportunity_ai_enabled: bool = True,
         manual_kill_switch: bool = False,
+        execution_disabled: bool = False,
         policy_mode: str = "shadow",
     ) -> None:
         self._lock = threading.RLock()
         self._opportunity_ai_enabled = bool(opportunity_ai_enabled)
         self._manual_kill_switch = bool(manual_kill_switch)
+        self._execution_disabled = bool(execution_disabled)
         self._policy_mode = self._normalize_policy_mode(policy_mode)
         self._revision = 0
 
@@ -46,6 +49,7 @@ class OpportunityRuntimeControls:
             return OpportunityRuntimeControlsSnapshot(
                 opportunity_ai_enabled=self._opportunity_ai_enabled,
                 manual_kill_switch=self._manual_kill_switch,
+                execution_disabled=self._execution_disabled,
                 policy_mode=self._policy_mode,
                 revision=self._revision,
             )
@@ -55,6 +59,7 @@ class OpportunityRuntimeControls:
         *,
         opportunity_ai_enabled: bool | None = None,
         manual_kill_switch: bool | None = None,
+        execution_disabled: bool | None = None,
         policy_mode: str | None = None,
     ) -> OpportunityRuntimeControlsSnapshot:
         with self._lock:
@@ -68,6 +73,11 @@ class OpportunityRuntimeControls:
                 next_kill = bool(manual_kill_switch)
                 if next_kill != self._manual_kill_switch:
                     self._manual_kill_switch = next_kill
+                    changed = True
+            if execution_disabled is not None:
+                next_execution_disabled = bool(execution_disabled)
+                if next_execution_disabled != self._execution_disabled:
+                    self._execution_disabled = next_execution_disabled
                     changed = True
             if policy_mode is not None:
                 next_mode = self._normalize_policy_mode(policy_mode)

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -69353,6 +69353,164 @@ def test_runtime_controls_manual_kill_switch_disable_then_reenable_retry_open_re
     assert len(execution.requests) == 1
 
 
+
+
+
+def test_runtime_controls_hard_stop_blocks_new_autonomous_open_before_risk_and_execution() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    open_signal = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+    open_signal.metadata = {
+        **dict(open_signal.metadata),
+        "opportunity_execution_disabled": "true",
+        "opportunity_runtime_controls_revision": "17",
+        "mode": "ai",
+    }
+
+    assert controller.process_signals([open_signal]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert controller._opportunity_open_outcomes == {}
+    events = [dict(event) for event in journal.export()]
+    assert not any(event.get("event") in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"} for event in events)
+    blocked = [event for event in events if event.get("event") == "opportunity_autonomy_enforcement"]
+    assert blocked
+    assert blocked[-1]["status"] == "blocked"
+    assert blocked[-1]["blocking_reason"] == "emergency_stop_active"
+    assert blocked[-1]["opportunity_runtime_controls_revision"] == "17"
+
+
+def test_runtime_controls_hard_stop_blocks_legal_autonomous_close_for_existing_tracker() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    correlation_key = "runtime-controls-hard-stop-close"
+    controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+        correlation_key=correlation_key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        environment_scope="paper",
+        portfolio_scope="paper-1",
+    )
+    close_signal = _opportunity_autonomy_signal("paper_autonomous", side="SELL")
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_execution_disabled": "true",
+        "mode": "ai",
+    }
+
+    assert controller.process_signals([close_signal]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    tracker = controller._opportunity_open_outcomes[correlation_key]
+    assert tracker.closed_quantity == pytest.approx(0.0)
+    events = [dict(event) for event in journal.export()]
+    blocked = [event for event in events if event.get("event") == "opportunity_autonomy_enforcement"]
+    assert blocked
+    assert blocked[-1]["blocking_reason"] == "emergency_stop_active"
+    assert not any(event.get("event") in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"} for event in events)
+
+
+def test_runtime_controls_hard_stop_replay_idempotency() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    blocked_open = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+    blocked_open.metadata = {**dict(blocked_open.metadata), "opportunity_execution_disabled": "true", "mode": "ai"}
+
+    assert controller.process_signals([blocked_open]) == []
+    assert controller.process_signals([blocked_open]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    blocked = [dict(event) for event in journal.export() if event.get("event") == "opportunity_autonomy_enforcement" and event.get("status") == "blocked"]
+    assert len(blocked) == 2
+    assert all(event.get("blocking_reason") == "emergency_stop_active" for event in blocked)
+
+
+def test_runtime_controls_hard_stop_clear_then_retry_open_reaches_execution() -> None:
+    risk_engine = DummyRiskEngine()
+    execution = DummyExecutionService()
+    journal = CollectingDecisionJournal()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    blocked_open = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+    blocked_open.metadata = {**dict(blocked_open.metadata), "opportunity_execution_disabled": "true", "mode": "ai"}
+    allowed_open = _opportunity_autonomy_signal("paper_autonomous", side="BUY", include_decision_payload=True, decision_effective_mode="paper_autonomous")
+    allowed_open.metadata = {**dict(allowed_open.metadata), "opportunity_execution_disabled": "false", "mode": "ai"}
+
+    assert controller.process_signals([blocked_open]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+
+    retried = controller.process_signals([allowed_open])
+    assert [result.status for result in retried] == ["filled"]
+    assert len(risk_engine.last_checks) == 1
+    assert len(execution.requests) == 1
+
+
+def test_opportunity_runtime_controls_execution_disabled_contract_minimal() -> None:
+    runtime_controls = OpportunityRuntimeControls(
+        policy_mode="live",
+        opportunity_ai_enabled=True,
+        manual_kill_switch=False,
+    )
+
+    initial = runtime_controls.snapshot()
+    assert initial.execution_disabled is False
+    initial_revision = initial.revision
+
+    enabled = runtime_controls.update(execution_disabled=True)
+    assert enabled.execution_disabled is True
+    assert enabled.revision == initial_revision + 1
+
+    unchanged = runtime_controls.update(execution_disabled=True)
+    assert unchanged.execution_disabled is True
+    assert unchanged.revision == enabled.revision
+
+    disabled = runtime_controls.update(execution_disabled=False)
+    assert disabled.execution_disabled is False
+    assert disabled.revision == enabled.revision + 1
+
 def test_opportunity_autonomy_duplicate_close_guard_incomplete_final_scope_does_not_suppress_with_valid_shadow_scope() -> (
     None
 ):


### PR DESCRIPTION
### Motivation
- Provide an operator-visible emergency stop that can block autonomous execution at runtime and be preserved in opportunity provenance metadata.
- Ensure that when execution is disabled by runtime controls autonomous requests are rejected early (before risk checks or execution) with clear audit metadata.
- Carry a revision for runtime-controls snapshots so callers can reason about control plane updates.

### Description
- Add `opportunity_execution_disabled` and `opportunity_runtime_controls_revision` to `_OPPORTUNITY_RUNTIME_LINEAGE_PROVENANCE_KEYS` so runtime-control signals are propagated into request metadata.
- Enforce an early hard-stop in `TradingController._handle_signal` that extracts the runtime-lineage snapshot and, when `opportunity_execution_disabled == "true"`, records an `opportunity_autonomy_enforcement` event with `emergency_stop_active` reasons, increments rejected metrics, and returns before any risk or execution interaction.
- Extend `OpportunityRuntimeControlsSnapshot` and `OpportunityRuntimeControls` to include an `execution_disabled` flag and to update the controls `revision` only when state changes occur.
- Add tests in `tests/test_trading_controller.py` that exercise blocking new autonomous opens, blocking legal autonomous closes for existing trackers, replay idempotency of blocked events, clear-and-retry recovery to execution, and the minimal contract semantics for `execution_disabled` revision behavior.

### Testing
- Ran targeted test selection with `pytest -q tests/test_trading_controller.py -k 'runtime_controls_hard_stop or execution_disabled_contract_minimal'` to validate the new blocking flows and runtime-controls contract, but collection failed due to a missing dependency (`ModuleNotFoundError: No module named 'numpy'`).
- No further automated tests were run in this environment due to the import failure during test collection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fac48e52bc832a9041f82ce1cf518c)