### PR TITLE
Uszczelnienie audit metadata blokad autonomizacji (runtime controls)

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -901,6 +901,18 @@ class TradingController:
         self, metadata: Mapping[str, object] | None
     ) -> dict[str, str]:
         lineage = self._extract_opportunity_runtime_lineage_snapshot(metadata)
+        if "opportunity_ai_enabled" not in lineage:
+            lineage["opportunity_ai_enabled"] = "true"
+        if "opportunity_ai_manual_kill_switch_active" not in lineage:
+            lineage["opportunity_ai_manual_kill_switch_active"] = "false"
+        if "ai_required_for_execution" not in lineage:
+            lineage["ai_required_for_execution"] = "true"
+        if "opportunity_policy_mode" not in lineage:
+            lineage["opportunity_policy_mode"] = str(self.environment)
+        if "opportunity_execution_disabled" not in lineage:
+            lineage["opportunity_execution_disabled"] = "false"
+        if "opportunity_runtime_controls_unavailable" not in lineage:
+            lineage["opportunity_runtime_controls_unavailable"] = "false"
         runtime_controls_unavailable = False
         try:
             runtime_snapshot = get_opportunity_runtime_controls().snapshot()
@@ -2841,6 +2853,7 @@ class TradingController:
             )
             metadata: dict[str, object] = {
                 "environment": self.environment,
+                **runtime_lineage,
                 **dict(diagnostics),
             }
             metadata.update(

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -69521,7 +69521,20 @@ def test_runtime_controls_hard_stop_metadata_true_remains_fail_closed() -> None:
             event for event in events if event.get("event") == "opportunity_autonomy_enforcement"
         ]
         assert blocked
