### PR TITLE
Enforce restored autonomous tracker scope isolation for follow-up close signals

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -3113,6 +3113,42 @@ class TradingController:
             request=request,
             tracker=existing_open_tracker,
         )
+        request_metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        normalized_signal_mode = str(request_metadata.get("mode") or "").strip().lower()
+        enforce_restored_scope_isolation = normalized_signal_mode == "ai" or (
+            normalized_signal_mode == ""
+            and self._is_opportunity_autonomy_enforced(signal, request)
+            and str(request_metadata.get("opportunity_autonomy_mode") or "").strip().lower()
+            in {"paper_autonomous", "live_autonomous"}
+        )
+        if (
+            correlation_key
+            and existing_open_tracker is not None
+            and existing_open_tracker.restored_from_repository
+            and self._is_closing_side(str(existing_open_tracker.side), str(request.side))
+            and self._is_autonomous_restored_tracker_contract(existing_open_tracker)
+            and enforce_restored_scope_isolation
+            and (
+                str(existing_open_tracker.symbol) != str(request.symbol)
+                or not self._matches_current_open_tracker_scope(
+                    correlation_key=correlation_key,
+                    symbol=str(request.symbol),
+                    tracker=existing_open_tracker,
+                )
+            )
+        ):
+            self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+            self._record_decision_event(
+                "signal_skipped",
+                signal=signal,
+                request=request,
+                status="skipped",
+                metadata={
+                    "reason": "restored_tracker_scope_mismatch_suppressed",
+                    "proxy_correlation_key": correlation_key,
+                },
+            )
+            return None
         if (
             correlation_key
             and existing_open_tracker is not None

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -70132,6 +70132,338 @@ def test_partial_close_restore_follow_up_close_uses_remaining_quantity_and_final
     labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
     assert any(row.label_quality == "final" for row in labels)
 
+
+
+def test_partial_open_restore_foreign_environment_close_does_not_execute(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 6, 10, 0, tzinfo=timezone.utc)
+    correlation_key = "partial-open-restore-foreign-environment"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+
+    execution_a = SequencedExecutionService(
+        [{"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 100.0}]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["partially_filled"]
+    restored_row = repository.load_open_outcomes()[0]
+    repository.upsert_open_outcome(
+        replace(
+            restored_row,
+            provenance={**dict(restored_row.provenance), "environment": "live", "portfolio": "paper-1"},
+        )
+    )
+
+    risk_b = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_b,
+        execution_service=SequencedExecutionService([{"status": "filled", "filled_quantity": 0.4, "avg_price": 101.0}]),
+        opportunity_shadow_repository=repository,
+    )
+    assert correlation_key in controller_b._opportunity_open_outcomes
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+
+    assert controller_b.process_signals([close_signal]) == []
+    assert risk_b.last_checks == []
+    assert execution_b.requests == []
+    assert not any(
+        event.get("event") in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+        for event in journal_b.export()
+    )
+
+
+def test_partial_open_restore_same_scope_symbol_mismatch_close_does_not_execute(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 6, 10, 30, tzinfo=timezone.utc)
+    correlation_key = "partial-open-restore-same-scope-symbol-mismatch"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+
+    execution_a = SequencedExecutionService(
+        [{"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 100.0}]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["partially_filled"]
+
+    risk_b = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_b,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 0.4, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.symbol = "ETH/USDT"
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "ai",
+        "opportunity_shadow_record_key": correlation_key,
+    }
+
+    assert controller_b.process_signals([close_signal]) == []
+    assert risk_b.last_checks == []
+    assert execution_b.requests == []
+    assert correlation_key in controller_b._opportunity_open_outcomes
+    assert not any(
+        event.get("event")
+        in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+        for event in journal_b.export()
+    )
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    assert not any(row.label_quality == "final" for row in labels)
+
+
+def test_partial_open_restore_foreign_portfolio_close_does_not_execute(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 6, 11, 0, tzinfo=timezone.utc)
+    correlation_key = "partial-open-restore-foreign-portfolio"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+
+    execution_a = SequencedExecutionService(
+        [{"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 100.0}]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["partially_filled"]
+    restored_row = repository.load_open_outcomes()[0]
+    repository.upsert_open_outcome(
+        replace(
+            restored_row,
+            provenance={**dict(restored_row.provenance), "environment": "paper", "portfolio": "portfolio-A"},
+        )
+    )
+
+    risk_b = DummyRiskEngine()
+    router_b, _channel_b, _audit_b = _router_with_channel()
+    journal_b = CollectingDecisionJournal()
+    execution_b = SequencedExecutionService([{"status": "filled", "filled_quantity": 0.4, "avg_price": 101.0}])
+    controller_b = TradingController(
+        risk_engine=risk_b,
+        execution_service=execution_b,
+        alert_router=router_b,
+        account_snapshot_provider=_account_snapshot,
+        portfolio_id="portfolio-B",
+        environment="paper",
+        risk_profile="balanced",
+        decision_journal=journal_b,
+        opportunity_shadow_repository=repository,
+    )
+    assert correlation_key in controller_b._opportunity_open_outcomes
+
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+
+    assert controller_b.process_signals([close_signal]) == []
+    assert risk_b.last_checks == []
+    assert execution_b.requests == []
+    assert not any(
+        event.get("event") in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+        for event in journal_b.export()
+    )
+
+
+def test_partial_open_restore_foreign_scope_close_without_mode_ai_does_not_execute(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 6, 11, 30, tzinfo=timezone.utc)
+    correlation_key = "partial-open-restore-foreign-no-mode-ai"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+
+    execution_a = SequencedExecutionService(
+        [{"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 100.0}]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["partially_filled"]
+    restored_row = repository.load_open_outcomes()[0]
+    repository.upsert_open_outcome(
+        replace(
+            restored_row,
+            provenance={
+                **dict(restored_row.provenance),
+                "environment": "live",
+                "portfolio": "paper-1",
+            },
+        )
+    )
+
+    risk_b = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_b,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 0.4, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+        include_mode=False,
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "opportunity_shadow_record_key": correlation_key,
+        "opportunity_autonomy_mode": "paper_autonomous",
+    }
+
+    assert controller_b.process_signals([close_signal]) == []
+    assert risk_b.last_checks == []
+    assert execution_b.requests == []
+    assert correlation_key in controller_b._opportunity_open_outcomes
+    assert not any(
+        event.get("event")
+        in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip()
+        == correlation_key
+        for event in journal_b.export()
+    )
+
+
+def test_partial_close_restore_foreign_scope_residual_close_does_not_finalize(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 6, 12, 0, tzinfo=timezone.utc)
+    correlation_key = "partial-close-restore-foreign-scope-residual"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+
+    execution_a = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 101.0},
+        ]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    partial_close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    partial_close_signal.metadata = {**dict(partial_close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    assert [row.status for row in controller_a.process_signals([partial_close_signal])] == ["partially_filled"]
+    restored_row = repository.load_open_outcomes()[0]
+    repository.upsert_open_outcome(
+        replace(
+            restored_row,
+            provenance={**dict(restored_row.provenance), "environment": "live", "portfolio": "paper-1"},
+        )
+    )
+
+    risk_b = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_b,
+        execution_service=SequencedExecutionService([{"status": "filled", "filled_quantity": 0.6, "avg_price": 102.0}]),
+        opportunity_shadow_repository=repository,
+    )
+    restored_tracker = controller_b._opportunity_open_outcomes[correlation_key]
+    assert restored_tracker.closed_quantity == pytest.approx(0.4, rel=1e-6)
+
+    residual_close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=2),
+    )
+    residual_close_signal.metadata = {**dict(residual_close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+    assert controller_b.process_signals([residual_close_signal]) == []
+    assert risk_b.last_checks == []
+    assert execution_b.requests == []
+    assert controller_b._opportunity_open_outcomes[correlation_key].closed_quantity == pytest.approx(0.4, rel=1e-6)
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    assert not any(row.label_quality == "final" for row in labels)
+    assert not any(
+        event.get("event") in {"order_executed", "order_partially_executed", "opportunity_outcome_attach"}
+        and str(event.get("order_opportunity_shadow_record_key") or "").strip() == correlation_key
+        for event in journal_b.export()
+    )
 def test_partial_open_follow_up_close_uses_real_filled_quantity(tmp_path: Path) -> None:
     execution = SequencedExecutionService(
         [


### PR DESCRIPTION
### Motivation
- Prevent autonomous follow-up close signals from acting on restored open trackers that were created in a different scope, environment, portfolio, or with a mismatched symbol unless the incoming signal explicitly indicates autonomous (AI) mode.
- Avoid unintended executions and premature finalization of restored outcomes when the runtime request does not match the restored tracker's scope.

### Description
- Add metadata normalization and compute `enforce_restored_scope_isolation` in `TradingController.process_signals` based on `mode` and `opportunity_autonomy_mode` to determine when to enforce scope isolation for restored autonomous trackers.
- Introduce an early-skip branch that returns `None` for follow-up close signals when the existing open tracker was restored from repository, is an autonomous contract, the signal is a closing side, scope or symbol does not match, and scope isolation is enforced, while incrementing metrics and recording a `signal_skipped` decision event with reason `restored_tracker_scope_mismatch_suppressed`.
- Keep the existing runtime-position and sign-mismatch checks intact for cases that do not meet the skip condition.
- Add unit tests that exercise foreign-environment, symbol-mismatch, foreign-portfolio, missing-`mode` semantics, and residual-close finalization behaviors.

### Testing
- Added unit tests in `tests/test_trading_controller.py` for `test_partial_open_restore_foreign_environment_close_does_not_execute`, `test_partial_open_restore_same_scope_symbol_mismatch_close_does_not_execute`, `test_partial_open_restore_foreign_portfolio_close_does_not_execute`, `test_partial_open_restore_foreign_scope_close_without_mode_ai_does_not_execute`, and `test_partial_close_restore_foreign_scope_residual_close_does_not_finalize`.
- Ran the updated test module with `pytest tests/test_trading_controller.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb0b9989a8832a9e9920f58c104dc9)