### PR TITLE
Runtime-controls: dodaj przypisanie źródła w eventach blokady autonomii

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -235,6 +235,9 @@ _OPPORTUNITY_RUNTIME_LINEAGE_PROVENANCE_KEYS = (
     "ai_decision_accepted",
     "opportunity_ai_disabled_reason",
     "opportunity_runtime_controls_unavailable",
+    "opportunity_runtime_controls_source",
+    "opportunity_runtime_controls_metadata_override",
+    "opportunity_runtime_controls_metadata_stale",
 )
 _LIVE_AUTONOMY_ADMISSION_BLOCKER_REASONS = frozenset(
     {
@@ -913,12 +916,19 @@ class TradingController:
             lineage["opportunity_execution_disabled"] = "false"
         if "opportunity_runtime_controls_unavailable" not in lineage:
             lineage["opportunity_runtime_controls_unavailable"] = "false"
+        if "opportunity_runtime_controls_source" not in lineage:
+            lineage["opportunity_runtime_controls_source"] = "snapshot"
+        if "opportunity_runtime_controls_metadata_override" not in lineage:
+            lineage["opportunity_runtime_controls_metadata_override"] = "false"
+        if "opportunity_runtime_controls_metadata_stale" not in lineage:
+            lineage["opportunity_runtime_controls_metadata_stale"] = "false"
         runtime_controls_unavailable = False
         try:
             runtime_snapshot = get_opportunity_runtime_controls().snapshot()
         except Exception:
             runtime_snapshot = None
             runtime_controls_unavailable = True
+            lineage["opportunity_runtime_controls_source"] = "snapshot_unavailable"
         if runtime_snapshot is not None:
             lineage["opportunity_ai_enabled"] = (
                 "true" if runtime_snapshot.opportunity_ai_enabled else "false"
@@ -939,12 +949,20 @@ class TradingController:
         if runtime_controls_unavailable:
             lineage["opportunity_runtime_controls_unavailable"] = "true"
         metadata_lineage = self._extract_opportunity_runtime_lineage_snapshot(metadata)
-        if metadata_lineage.get("opportunity_execution_disabled") == "true":
+        metadata_hard_stop = metadata_lineage.get("opportunity_execution_disabled") == "true"
+        metadata_stale_false = metadata_lineage.get("opportunity_execution_disabled") == "false"
+        snapshot_hard_stop = lineage.get("opportunity_execution_disabled") == "true"
+        if metadata_hard_stop:
             lineage["opportunity_execution_disabled"] = "true"
+            if not snapshot_hard_stop:
+                lineage["opportunity_runtime_controls_source"] = "metadata"
+                lineage["opportunity_runtime_controls_metadata_override"] = "true"
             if metadata_lineage.get("opportunity_runtime_controls_revision"):
                 lineage["opportunity_runtime_controls_revision"] = metadata_lineage[
                     "opportunity_runtime_controls_revision"
                 ]
+        elif snapshot_hard_stop and metadata_stale_false:
+            lineage["opportunity_runtime_controls_metadata_stale"] = "true"
         metadata_soft_kill = (
             metadata_lineage.get("opportunity_ai_enabled") == "false"
             and metadata_lineage.get("opportunity_ai_manual_kill_switch_active") == "true"

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -69529,6 +69529,9 @@ def test_runtime_controls_hard_stop_metadata_true_remains_fail_closed() -> None:
         assert blocked_event["autonomous_execution_allowed"] == "false"
         assert blocked_event["opportunity_execution_disabled"] == "true"
         assert blocked_event["opportunity_runtime_controls_unavailable"] == "false"
+        assert blocked_event["opportunity_runtime_controls_source"] == "metadata"
+        assert blocked_event["opportunity_runtime_controls_metadata_override"] == "true"
+        assert blocked_event["opportunity_runtime_controls_metadata_stale"] == "false"
         assert blocked_event["opportunity_ai_enabled"] == "true"
         assert blocked_event["opportunity_ai_manual_kill_switch_active"] == "false"
         assert blocked_event["ai_required_for_execution"] == "true"
@@ -69634,6 +69637,9 @@ def test_runtime_controls_hard_stop_snapshot_blocks_open_without_signal_metadata
         assert blocked_event["autonomous_execution_allowed"] == "false"
         assert blocked_event["opportunity_execution_disabled"] == "true"
         assert blocked_event["opportunity_runtime_controls_unavailable"] == "false"
+        assert blocked_event["opportunity_runtime_controls_source"] == "snapshot"
+        assert blocked_event["opportunity_runtime_controls_metadata_override"] == "false"
+        assert blocked_event["opportunity_runtime_controls_metadata_stale"] == "false"
         assert blocked_event["opportunity_ai_enabled"] == "true"
         assert blocked_event["opportunity_ai_manual_kill_switch_active"] == "false"
         assert blocked_event["ai_required_for_execution"] == "true"
@@ -69667,6 +69673,9 @@ def test_runtime_controls_hard_stop_snapshot_overrides_stale_false_metadata() ->
         assert execution.requests == []
         blocked = [dict(e) for e in journal.export() if e.get("event") == "opportunity_autonomy_enforcement"]
         assert blocked[-1]["blocking_reason"] == "emergency_stop_active"
+        assert blocked[-1]["opportunity_runtime_controls_source"] == "snapshot"
+        assert blocked[-1]["opportunity_runtime_controls_metadata_stale"] == "true"
+        assert blocked[-1]["opportunity_runtime_controls_metadata_override"] == "false"
     finally:
         runtime_controls.update(
             opportunity_ai_enabled=initial.opportunity_ai_enabled,
@@ -69701,6 +69710,9 @@ def test_runtime_controls_soft_snapshot_blocks_new_open_without_signal_metadata(
         assert blocked_event["autonomous_execution_allowed"] == "false"
         assert blocked_event["opportunity_execution_disabled"] == "false"
         assert blocked_event["opportunity_runtime_controls_unavailable"] == "false"
+        assert blocked_event["opportunity_runtime_controls_source"] == "snapshot"
+        assert blocked_event["opportunity_runtime_controls_metadata_override"] == "false"
+        assert blocked_event["opportunity_runtime_controls_metadata_stale"] == "false"
         assert blocked_event["opportunity_ai_enabled"] == "false"
         assert blocked_event["opportunity_ai_manual_kill_switch_active"] == "true"
         assert blocked_event["ai_required_for_execution"] == "true"
@@ -69789,6 +69801,9 @@ def test_runtime_controls_snapshot_unavailable_blocks_new_autonomous_open() -> N
         assert blocked_event["execution_permission"] == "blocked"
         assert blocked_event["autonomous_execution_allowed"] == "false"
         assert blocked_event["opportunity_runtime_controls_unavailable"] == "true"
+        assert blocked_event["opportunity_runtime_controls_source"] == "snapshot_unavailable"
+        assert blocked_event["opportunity_runtime_controls_metadata_override"] == "false"
+        assert blocked_event["opportunity_runtime_controls_metadata_stale"] == "false"
         assert blocked_event["opportunity_execution_disabled"] == "false"
         assert blocked_event["opportunity_ai_enabled"] == "true"
         assert blocked_event["opportunity_ai_manual_kill_switch_active"] == "false"


### PR DESCRIPTION
### Motivation
- Luka obserwowalności: zdarzenia blokad (`emergency_stop_active`, `autonomy_mode_denied`, `runtime_controls_unavailable`) nie pozwalały jednoznacznie ustalić, czy hard-stop pochodził z runtime snapshotu, z metadata (fail-closed) czy z braku snapshotu. 
- Celem jest tylko uzupełnienie event/journal metadata o minimalne pola atrybucji bez zmiany decyzji tradingowych ani semantyki blokad.

### Description
- Dodano trzy pola lineage: `opportunity_runtime_controls_source`, `opportunity_runtime_controls_metadata_override`, `opportunity_runtime_controls_metadata_stale` i ustawiono rozsądne domyślne stringowe wartości (`"snapshot"`/`"snapshot_unavailable"` i `"true"`/`"false"`).
- Przy wyjątku przy pobieraniu snapshotu ustawiane jest `opportunity_runtime_controls_source = "snapshot_unavailable"` i `opportunity_runtime_controls_unavailable = "true"`.
- Gdy metadata zawiera hard-stop (`opportunity_execution_disabled == "true"`) i snapshot nie wskazuje hard-stopu, source zmienia się na `"metadata"` a `opportunity_runtime_controls_metadata_override = "true"`.
- Gdy snapshot wskazuje hard-stop, a metadata jawnie ma `opportunity_execution_disabled == "false"`, oznaczane jest `opportunity_runtime_controls_metadata_stale = "true"` (stale false nadpisane przez snapshot true).

### Testing
- Zainstalowano zależności testowe: `PYENV_VERSION=3.11.14 python -m pip install -e '.[test]'` (sukces) i sprawdzono `PYENV_VERSION=3.11.14 python -c "import numpy; print(numpy.__version__)"` (wyświetlono `2.4.4`).
- Uruchomiono wybrane testy (exact nodes): `python -m pytest -q tests/test_trading_controller.py::test_runtime_controls_hard_stop_snapshot_blocks_open_without_signal_metadata tests/test_trading_controller.py::test_runtime_controls_hard_stop_metadata_true_remains_fail_closed tests/test_trading_controller.py::test_runtime_controls_hard_stop_snapshot_overrides_stale_false_metadata tests/test_trading_controller.py::test_runtime_controls_snapshot_unavailable_blocks_new_autonomous_open tests/test_trading_controller.py::test_runtime_controls_soft_snapshot_blocks_new_open_without_signal_metadata` — wynik: `5 passed`.
- Uruchomiono pełny selektor: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "opportunity_autonomy or autonomy or runtime_controls or controls or kill_switch or emergency or hard_stop or execution_disabled or unavailable or disabled or close or exit or open or risk or execution or enforcement or tracker or correlation or scope"` — wynik: `942 passed, 69 deselected`.
- Testy potwierdzają rozróżnienie przypadków A–D i nie wykazują regresji w decyzjach tradingowych.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae3272580832aae38dcf8889251cc)