### PR TITLE
Dodaj regresyjne testy same-batch arbitration dla restore (test-only)

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -71114,6 +71114,179 @@ def test_partial_close_follow_up_close_uses_remaining_quantity_and_finalizes(tmp
     )
 
 
+def test_same_batch_restored_residual_close_then_fresh_open_same_symbol_no_reentry(tmp_path: Path) -> None:
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    correlation_key = "same-batch-restored-close-then-open"
+    decision_timestamp = datetime(2026, 1, 6, 10, 0, tzinfo=timezone.utc)
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+
+    controller_b, execution_b, _journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    restored_close = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=1)
+    )
+    restored_close.metadata = {**dict(restored_close.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+    fresh_open = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="BUY", correlation_key="fresh-open-should-not-reenter", decision_timestamp=decision_timestamp + timedelta(minutes=2)
+    )
+    fresh_open.symbol = restored_close.symbol
+    fresh_open.metadata = {**dict(fresh_open.metadata), "mode": "ai"}
+
+    assert [row.status for row in controller_b.process_signals([restored_close, fresh_open])] == ["filled"]
+    assert len(execution_b.requests) == 1
+    assert execution_b.requests[0].side == "SELL"
+
+
+def test_same_batch_fresh_open_then_restored_residual_close_same_symbol_no_order_bypass(tmp_path: Path) -> None:
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    correlation_key = "same-batch-open-then-restored-close"
+    decision_timestamp = datetime(2026, 1, 6, 11, 0, tzinfo=timezone.utc)
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+
+    controller_b, execution_b, _journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 102.0},
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 103.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    fresh_open = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="BUY", correlation_key="order-open-before-close", decision_timestamp=decision_timestamp + timedelta(minutes=1)
+    )
+    fresh_open.metadata = {**dict(fresh_open.metadata), "mode": "ai"}
+    fresh_open.symbol = "BTC/USDT"
+    restored_close = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=2)
+    )
+    restored_close.metadata = {**dict(restored_close.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+    assert [row.status for row in controller_b.process_signals([fresh_open, restored_close])] == ["filled"]
+    assert len(execution_b.requests) == 1
+    assert execution_b.requests[0].side == "SELL"
+
+
+def test_same_batch_final_replay_close_does_not_enable_fresh_open_same_correlation(tmp_path: Path) -> None:
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    correlation_key = "same-batch-final-replay-close-open"
+    decision_timestamp = datetime(2026, 1, 6, 12, 0, tzinfo=timezone.utc)
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=1)
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    assert [row.status for row in controller_a.process_signals([close_signal])] == ["filled"]
+
+    controller_b, execution_b, _journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 102.0}]),
+        opportunity_shadow_repository=repository,
+    )
+    replay_close = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=2)
+    )
+    replay_close.metadata = {**dict(replay_close.metadata), "mode": "ai", "opportunity_shadow_record_key": correlation_key}
+    fresh_open_same_key = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=3)
+    )
+    fresh_open_same_key.metadata = {**dict(fresh_open_same_key.metadata), "mode": "ai"}
+    assert controller_b.process_signals([replay_close, fresh_open_same_key]) == []
+    assert execution_b.requests == []
+
+
+def test_same_batch_foreign_scope_close_does_not_enable_open_from_foreign_tracker(tmp_path: Path) -> None:
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    decision_timestamp = datetime(2026, 1, 6, 13, 0, tzinfo=timezone.utc)
+    foreign_key = "same-batch-foreign-scope-close"
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=foreign_key, decision_timestamp=decision_timestamp)]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService([{"status": "partially_filled", "filled_quantity": 0.4, "avg_price": 100.0}]),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="BUY", correlation_key=foreign_key, decision_timestamp=decision_timestamp
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["partially_filled"]
+    restored_row = repository.load_open_outcomes()[0]
+    repository.upsert_open_outcome(
+        replace(
+            restored_row,
+            provenance={**dict(restored_row.provenance), "environment": "live", "portfolio": "live-1"},
+        )
+    )
+
+    controller, execution, _journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]),
+        opportunity_shadow_repository=repository,
+    )
+    foreign_close = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="SELL", correlation_key=foreign_key, decision_timestamp=decision_timestamp + timedelta(minutes=1)
+    )
+    foreign_close.metadata = {**dict(foreign_close.metadata), "mode": "ai", "opportunity_shadow_record_key": foreign_key}
+    fresh_open = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="BUY", correlation_key="same-batch-fresh-open-after-foreign-close", decision_timestamp=decision_timestamp + timedelta(minutes=2)
+    )
+    fresh_open.metadata = {**dict(fresh_open.metadata), "mode": "ai"}
+    assert controller.process_signals([foreign_close, fresh_open]) == []
+    assert execution.requests == []
 
 def test_runtime_controls_soft_kill_switch_activated_after_risk_allows_legal_close() -> None:
     runtime_controls = get_opportunity_runtime_controls()


