### PR TITLE
Dodaj testy restart/restore dla residual partial-fill lifecycle

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -70011,6 +70011,127 @@ def test_partial_close_does_not_escalate_to_final_without_full_fill(tmp_path: Pa
     )
 
 
+
+
+def test_partial_open_restore_follow_up_close_uses_restored_filled_quantity(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 5, 13, 0, tzinfo=timezone.utc)
+    correlation_key = "partial-open-restore-follow-up-close-real-filled"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+
+    execution_a = SequencedExecutionService(
+        [{"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 100.0}]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["partially_filled"]
+    assert controller_a._opportunity_open_outcomes[correlation_key].entry_quantity == pytest.approx(0.4, rel=1e-6)
+
+    execution_b = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 0.4, "avg_price": 101.0}]
+    )
+    controller_b, _execution_b, _journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_b,
+        opportunity_shadow_repository=repository,
+    )
+    restored_tracker = controller_b._opportunity_open_outcomes[correlation_key]
+    assert restored_tracker.entry_quantity == pytest.approx(0.4, rel=1e-6)
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+    assert [row.status for row in controller_b.process_signals([close_signal])] == ["filled"]
+    assert len(execution_b.requests) == 1
+    assert execution_b.requests[0].quantity == pytest.approx(0.4, rel=1e-6)
+    assert execution_b.requests[0].quantity != pytest.approx(1.0, rel=1e-6)
+    labels = repository.load_outcome_labels()
+    assert any(row.correlation_key == correlation_key and row.label_quality == "final" for row in labels)
+
+
+def test_partial_close_restore_follow_up_close_uses_remaining_quantity_and_finalizes(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 5, 14, 0, tzinfo=timezone.utc)
+    correlation_key = "partial-close-restore-follow-up-close-remaining"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+
+    execution_a = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 101.0},
+        ]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    partial_close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    partial_close_signal.metadata = {**dict(partial_close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    assert [row.status for row in controller_a.process_signals([partial_close_signal])] == ["partially_filled"]
+    assert controller_a._opportunity_open_outcomes[correlation_key].closed_quantity == pytest.approx(0.4, rel=1e-6)
+    assert not any(
+        row.correlation_key == correlation_key and row.label_quality == "final"
+        for row in repository.load_outcome_labels()
+    )
+
+    execution_b = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 0.6, "avg_price": 102.0}]
+    )
+    controller_b, _execution_b, _journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_b,
+        opportunity_shadow_repository=repository,
+    )
+    restored_tracker = controller_b._opportunity_open_outcomes[correlation_key]
+    assert restored_tracker.entry_quantity == pytest.approx(1.0, rel=1e-6)
+    assert restored_tracker.closed_quantity == pytest.approx(0.4, rel=1e-6)
+
+    residual_close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+    )
+    residual_close_signal.metadata = {**dict(residual_close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+    assert [row.status for row in controller_b.process_signals([residual_close_signal])] == ["filled"]
+    assert len(execution_b.requests) == 1
+    assert execution_b.requests[0].quantity == pytest.approx(0.6, rel=1e-6)
+    assert correlation_key not in controller_b._opportunity_open_outcomes
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    assert any(row.label_quality == "final" for row in labels)
+
 def test_partial_open_follow_up_close_uses_real_filled_quantity(tmp_path: Path) -> None:
     execution = SequencedExecutionService(
         [


### PR DESCRIPTION
### Motivation
- Uzupełnienie brakującego pokrycia dla kontraktów restart/restore dotyczących residual lifecycle po partial OPEN i partial CLOSE bez modyfikacji kodu kontrolera.
- Celem jest zweryfikowanie, że przywrócony tracker zachowuje `entry_quantity`/`closed_quantity` i że follow-up CLOSE używa rzeczywistej pozostałej ilości przed finalizacją.

### Description
- Dodano dwa regresyjne testy w `tests/test_trading_controller.py`: `test_partial_open_restore_follow_up_close_uses_restored_filled_quantity` oraz `test_partial_close_restore_follow_up_close_uses_remaining_quantity_and_finalizes`.
- Zmiany ograniczono wyłącznie do pliku testowego i nie dotykają produkcyjnego `controller.py`, runtime controls ani repo API.
- Poprawiono drobne problemy składniowe w istniejącym pliku testowym naprawiając wstawione bloki kodu (brakujące nawiasy/listy) podczas edycji testów.

### Testing
- Zainstalowano zależności testowe: `PYENV_VERSION=3.11.14 python -m pip install -e '.[test]'` i potwierdzono `numpy` (`2.4.4`).
- Uruchomiono selektywne node’y: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "test_partial_open_restore_follow_up_close_uses_restored_filled_quantity or test_partial_close_restore_follow_up_close_uses_remaining_quantity_and_finalizes or test_partial_restore_foreign_scope_close_does_not_execute or test_partial_open_follow_up_close_uses_real_filled_quantity or test_partial_close_follow_up_close_uses_remaining_quantity_and_finalizes or test_runtime_controls_hard_stop_after_execute_partial_open_materializes_partial_quantity or test_runtime_controls_hard_stop_after_execute_partial_close_preserves_residual_tracker or test_partial_close_does_not_escalate_to_final_without_full_fill or test_opportunity_autonomy_duplicate_close_replay_after_restart_prunes_stale_open_tracker_with_partial_closed_quantity"` — wynik: `9 passed, 1018 deselected`.
- Uruchomiono pełny selektor: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "opportunity_autonomy or autonomy or restore or restored or restart or runtime_controls or controls or kill_switch or emergency or hard_stop or execution_disabled or unavailable or filled or nonfilled or rejected or canceled or pending or partial or partially or residual or close or exit or open or risk or execution or enforcement or tracker or correlation or scope"` — wynik: `964 passed, 63 deselected`.
- Zmiany skomitowano jako jedynie testowe; pliki wygenerowane (`reports/ci/decision_feed_metrics.json`, `bot_core/logs/`) nie zostały dodane do commita.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb051bd2f0832a9483f6ec865beee2)