-        assert blocked[-1]["blocking_reason"] == "emergency_stop_active"
+        blocked_event = blocked[-1]
+        assert blocked_event["blocking_reason"] == "emergency_stop_active"
+        assert blocked_event["autonomy_decisive_stage"] == "runtime_controls"
+        assert blocked_event["autonomy_decisive_reason"] == "emergency_stop_active"
+        assert blocked_event["execution_permission"] == "blocked"
+        assert blocked_event["autonomous_execution_allowed"] == "false"
+        assert blocked_event["opportunity_execution_disabled"] == "true"
+        assert blocked_event["opportunity_runtime_controls_unavailable"] == "false"
+        assert blocked_event["opportunity_ai_enabled"] == "true"
+        assert blocked_event["opportunity_ai_manual_kill_switch_active"] == "false"
+        assert blocked_event["ai_required_for_execution"] == "true"
+        assert blocked_event["opportunity_policy_mode"] in {"paper", "shadow"}
+        assert blocked_event["environment"] == "paper"
+        assert "opportunity_runtime_controls_revision" in blocked_event
         assert not any(
             event.get("event")
             in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
@@ -69613,8 +69626,20 @@ def test_runtime_controls_hard_stop_snapshot_blocks_open_without_signal_metadata
         assert execution.requests == []
         blocked = [dict(e) for e in journal.export() if e.get("event") == "opportunity_autonomy_enforcement"]
         assert blocked
-        assert blocked[-1]["blocking_reason"] == "emergency_stop_active"
-        assert blocked[-1]["opportunity_runtime_controls_revision"] == str(runtime_controls.snapshot().revision)
+        blocked_event = blocked[-1]
+        assert blocked_event["blocking_reason"] == "emergency_stop_active"
+        assert blocked_event["autonomy_decisive_stage"] == "runtime_controls"
+        assert blocked_event["autonomy_decisive_reason"] == "emergency_stop_active"
+        assert blocked_event["execution_permission"] == "blocked"
+        assert blocked_event["autonomous_execution_allowed"] == "false"
+        assert blocked_event["opportunity_execution_disabled"] == "true"
+        assert blocked_event["opportunity_runtime_controls_unavailable"] == "false"
+        assert blocked_event["opportunity_ai_enabled"] == "true"
+        assert blocked_event["opportunity_ai_manual_kill_switch_active"] == "false"
+        assert blocked_event["ai_required_for_execution"] == "true"
+        assert blocked_event["opportunity_policy_mode"] in {"paper", "shadow"}
+        assert blocked_event["opportunity_runtime_controls_revision"] == str(runtime_controls.snapshot().revision)
+        assert blocked_event["environment"] == "paper"
     finally:
         runtime_controls.update(
             opportunity_ai_enabled=initial.opportunity_ai_enabled,
@@ -69668,7 +69693,20 @@ def test_runtime_controls_soft_snapshot_blocks_new_open_without_signal_metadata(
         assert risk_engine.last_checks == []
         assert execution.requests == []
         blocked = [dict(e) for e in journal.export() if e.get("event") == "opportunity_autonomy_enforcement"]
-        assert blocked[-1]["blocking_reason"] == "autonomy_mode_denied"
+        blocked_event = blocked[-1]
+        assert blocked_event["blocking_reason"] == "autonomy_mode_denied"
+        assert blocked_event["autonomy_decisive_stage"] == "runtime_controls"
+        assert blocked_event["autonomy_decisive_reason"] == "autonomy_mode_denied"
+        assert blocked_event["execution_permission"] == "blocked"
+        assert blocked_event["autonomous_execution_allowed"] == "false"
+        assert blocked_event["opportunity_execution_disabled"] == "false"
+        assert blocked_event["opportunity_runtime_controls_unavailable"] == "false"
+        assert blocked_event["opportunity_ai_enabled"] == "false"
+        assert blocked_event["opportunity_ai_manual_kill_switch_active"] == "true"
+        assert blocked_event["ai_required_for_execution"] == "true"
+        assert blocked_event["opportunity_policy_mode"] == "live"
+        assert blocked_event["environment"] == "paper"
+        assert "opportunity_runtime_controls_revision" in blocked_event
     finally:
         runtime_controls.update(
             opportunity_ai_enabled=initial.opportunity_ai_enabled,
@@ -69744,8 +69782,19 @@ def test_runtime_controls_snapshot_unavailable_blocks_new_autonomous_open() -> N
             event for event in events if event.get("event") == "opportunity_autonomy_enforcement"
         ]
         assert blocked
-        assert blocked[-1]["blocking_reason"] == "runtime_controls_unavailable"
-        assert blocked[-1]["opportunity_runtime_controls_unavailable"] == "true"
+        blocked_event = blocked[-1]
+        assert blocked_event["blocking_reason"] == "runtime_controls_unavailable"
+        assert blocked_event["autonomy_decisive_stage"] == "runtime_controls"
+        assert blocked_event["autonomy_decisive_reason"] == "runtime_controls_unavailable"
+        assert blocked_event["execution_permission"] == "blocked"
+        assert blocked_event["autonomous_execution_allowed"] == "false"
+        assert blocked_event["opportunity_runtime_controls_unavailable"] == "true"
+        assert blocked_event["opportunity_execution_disabled"] == "false"
+        assert blocked_event["opportunity_ai_enabled"] == "true"
+        assert blocked_event["opportunity_ai_manual_kill_switch_active"] == "false"
+        assert blocked_event["ai_required_for_execution"] == "true"
+        assert blocked_event["opportunity_policy_mode"] == "paper"
+        assert blocked_event["environment"] == "paper"
         assert not any(
             event.get("event")
             in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}


### PR DESCRIPTION
### Motivation

- Wykryto brak spójnych, jawnych pól lineage w eventach blokady (hard-stop, soft kill-switch, runtime unavailable) co utrudnia audyt i różnicowanie źródeł blokad.  
- Celem było jedynie uzupełnienie obserwowalności / audit metadata bez zmiany decyzji tradingowych ani semantyki guardów.  
- Zakres zmian ograniczony do `bot_core/runtime/controller.py` oraz regresyjnych testów w `tests/test_trading_controller.py`.

### Description

- Dodano domyślne, deterministyczne wartości lineage w `_effective_opportunity_runtime_lineage_snapshot` (m.in. `opportunity_execution_disabled`, `opportunity_runtime_controls_unavailable`, `opportunity_ai_enabled`, `opportunity_ai_manual_kill_switch_active`, `ai_required_for_execution`, `opportunity_policy_mode`) aby eventy zawsze zawierały minimalny kontrakt auditowy (zgodnie z istniejącą konwencją stringów `"true"/"false"`).
- Propagowano wynikowy `runtime_lineage` do metadata budowanego eventu w ścieżce oceny uprawnień (`permission-evaluation`), co zapewnia, że blokady generowane na tej ścieżce zawierają runtime provenance bez zmiany decyzji.
- Rozszerzono 4 dokładne testy (exact-node) w `tests/test_trading_controller.py`, sprawdzające kompletność metadata dla: hard-stop (snapshot), hard-stop (metadata fail-closed), soft manual kill-switch, oraz snapshot unavailable; testy asercjami weryfikują m.in. `blocking_reason`, `autonomy_decisive_*`, `execution_permission`, oraz runtime lineage keys.
- Nie zmieniono logiki decyzyjnej ani kolejności guardów; typy lineage zachowują istniejącą konwencję (stringowe "true"/"false" tam gdzie stosowano), a pola booleanowe w eventach pozostają zgodne z dotychczasowym stylem.

### Testing

- Zainstalowano zależności testowe: `PYENV_VERSION=3.11.14 python -m pip install -e '.[test]'` (sukces).  
- Zweryfikowano numpy: `PYENV_VERSION=3.11.14 python -c "import numpy; print(numpy.__version__)"` → `2.4.4` (sukces).  
- Odpalone skupione testy exact-node:  
  - `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py::test_runtime_controls_hard_stop_snapshot_blocks_open_without_signal_metadata tests/test_trading_controller.py::test_runtime_controls_hard_stop_metadata_true_remains_fail_closed tests/test_trading_controller.py::test_runtime_controls_soft_snapshot_blocks_new_open_without_signal_metadata tests/test_trading_controller.py::test_runtime_controls_snapshot_unavailable_blocks_new_autonomous_open` → wszystkie 4 przeszły (4 passed).  
- Uruchomiono pełny selektor:  
  - `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "opportunity_autonomy or autonomy or runtime_controls or controls or kill_switch or emergency or hard_stop or execution_disabled or unavailable or disabled or close or exit or open or risk or execution or enforcement or tracker or correlation or scope"` → `942 passed, 69 deselected` (sukces).  
- Commit: zmiany zatwierdzone (commit message: "Harden autonomy enforcement audit lineage metadata"), hash: `f23af3b`.
- Wygenerowane artefakty tymczasowe (`reports/ci/decision_feed_metrics.json`, `bot_core/logs/`) zostały usunięte/przywrócone i nie weszły do commita.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fadcc5eef4832abd96990d0a8caa0c)