### PR TITLE
tests: add coverage for hard-stop behavior and partial-fill handling in trading controller

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -69704,6 +69704,66 @@ def test_runtime_controls_hard_stop_after_execute_nonfilled_open_does_not_materi
         )
 
 
+def test_runtime_controls_hard_stop_after_execute_partial_open_materializes_partial_quantity() -> None:
+    runtime_controls = get_opportunity_runtime_controls()
+    initial = runtime_controls.snapshot()
+    runtime_controls.update(execution_disabled=False, opportunity_ai_enabled=True, manual_kill_switch=False)
+    try:
+        decision_timestamp = datetime(2026, 1, 3, 12, 10, tzinfo=timezone.utc)
+        correlation_key = "hs-after-exec-open-partial"
+        execution = StatusExecutionService(status="partially_filled", filled_quantity=0.4, avg_price=99.0)
+        execution.after_execute_callback = lambda: runtime_controls.update(execution_disabled=True)
+        controller, execution, journal = _build_autonomy_controller_with_risk(
+            environment="paper",
+            risk_engine=DummyRiskEngine(),
+            execution_service=execution,
+            opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+                [8.0, 6.0, 4.0], environment="paper", portfolio_id="paper-1"
+            ),
+        )
+        repository = controller._opportunity_shadow_repository
+        assert repository is not None
+        repository.append_shadow_records(
+            [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        )
+        signal = _autonomy_signal_with_correlation(
+            mode="paper_autonomous",
+            side="BUY",
+            correlation_key=correlation_key,
+            decision_timestamp=decision_timestamp,
+            include_decision_payload=True,
+            decision_effective_mode="paper_autonomous",
+        )
+        signal.metadata = {**dict(signal.metadata), "mode": "ai"}
+        results = controller.process_signals([signal])
+        assert [r.status for r in results] == ["partially_filled"]
+        events = [dict(event) for event in journal.export()]
+        assert any(e.get("event") == "order_partially_executed" for e in events)
+        assert not any(e.get("event") == "order_executed" for e in events)
+        open_rows = [
+            row for row in repository.load_open_outcomes() if row.correlation_key == correlation_key
+        ]
+        assert len(open_rows) == 1
+        assert open_rows[0].entry_quantity == pytest.approx(0.4, rel=1e-6)
+        assert open_rows[0].entry_price == pytest.approx(99.0, rel=1e-6)
+        tracker = controller._opportunity_open_outcomes[correlation_key]
+        assert tracker.entry_quantity == pytest.approx(0.4, rel=1e-6)
+        assert tracker.entry_price == pytest.approx(99.0, rel=1e-6)
+        assert not any(
+            e.get("event") == "opportunity_autonomy_enforcement"
+            and e.get("status") == "blocked"
+            and str(e.get("blocking_reason") or "") == "emergency_stop_active"
+            for e in events
+        )
+    finally:
+        runtime_controls.update(
+            opportunity_ai_enabled=initial.opportunity_ai_enabled,
+            manual_kill_switch=initial.manual_kill_switch,
+            execution_disabled=initial.execution_disabled,
+            policy_mode=initial.policy_mode,
+        )
+
+
 def test_runtime_controls_hard_stop_after_execute_filled_close_finalizes_real_close() -> None:
     runtime_controls = get_opportunity_runtime_controls()
     initial = runtime_controls.snapshot()
@@ -69769,6 +69829,84 @@ def test_runtime_controls_hard_stop_after_execute_filled_close_finalizes_real_cl
         )
 
 
