### PR TITLE
Enforce opportunity autonomy controls before execution and add runtime-control transition tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -3328,6 +3328,10 @@ class TradingController:
         if not should_execute_open_leg:
             self._handle_liquidation_state(risk_result)
             return None
+        if self._is_opportunity_autonomy_enforced(signal, adjusted_request):
+            if not self._allow_last_mile_autonomy_execution(signal, adjusted_request, metric_labels):
+                self._handle_liquidation_state(risk_result)
+                return None
         try:
             result = self.execution_service.execute(adjusted_request, self._execution_context)
         except Exception as exc:  # noqa: BLE001
@@ -3485,6 +3489,77 @@ class TradingController:
         )
         self._handle_liquidation_state(risk_result)
         return result
+
+    def _allow_last_mile_autonomy_execution(
+        self,
+        signal: StrategySignal,
+        request: OrderRequest,
+        metric_labels: Mapping[str, str],
+    ) -> bool:
+        runtime_lineage = self._effective_opportunity_runtime_lineage_snapshot(request.metadata)
+        correlation_key = str((request.metadata or {}).get("opportunity_shadow_record_key") or "").strip()
+        existing_open_tracker = (
+            self._opportunity_open_outcomes.get(correlation_key) if correlation_key else None
+        )
+        is_legal_close = (
+            existing_open_tracker is not None
+            and str(existing_open_tracker.symbol) == str(request.symbol)
+            and self._is_closing_side(str(existing_open_tracker.side), str(request.side))
+            and self._matches_current_open_tracker_scope(
+                correlation_key=correlation_key,
+                symbol=str(request.symbol),
+                tracker=existing_open_tracker,
+            )
+        )
+        if runtime_lineage.get("opportunity_execution_disabled") == "true":
+            blocked_metadata: dict[str, object] = {
+                "environment": self.environment,
+                **runtime_lineage,
+                "execution_permission": "blocked",
+                "autonomous_execution_allowed": False,
+                "autonomy_primary_reason": "emergency_stop_active",
+                "blocking_reason": "emergency_stop_active",
+                "autonomy_decisive_stage": "runtime_controls",
+                "autonomy_decisive_reason": "emergency_stop_active",
+            }
+        elif runtime_lineage.get("opportunity_runtime_controls_unavailable") == "true" and not is_legal_close:
+            blocked_metadata = {
+                "environment": self.environment,
+                **runtime_lineage,
+                "execution_permission": "blocked",
+                "autonomous_execution_allowed": False,
+                "autonomy_primary_reason": "runtime_controls_unavailable",
+                "blocking_reason": "runtime_controls_unavailable",
+                "autonomy_decisive_stage": "runtime_controls",
+                "autonomy_decisive_reason": "runtime_controls_unavailable",
+            }
+        elif (
+            runtime_lineage.get("opportunity_ai_enabled") == "false"
+            and runtime_lineage.get("opportunity_ai_manual_kill_switch_active") == "true"
+            and runtime_lineage.get("ai_required_for_execution") == "true"
+            and existing_open_tracker is None
+        ):
+            blocked_metadata = {
+                "environment": self.environment,
+                **runtime_lineage,
+                "execution_permission": "blocked",
+                "autonomous_execution_allowed": False,
+                "autonomy_primary_reason": "autonomy_mode_denied",
+                "blocking_reason": "autonomy_mode_denied",
+                "autonomy_decisive_stage": "runtime_controls",
+                "autonomy_decisive_reason": "autonomy_mode_denied",
+            }
+        else:
+            return True
+        self._record_decision_event(
+            "opportunity_autonomy_enforcement",
+            signal=signal,
+            request=request,
+            status="blocked",
+            metadata=blocked_metadata,
+        )
+        self._metric_signals_total.inc(labels={**metric_labels, "status": "rejected"})
+        return False
 
     def _is_opportunity_autonomy_enforced(
         self,

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -68,6 +68,7 @@ class DummyRiskEngine(RiskEngine):
         self._liquidate = False
         self.last_checks: list[tuple[OrderRequest, AccountSnapshot, str]] = []
         self._result_queue: list[RiskCheckResult] = []
+        self.after_check_callback: Callable[[], None] | None = None
 
     def register_profile(self, profile: RiskProfile) -> None:  # pragma: no cover - nieużywane
         return None
@@ -82,6 +83,8 @@ class DummyRiskEngine(RiskEngine):
         self.last_checks.append((request, account, profile_name))
         if self._result_queue:
             self._result = self._result_queue.pop(0)
+        if self.after_check_callback is not None:
+            self.after_check_callback()
         return self._result
 
     def snapshot_state(self, profile_name: str) -> Mapping[str, object]:
@@ -69487,8 +69490,214 @@ def test_runtime_controls_hard_stop_clear_then_retry_open_reaches_execution() ->
     assert len(risk_engine.last_checks) == 1
     assert len(execution.requests) == 1
 
+def test_runtime_controls_hard_stop_activated_after_risk_blocks_before_execution_open() -> None:
+    runtime_controls = get_opportunity_runtime_controls()
+    initial = runtime_controls.snapshot()
+    try:
+        runtime_controls.update(execution_disabled=False, opportunity_ai_enabled=True, manual_kill_switch=False)
+        risk_engine = DummyRiskEngine()
+        controller, execution, journal = _build_autonomy_controller_with_risk(
+            environment="paper",
+            risk_engine=risk_engine,
+            opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes([8.0, 6.0, 4.0], environment="paper", portfolio_id="paper-1"),
+        )
+        risk_engine.after_check_callback = lambda: runtime_controls.update(execution_disabled=True)
+        open_signal = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+        open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+        assert controller.process_signals([open_signal]) == []
+        assert len(risk_engine.last_checks) == 1
+        assert execution.requests == []
+    finally:
+        runtime_controls.update(
+            opportunity_ai_enabled=initial.opportunity_ai_enabled,
+            manual_kill_switch=initial.manual_kill_switch,
+            execution_disabled=initial.execution_disabled,
+            policy_mode=initial.policy_mode,
+        )
 
 
+def test_runtime_controls_hard_stop_activated_after_risk_blocks_legal_close_before_execution() -> None:
+    runtime_controls = get_opportunity_runtime_controls()
+    initial = runtime_controls.snapshot()
+    try:
+        runtime_controls.update(execution_disabled=False, opportunity_ai_enabled=True, manual_kill_switch=False)
+        risk_engine = DummyRiskEngine()
+        controller, execution, journal = _build_autonomy_controller_with_risk(
+            environment="paper",
+            risk_engine=risk_engine,
+            opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes([8.0, 6.0, 4.0], environment="paper", portfolio_id="paper-1"),
+        )
+        correlation_key = "runtime-controls-hard-stop-after-risk-close"
+        controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            environment_scope="paper",
+            portfolio_scope="paper-1",
+        )
+        risk_engine.after_check_callback = lambda: runtime_controls.update(execution_disabled=True)
+        close_signal = _opportunity_autonomy_signal("paper_autonomous", side="SELL")
+        close_signal.metadata = {**dict(close_signal.metadata), "opportunity_shadow_record_key": correlation_key, "mode": "ai"}
+        assert controller.process_signals([close_signal]) == []
+        assert execution.requests == []
+        assert controller._opportunity_open_outcomes[correlation_key].closed_quantity == pytest.approx(0.0)
+    finally:
+        runtime_controls.update(
+            opportunity_ai_enabled=initial.opportunity_ai_enabled,
+            manual_kill_switch=initial.manual_kill_switch,
+            execution_disabled=initial.execution_disabled,
+            policy_mode=initial.policy_mode,
+        )
+
+
+def test_runtime_controls_soft_kill_switch_activated_after_risk_blocks_open_before_execution() -> None:
+    runtime_controls = get_opportunity_runtime_controls()
+    initial = runtime_controls.snapshot()
+    try:
+        runtime_controls.update(execution_disabled=False, opportunity_ai_enabled=True, manual_kill_switch=False, policy_mode="live")
+        risk_engine = DummyRiskEngine()
+        controller, execution, journal = _build_autonomy_controller_with_risk(
+            environment="paper",
+            risk_engine=risk_engine,
+            opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes([8.0, 6.0, 4.0], environment="paper", portfolio_id="paper-1"),
+        )
+        risk_engine.after_check_callback = lambda: runtime_controls.update(opportunity_ai_enabled=False, manual_kill_switch=True)
+        open_signal = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+        open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+        assert controller.process_signals([open_signal]) == []
+        assert len(risk_engine.last_checks) == 1
+        assert execution.requests == []
+    finally:
+        runtime_controls.update(
+            opportunity_ai_enabled=initial.opportunity_ai_enabled,
+            manual_kill_switch=initial.manual_kill_switch,
+            execution_disabled=initial.execution_disabled,
+            policy_mode=initial.policy_mode,
+        )
+
+
+def test_runtime_controls_soft_kill_switch_activated_after_risk_allows_legal_close() -> None:
+    runtime_controls = get_opportunity_runtime_controls()
+    initial = runtime_controls.snapshot()
+    try:
+        runtime_controls.update(
+            execution_disabled=False,
+            opportunity_ai_enabled=True,
+            manual_kill_switch=False,
+            policy_mode="live",
+        )
+        risk_engine = DummyRiskEngine()
+        controller, execution, journal = _build_autonomy_controller_with_risk(
+            environment="paper",
+            risk_engine=risk_engine,
+            opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+                [8.0, 6.0, 4.0], environment="paper", portfolio_id="paper-1"
+            ),
+        )
+        correlation_key = "runtime-controls-soft-after-risk-close"
+        controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            environment_scope="paper",
+            portfolio_scope="paper-1",
+        )
+        risk_engine.after_check_callback = lambda: runtime_controls.update(
+            opportunity_ai_enabled=False,
+            manual_kill_switch=True,
+            execution_disabled=False,
+        )
+        close_signal = _opportunity_autonomy_signal("paper_autonomous", side="SELL")
+        close_signal.metadata = {
+            **dict(close_signal.metadata),
+            "opportunity_shadow_record_key": correlation_key,
+            "mode": "ai",
+        }
+        results = controller.process_signals([close_signal])
+        assert [result.status for result in results] == ["filled"]
+        assert len(risk_engine.last_checks) >= 1
+        assert execution.requests
+        request = execution.requests[-1]
+        assert request.symbol == "BTC/USDT"
+        assert request.side == "SELL"
+        assert request.quantity == pytest.approx(1.0)
+        close_events = [
+            dict(event)
+            for event in journal.export()
+            if str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+        ]
+        assert not any(
+            event.get("event") == "opportunity_autonomy_enforcement"
+            and str(event.get("blocking_reason") or "").strip() == "autonomy_mode_denied"
+            for event in close_events
+        )
+    finally:
+        runtime_controls.update(
+            opportunity_ai_enabled=initial.opportunity_ai_enabled,
+            manual_kill_switch=initial.manual_kill_switch,
+            execution_disabled=initial.execution_disabled,
+            policy_mode=initial.policy_mode,
+        )
+
+
+def test_runtime_controls_snapshot_unavailable_after_risk_blocks_open_before_execution() -> None:
+    runtime_controls = get_opportunity_runtime_controls()
+    initial = runtime_controls.snapshot()
+    original_snapshot = runtime_controls.snapshot
+    try:
+        runtime_controls.update(
+            execution_disabled=False,
+            opportunity_ai_enabled=True,
+            manual_kill_switch=False,
+            policy_mode="paper",
+        )
+        risk_engine = DummyRiskEngine()
+        controller, execution, journal = _build_autonomy_controller_with_risk(
+            environment="paper",
+            risk_engine=risk_engine,
+            opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+                [8.0, 6.0, 4.0], environment="paper", portfolio_id="paper-1"
+            ),
+        )
+        risk_engine.after_check_callback = lambda: setattr(
+            runtime_controls,
+            "snapshot",
+            lambda: (_ for _ in ()).throw(RuntimeError("snapshot unavailable after risk")),
+        )
+        open_signal = _opportunity_autonomy_signal("paper_autonomous", side="BUY")
+        open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+        assert controller.process_signals([open_signal]) == []
+        assert len(risk_engine.last_checks) == 1
+        assert execution.requests == []
+        assert controller._opportunity_open_outcomes == {}
+        events = [dict(event) for event in journal.export()]
+        blocked = [event for event in events if event.get("event") == "opportunity_autonomy_enforcement"]
+        assert blocked
+        blocked_event = blocked[-1]
+        assert blocked_event["blocking_reason"] == "runtime_controls_unavailable"
+        assert blocked_event["opportunity_runtime_controls_source"] == "snapshot_unavailable"
+        assert blocked_event["opportunity_runtime_controls_unavailable"] == "true"
+        assert not any(
+            event.get("event") in {"order_executed", "order_partially_executed"}
+            for event in events
+        )
+        assert not any(event.get("event") == "opportunity_outcome_attach" for event in events)
+    finally:
+        runtime_controls.snapshot = original_snapshot
+        runtime_controls.update(
+            opportunity_ai_enabled=initial.opportunity_ai_enabled,
+            manual_kill_switch=initial.manual_kill_switch,
+            execution_disabled=initial.execution_disabled,
+            policy_mode=initial.policy_mode,
+        )
 
 
 def test_runtime_controls_hard_stop_metadata_true_remains_fail_closed() -> None:


