### PR TITLE
Dodaj repozytoryjny proof trwałości markera pending-entry

### DIFF
--- a/tests/ai/test_trading_opportunity_engine.py
+++ b/tests/ai/test_trading_opportunity_engine.py
@@ -1386,6 +1386,119 @@ def test_outcome_label_attach_allows_upgrade_proxy_to_partial_to_final(tmp_path)
     assert labels[0].label_quality == "final"
 
 
+def test_opportunity_shadow_repository_persists_pending_entry_marker_with_provenance(tmp_path) -> None:
+    repo = OpportunityShadowRepository(tmp_path / "shadow")
+    marker = OpportunityOutcomeLabel(
+        symbol="BTC/USDT",
+        decision_timestamp=datetime(2026, 1, 2, 10, 30, tzinfo=timezone.utc),
+        correlation_key="pending-entry-key",
+        horizon_minutes=0,
+        realized_return_bps=0.0,
+        max_favorable_excursion_bps=0.0,
+        max_adverse_excursion_bps=0.0,
+        label_quality="execution_proxy_pending_entry",
+        provenance={
+            "order_id": "pending-open-1",
+            "execution_status": "pending",
+            "symbol": "BTC/USDT",
+            "side": "BUY",
+            "environment": "paper",
+            "portfolio": "paper-1",
+            "correlation_key": "pending-entry-key",
+        },
+    )
+    repo.append_outcome_labels([marker])
+
+    reloaded_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    labels = reloaded_repo.load_outcome_labels()
+    persisted = next((row for row in labels if row.correlation_key == "pending-entry-key"), None)
+
+    assert persisted is not None
+    assert persisted.label_quality == "execution_proxy_pending_entry"
+    assert dict(persisted.provenance) == {
+        "order_id": "pending-open-1",
+        "execution_status": "pending",
+        "symbol": "BTC/USDT",
+        "side": "BUY",
+        "environment": "paper",
+        "portfolio": "paper-1",
+        "correlation_key": "pending-entry-key",
+    }
+    normalized_quality = str(persisted.label_quality).strip().lower()
+    assert not normalized_quality.startswith("final")
+    assert normalized_quality != "partial_exit_unconfirmed"
+    assert normalized_quality != "execution_proxy_pending_exit"
+
+
+def test_opportunity_shadow_repository_distinguishes_pending_entry_from_pending_exit_marker(
+    tmp_path,
+) -> None:
+    repo = OpportunityShadowRepository(tmp_path / "shadow")
+    labels = [
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=datetime(2026, 1, 2, 10, 30, tzinfo=timezone.utc),
+            correlation_key="pending-entry-key",
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            label_quality="execution_proxy_pending_entry",
+            provenance={
+                "order_id": "pending-open-1",
+                "execution_status": "pending",
+                "symbol": "BTC/USDT",
+                "side": "BUY",
+                "environment": "paper",
+                "portfolio": "paper-1",
+            },
+        ),
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=datetime(2026, 1, 2, 10, 31, tzinfo=timezone.utc),
+            correlation_key="pending-exit-key",
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            label_quality="execution_proxy_pending_exit",
+            provenance={
+                "order_id": "pending-close-1",
+                "execution_status": "pending",
+                "symbol": "BTC/USDT",
+                "side": "SELL",
+                "environment": "paper",
+                "portfolio": "paper-1",
+            },
+        ),
+    ]
+    repo.append_outcome_labels(labels)
+
+    reloaded_repo = OpportunityShadowRepository(tmp_path / "shadow")
+    loaded = reloaded_repo.load_outcome_labels()
+    pending_entry = [
+        row
+        for row in loaded
+        if row.label_quality == "execution_proxy_pending_entry"
+        and row.symbol == "BTC/USDT"
+        and str(row.provenance.get("side")) == "BUY"
+    ]
+    pending_exit = [
+        row
+        for row in loaded
+        if row.label_quality == "execution_proxy_pending_exit"
+        and row.symbol == "BTC/USDT"
+        and str(row.provenance.get("side")) == "SELL"
+    ]
+
+    assert len(loaded) == 2
+    assert len(pending_entry) == 1
+    assert len(pending_exit) == 1
+    assert pending_entry[0].label_quality != pending_exit[0].label_quality
+    assert pending_entry[0].provenance.get("order_id") == "pending-open-1"
+    assert pending_exit[0].provenance.get("order_id") == "pending-close-1"
+
+
 def test_record_key_is_canonical_for_same_instant_in_different_timezones() -> None:
     utc_instant = datetime(2026, 1, 2, 10, 30, tzinfo=timezone.utc)
     plus_two = utc_instant.astimezone(timezone(timedelta(hours=2)))