+def test_runtime_controls_hard_stop_after_execute_partial_close_preserves_residual_tracker() -> None:
+    runtime_controls = get_opportunity_runtime_controls()
+    initial = runtime_controls.snapshot()
+    runtime_controls.update(execution_disabled=False, opportunity_ai_enabled=True, manual_kill_switch=False)
+    try:
+        execution = StatusExecutionService(status="partial", filled_quantity=0.4, avg_price=99.0)
+        execution.after_execute_callback = lambda: runtime_controls.update(execution_disabled=True)
+        controller, execution, journal = _build_autonomy_controller_with_risk(
+            environment="paper",
+            risk_engine=DummyRiskEngine(),
+            execution_service=execution,
+            opportunity_shadow_repository=_autonomy_shadow_repository_with_final_outcomes(
+                [8.0, 6.0, 4.0], environment="paper", portfolio_id="paper-1"
+            ),
+        )
+        repository = controller._opportunity_shadow_repository
+        assert repository is not None
+        correlation_key = "hs-after-exec-close-partial"
+        decision_timestamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        repository.append_shadow_records(
+            [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        )
+        controller._opportunity_open_outcomes[correlation_key] = _OpportunityOpenOutcomeTracker(
+            correlation_key=correlation_key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            environment_scope="paper",
+            portfolio_scope="paper-1",
+        )
+        close_signal = _opportunity_autonomy_signal(
+            "paper_autonomous", side="SELL", include_decision_payload=True, decision_effective_mode="paper_autonomous"
+        )
+        close_signal.metadata = {**dict(close_signal.metadata), "opportunity_shadow_record_key": correlation_key, "mode": "ai"}
+        results = controller.process_signals([close_signal])
+        assert [r.status for r in results] == ["partial"]
+        tracker = controller._opportunity_open_outcomes[correlation_key]
+        assert tracker.closed_quantity == pytest.approx(0.4, rel=1e-6)
+        assert tracker.closed_quantity < tracker.entry_quantity
+        events = [dict(event) for event in journal.export()]
+        assert any(e.get("event") == "order_partially_executed" for e in events)
+        assert not any(e.get("event") == "order_executed" for e in events)
+        assert not any(
+            e.get("event") == "opportunity_autonomy_enforcement"
+            and e.get("status") == "blocked"
+            and str(e.get("blocking_reason") or "") == "emergency_stop_active"
+            for e in events
+        )
+        close_attach_events = [
+            e
+            for e in events
+            if e.get("event") == "opportunity_outcome_attach"
+            and str(e.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+        ]
+        assert close_attach_events
+        assert close_attach_events[-1].get("status") == "partial_attached"
+        assert close_attach_events[-1].get("final_correlation_key") in {"", None}
+        assert str(close_attach_events[-1].get("partial_correlation_key") or "").strip() != ""
+        labels = repository.load_outcome_labels()
+        assert not any(
+            row.correlation_key == correlation_key and row.label_quality == "final" for row in labels
+        )
+        assert any(
+            row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+            for row in labels
+        )
+    finally:
+        runtime_controls.update(
+            opportunity_ai_enabled=initial.opportunity_ai_enabled,
+            manual_kill_switch=initial.manual_kill_switch,
+            execution_disabled=initial.execution_disabled,
+            policy_mode=initial.policy_mode,
+        )
+
+
 def test_runtime_controls_hard_stop_after_execute_nonfilled_close_preserves_tracker() -> None:
     runtime_controls = get_opportunity_runtime_controls()
     initial = runtime_controls.snapshot()
@@ -69821,6 +69959,56 @@ def test_runtime_controls_hard_stop_after_execute_nonfilled_close_preserves_trac
             policy_mode=initial.policy_mode,
         )
 
+
+def test_partial_close_does_not_escalate_to_final_without_full_fill(tmp_path: Path) -> None:
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 101.0},
+        ]
+    )
+    controller, _execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        opportunity_shadow_repository=OpportunityShadowRepository(tmp_path / "shadow.db"),
+    )
+    repository = controller._opportunity_shadow_repository
+    assert repository is not None
+    decision_timestamp = datetime(2026, 1, 4, 12, 0, tzinfo=timezone.utc)
+    correlation_key = "partial-close-no-final-escalation"
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+
+    assert [row.status for row in controller.process_signals([open_signal])] == ["filled"]
+    assert [row.status for row in controller.process_signals([close_signal])] == ["partially_filled"]
+
+    tracker = controller._opportunity_open_outcomes[correlation_key]
+    assert tracker.closed_quantity == pytest.approx(0.4, rel=1e-6)
+    assert tracker.closed_quantity < tracker.entry_quantity
+    labels = repository.load_outcome_labels()
+    assert not any(
+        row.correlation_key == correlation_key and row.label_quality == "final" for row in labels
+    )
+    assert any(
+        row.correlation_key == correlation_key and row.label_quality == "partial_exit_unconfirmed"
+        for row in labels
+    )
 
 def test_runtime_controls_soft_kill_switch_activated_after_risk_allows_legal_close() -> None:
     runtime_controls = get_opportunity_runtime_controls()


### PR DESCRIPTION
### Motivation
- Ensure the controller correctly handles emergency/hard stop changes that occur during or after executions, especially for partial fills and their effects on open outcome tracking and labels.
- Prevent partial closes from being escalated to final labels when they are not fully filled.

### Description
- Added `test_runtime_controls_hard_stop_after_execute_partial_open_materializes_partial_quantity` to verify a partial open persists as an open outcome with the correct `entry_quantity` and `entry_price` when a hard stop is activated after a partial fill.
- Added `test_runtime_controls_hard_stop_after_execute_partial_close_preserves_residual_tracker` to verify a partial close updates the tracker `closed_quantity`, emits `partial_attached` events, and records a `partial_exit_unconfirmed` label without producing a final label when a hard stop is activated after the partial close.
- Added `test_partial_close_does_not_escalate_to_final_without_full_fill` to validate a sequence of fills where the close is only partially filled does not mark the outcome as `final` and retains `partial_exit_unconfirmed` labeling.

### Testing
- Ran the new tests directly with `pytest tests/test_trading_controller.py::test_runtime_controls_hard_stop_after_execute_partial_open_materializes_partial_quantity`, `pytest tests/test_trading_controller.py::test_runtime_controls_hard_stop_after_execute_partial_close_preserves_residual_tracker`, and `pytest tests/test_trading_controller.py::test_partial_close_does_not_escalate_to_final_without_full_fill` and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fafb2e2938832ab7a723d754b98961)