### PR TITLE
chore: zastosuj formatowanie ruff w testach trading opportunity engine

### DIFF
--- a/tests/ai/test_trading_opportunity_engine.py
+++ b/tests/ai/test_trading_opportunity_engine.py
@@ -1386,7 +1386,9 @@ def test_outcome_label_attach_allows_upgrade_proxy_to_partial_to_final(tmp_path)
     assert labels[0].label_quality == "final"
 
 
-def test_opportunity_shadow_repository_persists_pending_entry_marker_with_provenance(tmp_path) -> None:
+def test_opportunity_shadow_repository_persists_pending_entry_marker_with_provenance(
+    tmp_path,
+) -> None:
     repo = OpportunityShadowRepository(tmp_path / "shadow")
     marker = OpportunityOutcomeLabel(
         symbol="BTC/USDT",


### PR DESCRIPTION
### Motivation

- Naprawić drift formattera przez zaakceptowanie outputu `ruff format` dla pliku `tests/ai/test_trading_opportunity_engine.py`, aby pre-commit nie zgłaszał zmian.

### Description

- Zastosowano `ruff format` do `tests/ai/test_trading_opportunity_engine.py`, jedynie przełamano długą sygnaturę funkcji testowej na wielolinijkową; brak zmian logicznych, wartości oczekiwanych, konfiguracji CI ani dokumentacji.

### Testing

- Uruchomiono `python -m ruff format .` (sukces), `git diff --check` (sukces), `python -m pre_commit run --all-files --show-diff-on-failure` (niepowodzenie: `No module named pre_commit` w środowisku), oraz `python -m pytest -q tests/ai/test_trading_opportunity_engine.py -k "pending_entry_marker or outcome_label_attach" -xvv` (niepowodzenie w kolekcji testów: `ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba3e030d8832aa03dc036accdffc2)