### PR DESCRIPTION
### Motivation

- Ensure last-mile execution honors opportunity autonomy/runtime controls (emergency stop, manual kill switch, snapshot availability) that may change between risk checks and execution.

### Description

- Add `_allow_last_mile_autonomy_execution` to `TradingController` to consult runtime lineage and decide whether to permit execution, recording a decision event and metrics when blocked.  
- Invoke the new check in the main execution path when `_is_opportunity_autonomy_enforced` is true to short-circuit execution if runtime controls disallow it.  
- Implement blocking conditions for `opportunity_execution_disabled`, unavailable runtime controls, and AI/manual kill-switch combinations while allowing legal closes to proceed.  
- Extend `DummyRiskEngine` in tests with an `after_check_callback` hook and call it from `apply_pre_trade_checks` to simulate runtime-control changes that occur after risk evaluation.  
- Add multiple tests in `tests/test_trading_controller.py` to exercise hard-stop, soft-kill, legal-close exceptions, and snapshot-unavailable scenarios that change after the risk check.

### Testing

- Added unit tests exercising runtime-control transitions: `test_runtime_controls_hard_stop_activated_after_risk_blocks_before_execution`, `test_runtime_controls_hard_stop_activated_after_risk_blocks_legal_close_before_execution`, `test_runtime_controls_soft_kill_switch_activated_after_risk_blocks_open_before_execution`, `test_runtime_controls_soft_kill_switch_activated_after_risk_allows_legal_close`, and `test_runtime_controls_snapshot_unavailable_after_risk_blocks_open_before_execution`, all run as part of the test suite.  
- The modified `DummyRiskEngine` test helper and the new tests executed and passed in the local test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fae741c16c832a80d4724624d0fbc3)