### PR DESCRIPTION
### Motivation
- Występowała luka testowa w ścieżce same-cycle arbitration/admission po restore dotyczącą scenariuszy `CLOSE` + `OPEN` (oraz odwrotne i replay/foreign), które nie były deterministycznie pokryte przez istniejące testy. 
- Celem było zamknięcie tej luki najwęższym możliwym zakresem — tylko testy, bez zmian produkcyjnej logiki kontrolera.

### Description
- Dodano cztery regresyjne testy w `tests/test_trading_controller.py`: `test_same_batch_restored_residual_close_then_fresh_open_same_symbol_no_reentry`, `test_same_batch_fresh_open_then_restored_residual_close_same_symbol_no_order_bypass`, `test_same_batch_final_replay_close_does_not_enable_fresh_open_same_correlation` oraz `test_same_batch_foreign_scope_close_does_not_enable_open_from_foreign_tracker`.
- Testy wykorzystują istniejące helpery (`SequencedExecutionService`, `DummyRiskEngine`, `OpportunityShadowRepository`, `_build_autonomy_controller_with_risk`, `_autonomy_signal_with_correlation`, `_shadow_record_for_key`) i nie zmieniają kodu produkcyjnego (`bot_core/runtime/controller.py` bez modyfikacji).
- Testy sprawdzają deterministyczne zachowanie tej ścieżki: legalny residual `CLOSE` wykonuje się, fresh `OPEN` nie re-enters w tym samym batchu (chyba że istnieje jawny kontrakt), replay `CLOSE` jest supresowany, oraz foreign-scope close nie legalizuje fresh open.

### Testing
- Zainstalowano zależności testowe: `PYENV_VERSION=3.11.14 python -m pip install -e '.[test]'` — zakończono sukcesem.
- Walidacja środowiska: `PYENV_VERSION=3.11.14 python -c "import numpy; print(numpy.__version__)"` wypisało zainstalowaną wersję `numpy`.
- Uruchomiono wybrane node’y testowe: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py::test_same_batch_restored_residual_close_then_fresh_open_same_symbol_no_reentry tests/test_trading_controller.py::test_same_batch_fresh_open_then_restored_residual_close_same_symbol_no_order_bypass tests/test_trading_controller.py::test_same_batch_final_replay_close_does_not_enable_fresh_open_same_correlation tests/test_trading_controller.py::test_same_batch_foreign_scope_close_does_not_enable_open_from_foreign_tracker tests/test_trading_controller.py::test_finalized_residual_close_restart_replay_close_is_idempotent tests/test_trading_controller.py::test_final_label_blocks_replay_close_with_fresh_close_lineage_after_restart tests/test_trading_controller.py::test_partial_close_restore_residual_final_upgrades_or_resolves_partial_label tests/test_trading_controller.py::test_partial_close_restore_residual_final_replay_is_idempotent tests/test_trading_controller.py::test_partial_open_restore_foreign_environment_close_does_not_execute tests/test_trading_controller.py::test_partial_open_restore_foreign_portfolio_close_does_not_execute tests/test_trading_controller.py::test_partial_open_restore_same_scope_symbol_mismatch_close_does_not_execute` — wynik: `11 passed`.
- Uruchomiono pełny selektor dla pliku z filtrem: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "opportunity_autonomy or autonomy or arbitration or conflict or same_batch or batch or restore or restored or restart or replay or duplicate or idempotent or lineage or provenance or model_version or decision_source or shadow_record_key or decision_timestamp or foreign or scope or portfolio or environment or symbol or filled or nonfilled or rejected or canceled or pending or partial or partially or residual or final or proxy or label or attach or close or exit or open or risk or execution or enforcement or tracker or correlation"` — wynik: `1007 passed, 35 deselected`.
- Commit z testami został utworzony (test-only). Commit hash: `69b317f`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb26886240832ab034783808201f52)