### PR TITLE
Zablokuj autonomous OPEN gdy `account_snapshot_provider()` jest niedostępny (fail-close)

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -3010,10 +3010,25 @@ class TradingController:
                     request_metadata = sanitized_request_metadata
             if duplicate_open_guard_enabled and existing_open_tracker is None:
                 account_for_untracked_exposure: AccountSnapshot | None
+                account_snapshot_unavailable = False
                 try:
                     account_for_untracked_exposure = self.account_snapshot_provider()
                 except Exception:  # pragma: no cover - diagnostics only
                     account_for_untracked_exposure = None
+                    account_snapshot_unavailable = True
+                if account_snapshot_unavailable:
+                    self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+                    self._record_decision_event(
+                        "signal_skipped",
+                        signal=signal,
+                        request=request,
+                        status="skipped",
+                        metadata={
+                            "reason": "autonomous_open_account_snapshot_unavailable_suppressed",
+                            "proxy_correlation_key": correlation_key,
+                        },
+                    )
+                    return None
                 runtime_position_notional = self._runtime_position_notional_for_symbol(
                     account=account_for_untracked_exposure,
                     symbol=str(request.symbol),

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -71342,6 +71342,92 @@ def test_fresh_autonomous_open_with_explicit_decision_payload_blocks_when_accoun
     assert reconciliation_blocks
 
 
+def test_fresh_autonomous_open_blocks_when_account_snapshot_provider_raises(tmp_path: Path) -> None:
+    correlation_key = "fresh-open-account-snapshot-provider-raises"
+    decision_timestamp = datetime(2026, 1, 6, 12, 36, tzinfo=timezone.utc)
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.account_snapshot_provider = lambda: (_ for _ in ()).throw(RuntimeError("account unavailable"))
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    signal.metadata = {**dict(signal.metadata), "mode": "ai"}
+
+    assert controller.process_signals([signal]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert correlation_key not in controller._opportunity_open_outcomes
+    assert _order_path_events_with_shadow_key(journal, correlation_key) == []
+    assert _opportunity_attach_events_referencing_key(journal, correlation_key) == []
+    reconciliation_blocks = [
+        event
+        for event in journal.export()
+        if event.get("event") in {"signal_skipped", "opportunity_autonomy_enforcement"}
+        and event.get("reason") == "autonomous_open_account_snapshot_unavailable_suppressed"
+        and str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+    ]
+    assert reconciliation_blocks
+
+
+def test_fresh_autonomous_open_with_explicit_payload_blocks_when_account_snapshot_provider_raises(
+    tmp_path: Path,
+) -> None:
+    correlation_key = "fresh-open-explicit-payload-account-snapshot-provider-raises"
+    decision_timestamp = datetime(2026, 1, 6, 12, 37, tzinfo=timezone.utc)
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller.account_snapshot_provider = lambda: (_ for _ in ()).throw(RuntimeError("account unavailable"))
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+        include_decision_payload=True,
+        decision_effective_mode="paper_autonomous",
+    )
+    signal.metadata = {**dict(signal.metadata), "mode": "ai"}
+
+    assert controller.process_signals([signal]) == []
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert correlation_key not in controller._opportunity_open_outcomes
+    assert _order_path_events_with_shadow_key(journal, correlation_key) == []
+    assert _opportunity_attach_events_referencing_key(journal, correlation_key) == []
+    reconciliation_blocks = [
+        event
+        for event in journal.export()
+        if event.get("event") in {"signal_skipped", "opportunity_autonomy_enforcement"}
+        and event.get("reason") == "autonomous_open_account_snapshot_unavailable_suppressed"
+        and str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+    ]
+    assert reconciliation_blocks
+
+
 def test_fresh_autonomous_open_without_account_exposure_still_reaches_execution(tmp_path: Path) -> None:
     correlation_key = "fresh-open-no-account-exposure-allowed"
     decision_timestamp = datetime(2026, 1, 6, 12, 40, tzinfo=timezone.utc)


### PR DESCRIPTION
### Motivation
- Audyt wykazał, że wyjątek z `account_snapshot_provider()` był dotychczas tłumiony na `None`, co skutkowało faktycznym fail-open dla świeżych autonomous OPEN i pozwalało pominąć weryfikację exposure.
- Należało wymusić najwęższy możliwy seam: fail-closed tylko dla ścieżki fresh autonomous OPEN przy niedostępnym providerze, bez zmian w innych mechanizmach (restore/close/runtimes/failover).
- Trzeba również zapobiec obejściu tej blokady przez explicit decision payload; legalny fresh OPEN bez exposure ma pozostać dozwolony.

### Description
- W `bot_core/runtime/controller.py` dodano w ścieżce duplicate-open guard wykrycie sytuacji, gdy `account_snapshot_provider()` rzuca wyjątek i natychmiastowe zablokowanie sygnału z zapisem eventu reason `autonomous_open_account_snapshot_unavailable_suppressed` oraz metryk, bez przechodzenia do risk/execution oraz bez tworzenia trackerów.
- Dla niezmienionych przypadków: snapshot dostępny z brakiem pozycji wciąż pozwala na legalny OPEN; restored CLOSE i runtime_position_notional nie zostały zmienione funkcjonalnie.
- Dodano dwa regresyjne testy w `tests/test_trading_controller.py`: `test_fresh_autonomous_open_blocks_when_account_snapshot_provider_raises` oraz `test_fresh_autonomous_open_with_explicit_payload_blocks_when_account_snapshot_provider_raises`.

### Testing
- Zainstalowano deps testowe poleceniem `PYENV_VERSION=3.11.14 python -m pip install -e '.[test]'` i potwierdzono `numpy` przez `PYENV_VERSION=3.11.14 python -c "import numpy; print(numpy.__version__)"` (wynik `2.4.4`).
- Uruchomiono nowe exact node-y: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "test_fresh_autonomous_open_blocks_when_account_snapshot_provider_raises or test_fresh_autonomous_open_with_explicit_payload_blocks_when_account_snapshot_provider_raises"` i oba przeszły (`2 passed`).
- Uruchomiono wymagany zestaw regresyjny i pełny selector: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "opportunity_autonomy or autonomy or reconciliation or account_snapshot or ..."` i testy krytyczne przeszły (`1021 passed, 27 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4b9929f4832aa98b0be29a4e0567)