### PR TITLE
Block autonomous opens when runtime controls snapshot fails while allowing legal closes

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -234,6 +234,7 @@ _OPPORTUNITY_RUNTIME_LINEAGE_PROVENANCE_KEYS = (
     "final_decision_accepted",
     "ai_decision_accepted",
     "opportunity_ai_disabled_reason",
+    "opportunity_runtime_controls_unavailable",
 )
 _LIVE_AUTONOMY_ADMISSION_BLOCKER_REASONS = frozenset(
     {
@@ -900,10 +901,12 @@ class TradingController:
         self, metadata: Mapping[str, object] | None
     ) -> dict[str, str]:
         lineage = self._extract_opportunity_runtime_lineage_snapshot(metadata)
+        runtime_controls_unavailable = False
         try:
             runtime_snapshot = get_opportunity_runtime_controls().snapshot()
         except Exception:
             runtime_snapshot = None
+            runtime_controls_unavailable = True
         if runtime_snapshot is not None:
             lineage["opportunity_ai_enabled"] = (
                 "true" if runtime_snapshot.opportunity_ai_enabled else "false"
@@ -921,6 +924,8 @@ class TradingController:
                 and runtime_snapshot.manual_kill_switch
             ):
                 lineage["ai_required_for_execution"] = "true"
+        if runtime_controls_unavailable:
+            lineage["opportunity_runtime_controls_unavailable"] = "true"
         metadata_lineage = self._extract_opportunity_runtime_lineage_snapshot(metadata)
         if metadata_lineage.get("opportunity_execution_disabled") == "true":
             lineage["opportunity_execution_disabled"] = "true"
@@ -2721,6 +2726,12 @@ class TradingController:
                 request = replace(request, metadata=sanitized_request_metadata)
         if self._is_opportunity_autonomy_enforced(signal, request):
             runtime_lineage = self._effective_opportunity_runtime_lineage_snapshot(request.metadata)
+            correlation_key = str(
+                (request.metadata or {}).get("opportunity_shadow_record_key") or ""
+            ).strip()
+            existing_open_tracker = (
+                self._opportunity_open_outcomes.get(correlation_key) if correlation_key else None
+            )
             if runtime_lineage.get("opportunity_execution_disabled") == "true":
                 hard_stop_metadata: dict[str, object] = {
                     "environment": self.environment,
@@ -2741,6 +2752,37 @@ class TradingController:
                 )
                 self._metric_signals_total.inc(labels={**metric_labels, "status": "rejected"})
                 return None
+            if runtime_lineage.get("opportunity_runtime_controls_unavailable") == "true":
+                is_legal_close = (
+                    existing_open_tracker is not None
+                    and str(existing_open_tracker.symbol) == str(request.symbol)
+                    and self._is_closing_side(str(existing_open_tracker.side), str(request.side))
+                    and self._matches_current_open_tracker_scope(
+                        correlation_key=correlation_key,
+                        symbol=str(request.symbol),
+                        tracker=existing_open_tracker,
+                    )
+                )
+                if not is_legal_close:
+                    unavailable_metadata: dict[str, object] = {
+                        "environment": self.environment,
+                        **runtime_lineage,
+                        "execution_permission": "blocked",
+                        "autonomous_execution_allowed": False,
+                        "autonomy_primary_reason": "runtime_controls_unavailable",
+                        "blocking_reason": "runtime_controls_unavailable",
+                        "autonomy_decisive_stage": "runtime_controls",
+                        "autonomy_decisive_reason": "runtime_controls_unavailable",
+                    }
+                    self._record_decision_event(
+                        "opportunity_autonomy_enforcement",
+                        signal=signal,
+                        request=request,
+                        status="blocked",
+                        metadata=unavailable_metadata,
+                    )
+                    self._metric_signals_total.inc(labels={**metric_labels, "status": "rejected"})
+                    return None
             if self._is_autonomous_open_handoff_path(request):
                 contract_valid, missing_fields, mode, blocking_reason = (
                     self._validate_autonomous_open_handoff_contract(
@@ -2836,12 +2878,6 @@ class TradingController:
                         **autonomy_chain,
                     },
                 )
-            correlation_key = str(
-                (request.metadata or {}).get("opportunity_shadow_record_key") or ""
-            ).strip()
-            existing_open_tracker = (
-                self._opportunity_open_outcomes.get(correlation_key) if correlation_key else None
-            )
             runtime_controls_disable_new_open = (
                 runtime_lineage.get("opportunity_ai_enabled") == "false"
                 and runtime_lineage.get("opportunity_ai_manual_kill_switch_active") == "true"

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -69717,6 +69717,278 @@ def test_runtime_controls_soft_snapshot_allows_legal_close_without_signal_metada
             policy_mode=initial.policy_mode,
         )
 
+
+def test_runtime_controls_snapshot_unavailable_blocks_new_autonomous_open() -> None:
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    runtime_controls = get_opportunity_runtime_controls()
+    original_snapshot = runtime_controls.snapshot
+    runtime_controls.snapshot = lambda: (_ for _ in ()).throw(RuntimeError("snapshot unavailable"))
+    try:
+        open_signal = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+        open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+        assert controller.process_signals([open_signal]) == []
+        assert risk_engine.last_checks == []
+        assert execution.requests == []
+        assert controller._opportunity_open_outcomes == {}
+        events = [dict(event) for event in journal.export()]
+        blocked = [
+            event for event in events if event.get("event") == "opportunity_autonomy_enforcement"
+        ]
+        assert blocked
+        assert blocked[-1]["blocking_reason"] == "runtime_controls_unavailable"
+        assert blocked[-1]["opportunity_runtime_controls_unavailable"] == "true"
+        assert not any(
+            event.get("event")
+            in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+            for event in events
+        )
+    finally:
+        runtime_controls.snapshot = original_snapshot
+
+
+def test_runtime_controls_snapshot_unavailable_metadata_hard_stop_remains_fail_closed() -> None:
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    runtime_controls = get_opportunity_runtime_controls()
+    original_snapshot = runtime_controls.snapshot
+    runtime_controls.snapshot = lambda: (_ for _ in ()).throw(RuntimeError("snapshot unavailable"))
+    try:
+        open_signal = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+        open_signal.metadata = {
+            **dict(open_signal.metadata),
+            "opportunity_execution_disabled": "true",
+            "mode": "ai",
+        }
+        assert controller.process_signals([open_signal]) == []
+        assert risk_engine.last_checks == []
+        assert execution.requests == []
+        blocked = [
+            dict(event)
+            for event in journal.export()
+            if event.get("event") == "opportunity_autonomy_enforcement"
+        ]
+        assert blocked
+        assert blocked[-1]["blocking_reason"] == "emergency_stop_active"
+    finally:
+        runtime_controls.snapshot = original_snapshot
+
+
+def test_runtime_controls_snapshot_unavailable_legal_close_policy() -> None:
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    correlation_key = "runtime-controls-unavailable-legal-close"
+    controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+        correlation_key=correlation_key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        environment_scope="paper",
+        portfolio_scope="paper-1",
+    )
+    runtime_controls = get_opportunity_runtime_controls()
+    original_snapshot = runtime_controls.snapshot
+    runtime_controls.snapshot = lambda: (_ for _ in ()).throw(RuntimeError("snapshot unavailable"))
+    try:
+        close_signal = _opportunity_autonomy_signal(
+            "paper_autonomous",
+            side="SELL",
+            include_decision_payload=True,
+            decision_effective_mode="paper_autonomous",
+        )
+        close_signal.metadata = {
+            **dict(close_signal.metadata),
+            "opportunity_shadow_record_key": correlation_key,
+            "mode": "ai",
+        }
+        results = controller.process_signals([close_signal])
+        assert [result.status for result in results] == ["filled"]
+        assert len(risk_engine.last_checks) >= 1
+        assert execution.requests
+        events = [
+            dict(event)
+            for event in journal.export()
+            if str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+        ]
+        assert not any(
+            event.get("event") == "opportunity_autonomy_enforcement"
+            and event.get("blocking_reason") == "runtime_controls_unavailable"
+            for event in events
+        )
+    finally:
+        runtime_controls.snapshot = original_snapshot
+
+
+def test_runtime_controls_snapshot_unavailable_invalid_close_does_not_execute() -> None:
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    runtime_controls = get_opportunity_runtime_controls()
+    original_snapshot = runtime_controls.snapshot
+    runtime_controls.snapshot = lambda: (_ for _ in ()).throw(RuntimeError("snapshot unavailable"))
+    try:
+        invalid_close_signal = _opportunity_autonomy_signal("paper_autonomous", side="SELL")
+        invalid_close_signal.metadata = {
+            **dict(invalid_close_signal.metadata),
+            "opportunity_shadow_record_key": "missing-correlation",
+            "mode": "ai",
+        }
+        assert controller.process_signals([invalid_close_signal]) == []
+        assert risk_engine.last_checks == []
+        assert execution.requests == []
+        events = [dict(event) for event in journal.export()]
+        blocked = [
+            event for event in events if event.get("event") == "opportunity_autonomy_enforcement"
+        ]
+        assert blocked
+        assert blocked[-1]["blocking_reason"] == "runtime_controls_unavailable"
+        assert not any(
+            event.get("event")
+            in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+            for event in events
+        )
+    finally:
+        runtime_controls.snapshot = original_snapshot
+
+
+def test_runtime_controls_snapshot_unavailable_close_symbol_mismatch_does_not_execute() -> None:
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    correlation_key = "runtime-controls-unavailable-close-symbol-mismatch"
+    controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+        correlation_key=correlation_key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        environment_scope="paper",
+        portfolio_scope="paper-1",
+    )
+    runtime_controls = get_opportunity_runtime_controls()
+    original_snapshot = runtime_controls.snapshot
+    runtime_controls.snapshot = lambda: (_ for _ in ()).throw(RuntimeError("snapshot unavailable"))
+    try:
+        close_signal = _opportunity_autonomy_signal("paper_autonomous", side="SELL")
+        close_signal.symbol = "ETH/USDT"
+        close_signal.metadata = {
+            **dict(close_signal.metadata),
+            "opportunity_shadow_record_key": correlation_key,
+            "mode": "ai",
+        }
+        assert controller.process_signals([close_signal]) == []
+        assert risk_engine.last_checks == []
+        assert execution.requests == []
+        tracker = controller._opportunity_open_outcomes[correlation_key]
+        assert tracker.closed_quantity == pytest.approx(0.0)
+        events = [dict(event) for event in journal.export()]
+        blocked = [
+            event for event in events if event.get("event") == "opportunity_autonomy_enforcement"
+        ]
+        assert blocked
+        assert not any(
+            event.get("event")
+            in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+            for event in events
+        )
+    finally:
+        runtime_controls.snapshot = original_snapshot
+
+
+def test_runtime_controls_snapshot_unavailable_foreign_scope_close_does_not_execute() -> None:
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+            [8.0, 6.0, 4.0],
+            environment="paper",
+            portfolio_id="paper-1",
+        ),
+    )
+    correlation_key = "runtime-controls-unavailable-close-foreign-scope"
+    controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+        correlation_key=correlation_key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        environment_scope="live",
+        portfolio_scope="live-1",
+    )
+    runtime_controls = get_opportunity_runtime_controls()
+    original_snapshot = runtime_controls.snapshot
+    runtime_controls.snapshot = lambda: (_ for _ in ()).throw(RuntimeError("snapshot unavailable"))
+    try:
+        close_signal = _opportunity_autonomy_signal("paper_autonomous", side="SELL")
+        close_signal.metadata = {
+            **dict(close_signal.metadata),
+            "opportunity_shadow_record_key": correlation_key,
+            "mode": "ai",
+        }
+        assert controller.process_signals([close_signal]) == []
+        assert risk_engine.last_checks == []
+        assert execution.requests == []
+        tracker = controller._opportunity_open_outcomes[correlation_key]
+        assert tracker.closed_quantity == pytest.approx(0.0)
+        events = [dict(event) for event in journal.export()]
+        blocked = [
+            event for event in events if event.get("event") == "opportunity_autonomy_enforcement"
+        ]
+        assert blocked
+        assert not any(
+            event.get("event")
+            in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+            for event in events
+        )
+    finally:
+        runtime_controls.snapshot = original_snapshot
+
 def test_opportunity_runtime_controls_execution_disabled_contract_minimal() -> None:
     runtime_controls = OpportunityRuntimeControls(
         policy_mode="live",


### PR DESCRIPTION
### Motivation
- Ensure safe behavior when `get_opportunity_runtime_controls().snapshot()` raises an exception by treating runtime controls as unavailable and preventing new autonomous opens while still permitting legal closes for existing tracked opportunities.
- Surface runtime-controls-unavailable provenance to decision metadata so downstream systems and auditing can detect the failure mode.
- Avoid accidental execution when runtime controls cannot be read, preserving safety and observability.

### Description
- Added `"opportunity_runtime_controls_unavailable"` to the opportunity runtime lineage provenance keys. 
- In `_effective_opportunity_runtime_lineage_snapshot` set a flag when `snapshot()` raises and populate `opportunity_runtime_controls_unavailable = "true"` in the returned lineage when snapshot retrieval fails. 
- Moved extraction of `correlation_key`/`existing_open_tracker` earlier in the opportunity autonomy enforcement path and added logic that blocks new autonomous opens if runtime controls are unavailable, while permitting a legal close when it matches an existing open tracker and scope; blocked requests record decision events with `blocking_reason` and `autonomy_primary_reason` set to `"runtime_controls_unavailable"`. 

### Testing
- Updated `tests/test_trading_controller.py` with multiple scenarios and ran the following new automated tests: `test_runtime_controls_snapshot_unavailable_blocks_new_autonomous_open`, `test_runtime_controls_snapshot_unavailable_metadata_hard_stop_remains_fail_closed`, `test_runtime_controls_snapshot_unavailable_legal_close_policy`, `test_runtime_controls_snapshot_unavailable_invalid_close_does_not_execute`, `test_runtime_controls_snapshot_unavailable_close_symbol_mismatch_does_not_execute`, and `test_runtime_controls_snapshot_unavailable_foreign_scope_close_does_not_execute`. 
- All added tests passed locally against the modified controller implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad1575334832aa127620407ebbfe3)