### PR DESCRIPTION
### Motivation
- Udowodnić na poziomie repozytorium, że istniejąca struktura `OpportunityOutcomeLabel` / `OpportunityShadowRepository` może bez migracji i bez zmiany API zapisać i odczytać trwały marker pending (`label_quality="execution_proxy_pending_entry"`) z pełnym `provenance` w celu późniejszego wykorzystania jako durable pending marker.

### Description
- Dodano dwa testy w `tests/ai/test_trading_opportunity_engine.py`: `test_opportunity_shadow_repository_persists_pending_entry_marker_with_provenance` oraz `test_opportunity_shadow_repository_distinguishes_pending_entry_from_pending_exit_marker`.
- Testy zapisują `OpportunityOutcomeLabel` z `label_quality="execution_proxy_pending_entry"` i pełnym słownikiem `provenance`, ponownie otwierają `OpportunityShadowRepository` i weryfikują, że `label_quality` jest wolnym stringiem, `provenance` zachowuje wymagane pola oraz że marker entry można odróżnić od exit po `label_quality` + `provenance` (np. `side`, `order_id`).
- Nie wprowadzono zmian w produkcyjnym kodzie poza dodaniem testów i zachowano brak zmian w kontrolerze/API/migracji.

### Testing
- Uruchomiono instalację testowych zależności `PYENV_VERSION=3.11.14 python -m pip install -e '.[test]'` i sprawdzono `numpy` (`PYENV_VERSION=3.11.14 python -c "import numpy; print(numpy.__version__)"`) — `2.4.4` sukces.
- Uruchomiono jednostkowe proof node'y: `PYENV_VERSION=3.11.14 python -m pytest -q tests/ai/test_trading_opportunity_engine.py::test_opportunity_shadow_repository_persists_pending_entry_marker_with_provenance tests/ai/test_trading_opportunity_engine.py::test_opportunity_shadow_repository_distinguishes_pending_entry_from_pending_exit_marker` — wynik: `2 passed`.
- Uruchomiono wybrane regresje pending/restart node'y: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py::test_autonomous_open_pending_replay_does_not_submit_duplicate_order tests/test_trading_controller.py::test_autonomous_open_pending_same_symbol_different_correlation_does_not_submit_duplicate_order tests/test_trading_controller.py::test_autonomous_open_pending_like_statuses_reserve_replay_guard tests/test_trading_controller.py::test_pending_open_same_correlation_after_controller_restart_current_contract tests/test_trading_controller.py::test_pending_open_same_symbol_different_correlation_after_controller_restart_current_contract tests/test_trading_controller.py::test_pending_close_after_controller_restart_current_contract_duplicates_despite_proxy_label tests/test_trading_controller.py::test_rejected_open_after_controller_restart_allows_retry` — wynik: `11 passed`.
- Uruchomiono szeroki selector: `PYENV_VERSION=3.11.14 python -m pytest -q tests/test_trading_controller.py -k "opportunity_autonomy or autonomy or pending or submitted or accepted or open_order or resting or duplicate or replay or restart or restored or recovery or durable or persistence or idempotent or client_order_id or order_id or order_execution_result or rejected or canceled or reconciliation or account_snapshot or account or snapshot or exposure or position or quantity or notional or mismatch or last_mile or after_risk or event or journal or submitted or executed or partially_executed or lineage or provenance or foreign or scope or portfolio or environment or symbol or filled or nonfilled or close or exit or open or risk or execution or enforcement or tracker or correlation or attach or label"` — wynik: `1041 passed, 28 deselected`.
- Commit z testami: `3978c9d` i finalny `git status --short` jest czysty.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb822def38832a9e0cba7febb9812f)