### PR TITLE
Guard autonomous opens against untracked runtime account positions

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -3008,6 +3008,29 @@ class TradingController:
                     sanitized_request_metadata.pop("opportunity_autonomy_decision", None)
                     request = replace(request, metadata=sanitized_request_metadata)
                     request_metadata = sanitized_request_metadata
+            if duplicate_open_guard_enabled and existing_open_tracker is None:
+                account_for_untracked_exposure: AccountSnapshot | None
+                try:
+                    account_for_untracked_exposure = self.account_snapshot_provider()
+                except Exception:  # pragma: no cover - diagnostics only
+                    account_for_untracked_exposure = None
+                runtime_position_notional = self._runtime_position_notional_for_symbol(
+                    account=account_for_untracked_exposure,
+                    symbol=str(request.symbol),
+                )
+                if runtime_position_notional is not None and abs(runtime_position_notional) > 1e-12:
+                    self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+                    self._record_decision_event(
+                        "signal_skipped",
+                        signal=signal,
+                        request=request,
+                        status="skipped",
+                        metadata={
+                            "reason": "autonomous_open_untracked_runtime_position_suppressed",
+                            "proxy_correlation_key": correlation_key,
+                        },
+                    )
+                    return None
             if (
                 duplicate_open_guard_enabled
                 and existing_open_tracker is None

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -71243,6 +71243,182 @@ def test_same_batch_fresh_open_then_restored_residual_close_same_symbol_no_order
     assert any(event["event"] == "order_executed" for event in close_events)
 
 
+def test_fresh_autonomous_open_blocks_when_account_snapshot_has_untracked_position(tmp_path: Path) -> None:
+    correlation_key = "fresh-open-untracked-account-exposure"
+    decision_timestamp = datetime(2026, 1, 6, 12, 30, tzinfo=timezone.utc)
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"BTCUSDT_position": 0.75, "USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+
+    correlation_key = "fresh-open-untracked-account-exposure"
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    signal.metadata = {**dict(signal.metadata), "mode": "ai"}
+
+    assert controller.process_signals([signal]) == []
+    assert execution.requests == []
+    assert risk_engine.last_checks == []
+    assert correlation_key not in controller._opportunity_open_outcomes
+    assert _order_path_events_with_shadow_key(journal, correlation_key) == []
+    assert _opportunity_attach_events_referencing_key(journal, correlation_key) == []
+    reconciliation_blocks = [
+        event
+        for event in journal.export()
+        if event.get("event") in {"signal_skipped", "opportunity_autonomy_enforcement"}
+        and event.get("reason") == "autonomous_open_untracked_runtime_position_suppressed"
+        and str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+    ]
+    assert reconciliation_blocks
+
+
+def test_fresh_autonomous_open_with_explicit_decision_payload_blocks_when_account_snapshot_has_untracked_position(
+    tmp_path: Path,
+) -> None:
+    correlation_key = "fresh-open-explicit-payload-untracked-exposure"
+    decision_timestamp = datetime(2026, 1, 6, 12, 35, tzinfo=timezone.utc)
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"BTCUSDT_position": 0.75, "USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    signal.metadata = {**dict(signal.metadata), "mode": "ai"}
+
+    assert controller.process_signals([signal]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert correlation_key not in controller._opportunity_open_outcomes
+    assert _order_path_events_with_shadow_key(journal, correlation_key) == []
+    assert _opportunity_attach_events_referencing_key(journal, correlation_key) == []
+    reconciliation_blocks = [
+        event
+        for event in journal.export()
+        if event.get("event") in {"signal_skipped", "opportunity_autonomy_enforcement"}
+        and event.get("reason") == "autonomous_open_untracked_runtime_position_suppressed"
+        and str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+    ]
+    assert reconciliation_blocks
+
+
+def test_fresh_autonomous_open_without_account_exposure_still_reaches_execution(tmp_path: Path) -> None:
+    correlation_key = "fresh-open-no-account-exposure-allowed"
+    decision_timestamp = datetime(2026, 1, 6, 12, 40, tzinfo=timezone.utc)
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    risk_engine = DummyRiskEngine()
+    controller, execution, _journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    signal.metadata = {**dict(signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller.process_signals([signal])] == ["filled"]
+    assert len(risk_engine.last_checks) == 1
+    assert len(execution.requests) == 1
+    assert execution.requests[0].side == "BUY"
+    assert correlation_key in controller._opportunity_open_outcomes
+
+
+def test_fresh_autonomous_open_with_explicit_decision_payload_without_account_exposure_still_reaches_execution(
+    tmp_path: Path,
+) -> None:
+    correlation_key = "fresh-open-explicit-payload-no-exposure-allowed"
+    decision_timestamp = datetime(2026, 1, 6, 12, 45, tzinfo=timezone.utc)
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    risk_engine = DummyRiskEngine()
+    controller, execution, _journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    signal.metadata = {**dict(signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller.process_signals([signal])] == ["filled"]
+    assert len(risk_engine.last_checks) == 1
+    assert len(execution.requests) == 1
+    assert execution.requests[0].side == "BUY"
+    assert execution.requests[0].symbol == signal.symbol
+    assert correlation_key in controller._opportunity_open_outcomes
+
+
 def test_same_batch_final_replay_close_does_not_enable_fresh_open_same_correlation(tmp_path: Path) -> None:
     repository = OpportunityShadowRepository(tmp_path / "shadow.db")
     correlation_key = "same-batch-final-replay-close-open"


### PR DESCRIPTION
### Motivation

- Prevent autonomous open signals from creating duplicate/untracked exposure when the live account snapshot already contains a runtime position for the same symbol.
- Ensure the duplicate-open guard also blocks signals that include an explicit decision payload matching the requested autonomy mode.
- Allow normal autonomous opens to proceed when the account snapshot shows no exposure for the symbol.

### Description

- Added a runtime-exposure guard in `TradingController` that, when `duplicate_open_guard_enabled` is set and there is no existing open tracker, calls `account_snapshot_provider()` and computes `runtime_position_notional` via `_runtime_position_notional_for_symbol` for the request symbol. 
- If a non-zero runtime notional is found the controller increments the `_metric_signals_total` with `status: skipped`, records a `signal_skipped` decision event with `reason: autonomous_open_untracked_runtime_position_suppressed`, and returns `None` to block the signal.
- Protected the account snapshot call with a broad `except Exception` to avoid failing signal processing if the provider errors, and recorded the event/metric paths used for observability.
- Added unit tests in `tests/test_trading_controller.py` covering blocked and allowed cases for fresh autonomous opens with and without explicit decision payloads and with/without account exposure.

### Testing

- Added and ran `test_fresh_autonomous_open_blocks_when_account_snapshot_has_untracked_position` which asserts signals are skipped and no execution/risk checks occur; the test passed.
- Added and ran `test_fresh_autonomous_open_with_explicit_decision_payload_blocks_when_account_snapshot_has_untracked_position` which asserts explicit-payload opens are also blocked when exposure exists; the test passed.
- Added and ran `test_fresh_autonomous_open_without_account_exposure_still_reaches_execution` and `test_fresh_autonomous_open_with_explicit_decision_payload_without_account_exposure_still_reaches_execution` which assert normal execution proceeds when no account exposure exists; both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2ed2f400832a8bbe7afd7e22c223)