### PR TITLE
Persist and honor durable pending OPEN markers to suppress duplicate autonomous opens

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -583,6 +583,11 @@ class TradingController:
         repr=False,
         default_factory=dict,
     )
+    _pending_autonomous_open_signatures_by_key: dict[str, tuple[str, str, str, str]] = field(
+        init=False,
+        repr=False,
+        default_factory=dict,
+    )
 
     def __post_init__(self) -> None:
         self.performance_guard_recent_final_window_size = _validate_optional_positive_int(
@@ -710,7 +715,9 @@ class TradingController:
         self._opportunity_open_outcomes = {}
         self._pending_autonomous_order_replays = set()
         self._pending_autonomous_open_signatures = {}
+        self._pending_autonomous_open_signatures_by_key = {}
         self._restore_opportunity_open_outcomes()
+        self._restore_pending_autonomous_open_guards()
 
     def _restore_opportunity_open_outcomes(self) -> None:
         repository = self._opportunity_shadow_repository
@@ -806,6 +813,34 @@ class TradingController:
                 portfolio_scope=restored_portfolio or None,
                 restored_from_repository=True,
             )
+
+    def _restore_pending_autonomous_open_guards(self) -> None:
+        repository = self._opportunity_shadow_repository
+        if repository is None:
+            return
+        try:
+            labels = repository.load_outcome_labels()
+        except Exception:  # pragma: no cover - diagnostics only
+            return
+        for label in labels:
+            if str(label.label_quality).strip() != "execution_proxy_pending_entry":
+                continue
+            provenance = label.provenance if isinstance(label.provenance, Mapping) else {}
+            order_id = str(provenance.get("order_id") or "").strip()
+            status = _normalize_execution_status(provenance.get("execution_status"))
+            if not order_id or status not in _PENDING_EXECUTION_STATUSES:
+                continue
+            correlation_key = str(label.correlation_key).strip()
+            symbol = str(label.symbol).strip()
+            side = str(provenance.get("side") or "").strip().upper()
+            environment = str(provenance.get("environment") or "").strip()
+            portfolio = str(provenance.get("portfolio") or "").strip()
+            if not correlation_key or not symbol or side not in _BUY_SIDES | _SELL_SIDES:
+                continue
+            self._pending_autonomous_order_replays.add(correlation_key)
+            signature = (environment, portfolio, symbol, side)
+            self._pending_autonomous_open_signatures[signature] = correlation_key
+            self._pending_autonomous_open_signatures_by_key[correlation_key] = signature
 
     def _persist_open_outcome_tracker(self, tracker: _OpportunityOpenOutcomeTracker) -> None:
         repository = self._opportunity_shadow_repository
@@ -3335,9 +3370,11 @@ class TradingController:
                 },
             )
             return None
-        if self._is_pending_autonomous_order_replay(
-            request=request, correlation_key=correlation_key
-        ):
+        pending_replay_reason = self._pending_autonomous_order_replay_reason(
+            request=request,
+            correlation_key=correlation_key,
+        )
+        if pending_replay_reason is not None:
             self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
             self._record_decision_event(
                 "signal_skipped",
@@ -3345,7 +3382,7 @@ class TradingController:
                 request=request,
                 status="skipped",
                 metadata={
-                    "reason": "pending_autonomous_order_replay_suppressed",
+                    "reason": pending_replay_reason,
                     "proxy_correlation_key": correlation_key,
                 },
             )
@@ -3633,20 +3670,22 @@ class TradingController:
         self._handle_liquidation_state(risk_result)
         return result
 
-    def _is_pending_autonomous_order_replay(
+    def _pending_autonomous_order_replay_reason(
         self, *, request: OrderRequest, correlation_key: str
-    ) -> bool:
+    ) -> str | None:
         if not correlation_key:
-            return False
-        if not self._is_autonomous_order_request(request):
-            return False
-        if correlation_key in self._pending_autonomous_order_replays:
-            return True
+            return None
         pending_signature = self._pending_autonomous_open_signature(request=request)
-        if pending_signature is None:
-            return False
-        pending_correlation_key = self._pending_autonomous_open_signatures.get(pending_signature)
-        return bool(pending_correlation_key and pending_correlation_key != correlation_key)
+        if pending_signature is not None:
+            stored_signature = self._pending_autonomous_open_signatures_by_key.get(correlation_key)
+            if stored_signature is not None and stored_signature == pending_signature:
+                return "pending_autonomous_order_durable_replay_suppressed"
+            pending_correlation_key = self._pending_autonomous_open_signatures.get(pending_signature)
+            if pending_correlation_key and pending_correlation_key != correlation_key:
+                return "pending_autonomous_order_durable_symbol_replay_suppressed"
+        if pending_signature is None and correlation_key in self._pending_autonomous_order_replays:
+            return "pending_autonomous_order_replay_suppressed"
+        return None
 
     def _update_pending_autonomous_order_replay_state(
         self,
@@ -3668,6 +3707,13 @@ class TradingController:
             pending_signature = self._pending_autonomous_open_signature(request=request)
             if pending_signature is not None:
                 self._pending_autonomous_open_signatures[pending_signature] = correlation_key
+                self._pending_autonomous_open_signatures_by_key[correlation_key] = pending_signature
+            self._persist_pending_autonomous_open_marker(
+                request=request,
+                correlation_key=correlation_key,
+                normalized_status=normalized_status,
+                order_id=str(result.order_id or "").strip(),
+            )
             return
         self._pending_autonomous_order_replays.discard(correlation_key)
         self._pending_autonomous_open_signatures = {
@@ -3675,6 +3721,56 @@ class TradingController:
             for signature, tracked_key in self._pending_autonomous_open_signatures.items()
             if tracked_key != correlation_key
         }
+        self._pending_autonomous_open_signatures_by_key.pop(correlation_key, None)
+
+    def _persist_pending_autonomous_open_marker(
+        self,
+        *,
+        request: OrderRequest,
+        correlation_key: str,
+        normalized_status: str,
+        order_id: str,
+    ) -> None:
+        repository = self._opportunity_shadow_repository
+        if repository is None:
+            return
+        signature = self._pending_autonomous_open_signature(request=request)
+        if signature is None:
+            return
+        environment, portfolio, symbol, side = signature
+        request_metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        timestamp_raw = request_metadata.get("opportunity_decision_timestamp")
+        timestamp_utc = datetime.now(timezone.utc)
+        if timestamp_raw is not None:
+            try:
+                parsed = datetime.fromisoformat(str(timestamp_raw))
+                timestamp_utc = parsed.astimezone(timezone.utc) if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+            except ValueError:
+                pass
+        marker = OpportunityOutcomeLabel(
+            symbol=symbol,
+            decision_timestamp=timestamp_utc,
+            correlation_key=correlation_key,
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            provenance={
+                "source": "trading_controller_execution_result",
+                "order_id": order_id,
+                "execution_status": normalized_status,
+                "symbol": symbol,
+                "side": side,
+                "environment": environment,
+                "portfolio": portfolio,
+                "correlation_key": correlation_key,
+            },
+            label_quality="execution_proxy_pending_entry",
+        )
+        try:
+            repository.attach_outcome_labels_idempotent([marker])
+        except Exception:  # pragma: no cover - diagnostics only
+            _LOGGER.debug("Nie udało się zapisać pending OPEN marker", exc_info=True)
 
     def _is_autonomous_order_request(self, request: OrderRequest) -> bool:
         request_metadata = request.metadata if isinstance(request.metadata, Mapping) else {}

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -711,6 +711,7 @@ def _build_autonomy_controller_with_risk(
     risk_engine: DummyRiskEngine,
     execution_service: ExecutionService | None = None,
     opportunity_shadow_repository: OpportunityShadowRepository | None = None,
+    portfolio_id: str | None = None,
 ) -> tuple[TradingController, ExecutionService, CollectingDecisionJournal]:
     execution = execution_service or DummyExecutionService()
     router, _channel, _audit = _router_with_channel()
@@ -720,7 +721,7 @@ def _build_autonomy_controller_with_risk(
         execution_service=execution,
         alert_router=router,
         account_snapshot_provider=_account_snapshot,
-        portfolio_id=f"{environment}-1",
+        portfolio_id=portfolio_id or f"{environment}-1",
         environment=environment,
         risk_profile="balanced",
         decision_journal=journal,
@@ -49960,7 +49961,14 @@ def test_opportunity_autonomous_open_non_filled_status_does_not_create_open_trac
     assert open_outcomes[0].entry_quantity == pytest.approx(1.0, rel=1e-6)
 
     labels = shadow_repo.load_outcome_labels()
-    assert [row for row in labels if row.correlation_key == first_key] == []
+    if open_status == "pending":
+        assert any(
+            row.correlation_key == first_key
+            and row.label_quality == "execution_proxy_pending_entry"
+            for row in labels
+        )
+    else:
+        assert [row for row in labels if row.correlation_key == first_key] == []
 
     skipped_events = [
         event
@@ -50871,7 +50879,8 @@ def test_opportunity_autonomous_open_unrecognized_non_fill_zero_fill_does_not_cr
     controller.process_signals([open_signal])
 
     labels = shadow_repo.load_outcome_labels()
-    assert labels == []
+    assert len(labels) == 1
+    assert labels[0].label_quality == "execution_proxy_pending_entry"
     assert shadow_repo.load_open_outcomes() == []
 
 
@@ -50916,7 +50925,11 @@ def test_autonomous_open_pending_replay_does_not_submit_duplicate_order(tmp_path
     assert len(execution.requests) == 1
     assert len(risk_engine.last_checks) == 1
     assert repository.load_open_outcomes() == []
-    assert repository.load_outcome_labels() == []
+    assert any(
+        row.label_quality == "execution_proxy_pending_entry"
+        and row.correlation_key == correlation_key
+        for row in repository.load_outcome_labels()
+    )
     order_events = _order_path_events_with_shadow_key(journal, correlation_key)
     assert not any(
         event.get("event") in {"order_executed", "order_partially_executed"}
@@ -50928,7 +50941,7 @@ def test_autonomous_open_pending_replay_does_not_submit_duplicate_order(tmp_path
     )
     assert any(
         event.get("event") == "signal_skipped"
-        and event.get("reason") == "pending_autonomous_order_replay_suppressed"
+        and event.get("reason") == "pending_autonomous_order_durable_replay_suppressed"
         for event in journal.export()
     )
 
@@ -50997,7 +51010,11 @@ def test_autonomous_open_pending_same_symbol_different_correlation_does_not_subm
     assert second == []
     assert len(execution.requests) == 1
     assert repository.load_open_outcomes() == []
-    assert repository.load_outcome_labels() == []
+    assert any(
+        row.label_quality == "execution_proxy_pending_entry"
+        and row.correlation_key == correlation_key_a
+        for row in repository.load_outcome_labels()
+    )
     order_events_b = _order_path_events_with_shadow_key(journal, correlation_key_b)
     assert not any(
         event.get("event") in {"order_executed", "order_partially_executed"}
@@ -51005,7 +51022,7 @@ def test_autonomous_open_pending_same_symbol_different_correlation_does_not_subm
     )
     assert any(
         event.get("event") == "signal_skipped"
-        and event.get("reason") == "pending_autonomous_order_replay_suppressed"
+        and event.get("reason") == "pending_autonomous_order_durable_symbol_replay_suppressed"
         and event.get("proxy_correlation_key") == correlation_key_b
         for event in journal.export()
     )
@@ -51060,7 +51077,11 @@ def test_autonomous_open_pending_like_statuses_reserve_replay_guard(
     assert second == []
     assert len(execution.requests) == 1
     assert repository.load_open_outcomes() == []
-    assert repository.load_outcome_labels() == []
+    assert any(
+        row.label_quality == "execution_proxy_pending_entry"
+        and row.correlation_key == correlation_key
+        for row in repository.load_outcome_labels()
+    )
     key_events = _order_path_events_with_shadow_key(journal, correlation_key)
     assert not any(
         event.get("event") in {"order_executed", "order_partially_executed"} for event in key_events
@@ -51071,12 +51092,12 @@ def test_autonomous_open_pending_like_statuses_reserve_replay_guard(
     )
     assert any(
         event.get("event") == "signal_skipped"
-        and event.get("reason") == "pending_autonomous_order_replay_suppressed"
+        and event.get("reason") == "pending_autonomous_order_durable_replay_suppressed"
         for event in journal.export()
     )
 
 
-def test_pending_open_same_correlation_after_controller_restart_current_contract(
+def test_pending_open_same_correlation_after_controller_restart_blocks_with_durable_marker(
     tmp_path: Path,
 ) -> None:
     decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
@@ -51122,17 +51143,23 @@ def test_pending_open_same_correlation_after_controller_restart_current_contract
         opportunity_shadow_repository=repository,
     )
     replay = controller_b.process_signals([signal])
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
 
-    assert [row.status for row in replay] == ["filled"]
-    assert len(execution_b.requests) == 1
-    assert not any(
+    assert replay == []
+    assert execution_b.requests == []
+    assert any(row.label_quality == "execution_proxy_pending_entry" for row in labels)
+    assert repository.load_open_outcomes() == []
+    assert not any(row.label_quality.startswith("final") for row in labels)
+    assert not any(row.label_quality == "partial_exit_unconfirmed" for row in labels)
+    assert not any(row.label_quality == "execution_proxy_pending_exit" for row in labels)
+    assert any(
         event.get("event") == "signal_skipped"
-        and event.get("reason") == "pending_autonomous_order_replay_suppressed"
+        and event.get("reason") == "pending_autonomous_order_durable_replay_suppressed"
         for event in journal_b.export()
     )
 
 
-def test_pending_open_same_symbol_different_correlation_after_controller_restart_current_contract(
+def test_pending_open_same_symbol_different_correlation_after_controller_restart_blocks_with_durable_marker(
     tmp_path: Path,
 ) -> None:
     decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
@@ -51193,12 +51220,205 @@ def test_pending_open_same_symbol_different_correlation_after_controller_restart
         decision_timestamp=decision_timestamp,
     )
     replay = controller_b.process_signals([signal_b])
+    labels_b = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key_b]
 
-    assert [row.status for row in replay] == ["filled"]
+    assert replay == []
+    assert execution_b.requests == []
+    assert labels_b == []
+    assert not any(row.correlation_key == correlation_key_b for row in repository.load_open_outcomes())
+    assert any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "pending_autonomous_order_durable_symbol_replay_suppressed"
+        for event in journal_b.export()
+    )
+
+
+def test_pending_open_rejected_after_controller_restart_allows_retry_without_durable_marker(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = OpportunityShadowRepository(tmp_path / "shadow")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    execution_a = SequencedExecutionService(
+        [{"status": "rejected", "order_id": "reject-A", "filled_quantity": 0.0, "avg_price": None}]
+    )
+    controller_a, _ea, _ja = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    assert [row.status for row in controller_a.process_signals([signal])] == ["rejected"]
+    assert not any(
+        row.label_quality == "execution_proxy_pending_entry"
+        for row in repository.load_outcome_labels()
+    )
+    execution_b = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+    )
+    controller_b, _eb, _jb = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_b,
+        opportunity_shadow_repository=repository,
+    )
+    retry = controller_b.process_signals([signal])
+    assert [row.status for row in retry] == ["filled"]
+    assert len(execution_b.requests) == 1
+
+
+def test_pending_open_durable_marker_foreign_environment_same_correlation_does_not_block_current_scope(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    correlation_key = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    repository = OpportunityShadowRepository(tmp_path / "shadow")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                correlation_key=correlation_key,
+                horizon_minutes=0,
+                realized_return_bps=0.0,
+                max_favorable_excursion_bps=0.0,
+                max_adverse_excursion_bps=0.0,
+                provenance={
+                    "order_id": "foreign-pending-open",
+                    "execution_status": "pending",
+                    "symbol": "BTC/USDT",
+                    "side": "BUY",
+                    "environment": "live",
+                    "portfolio": "live-1",
+                    "correlation_key": correlation_key,
+                },
+                label_quality="execution_proxy_pending_entry",
+            )
+        ]
+    )
+    execution_b = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}])
+    controller_b, journal_b = _build_autonomy_controller_with_execution(
+        environment="paper",
+        execution_service=execution_b,
+        opportunity_shadow_repository=repository,
+    )
+    signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    result = controller_b.process_signals([signal])
+    assert [row.status for row in result] == ["filled"]
     assert len(execution_b.requests) == 1
     assert not any(
         event.get("event") == "signal_skipped"
-        and event.get("reason") == "pending_autonomous_order_replay_suppressed"
+        and event.get("reason") == "pending_autonomous_order_durable_replay_suppressed"
+        for event in journal_b.export()
+    )
+
+
+def test_pending_open_durable_marker_foreign_portfolio_same_symbol_different_key_does_not_block_current_scope(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    key_a = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=1,
+    )
+    key_b = OpportunityShadowRecord.build_record_key(
+        symbol="BTC/USDT",
+        decision_timestamp=decision_timestamp,
+        model_version="opportunity-v1",
+        rank=2,
+    )
+    repository = OpportunityShadowRepository(tmp_path / "shadow")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(correlation_key=key_a, decision_timestamp=decision_timestamp),
+            _shadow_record_for_key(correlation_key=key_b, decision_timestamp=decision_timestamp),
+        ]
+    )
+    repository.append_outcome_labels(
+        [
+            OpportunityOutcomeLabel(
+                symbol="BTC/USDT",
+                decision_timestamp=decision_timestamp,
+                correlation_key=key_a,
+                horizon_minutes=0,
+                realized_return_bps=0.0,
+                max_favorable_excursion_bps=0.0,
+                max_adverse_excursion_bps=0.0,
+                provenance={
+                    "order_id": "pending-portfolio-a",
+                    "execution_status": "pending",
+                    "symbol": "BTC/USDT",
+                    "side": "BUY",
+                    "environment": "paper",
+                    "portfolio": "portfolio-A",
+                    "correlation_key": key_a,
+                },
+                label_quality="execution_proxy_pending_entry",
+            )
+        ]
+    )
+    execution_b = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}])
+    controller_b, _execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        portfolio_id="portfolio-B",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_b,
+        opportunity_shadow_repository=repository,
+    )
+    signal_b = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=key_b,
+        decision_timestamp=decision_timestamp,
+    )
+    result = controller_b.process_signals([signal_b])
+    assert result == []
+    assert len(execution_b.requests) == 0
+    enforcement_events = [
+        event for event in journal_b.export() if event.get("event") == "opportunity_autonomy_enforcement"
+    ]
+    assert enforcement_events
+    assert (
+        enforcement_events[-1].get("blocking_reason")
+        == "accepted_autonomous_handoff_shadow_reference_scope_mismatch"
+    )
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "pending_autonomous_order_durable_replay_suppressed"
+        for event in journal_b.export()
+    )
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "pending_autonomous_order_durable_symbol_replay_suppressed"
         for event in journal_b.export()
     )
 
@@ -51274,6 +51494,52 @@ def test_pending_close_after_controller_restart_current_contract_duplicates_desp
     replay = controller_b.process_signals([close_signal])
     assert [row.status for row in replay] == ["filled"]
     assert len(execution_b.requests) == 1
+
+
+def test_pending_close_same_process_replay_keeps_non_durable_reason(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
+    correlation_key = "pending-close-same-process-nondurable-reason"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+    )
+    execution = SequencedExecutionService(
+        [
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+            {"status": "pending", "order_id": "close-pending-1", "filled_quantity": 0.0, "avg_price": None},
+            {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0},
+        ]
+    )
+    controller, _ex, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution,
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {**dict(close_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller.process_signals([open_signal])] == ["filled"]
+    assert [row.status for row in controller.process_signals([close_signal])] == ["pending"]
+    replay = controller.process_signals([close_signal])
+    assert replay == []
+    assert len(execution.requests) == 2
+    skip_events = [event for event in journal.export() if event.get("event") == "signal_skipped"]
+    assert any(event.get("reason") == "pending_autonomous_order_replay_suppressed" for event in skip_events)
+    assert not any(
+        str(event.get("reason", "")).startswith("pending_autonomous_order_durable")
+        for event in skip_events
+    )
 
 
 def test_rejected_open_after_controller_restart_allows_retry(tmp_path: Path) -> None:
@@ -51367,7 +51633,7 @@ def test_autonomous_open_rejected_result_allows_retry_without_pending_suppressio
     assert len(risk_engine.last_checks) == 2
     assert not any(
         event.get("event") == "signal_skipped"
-        and event.get("reason") == "pending_autonomous_order_replay_suppressed"
+        and event.get("reason").startswith("pending_autonomous_order_durable")
         for event in journal.export()
     )
 


### PR DESCRIPTION
### Motivation

- Prevent duplicate autonomous OPEN orders being submitted after controller restarts by durable registration of pending opens and more precise suppression reasons.

### Description

- Added a new field `self._pending_autonomous_open_signatures_by_key` to track the pending signature keyed by `correlation_key` and a corresponding restoration path in `._restore_pending_autonomous_open_guards` that loads `execution_proxy_pending_entry` labels from the repository and reconstructs in-memory guards.
- Replaced boolean check `._is_pending_autonomous_order_replay` with `._pending_autonomous_order_replay_reason` to return descriptive suppression reasons and added logic to consult both signature->key and key->signature mappings to distinguish durable symbol-level vs durable-key-level suppression.
- Persist pending open markers with `._persist_pending_autonomous_open_marker` when an autonomous open request enters a pending-like execution status, and update `._update_pending_autonomous_order_replay_state` to maintain both signature maps and call the persister.
- Updated unit tests in `tests/test_trading_controller.py` to reflect durable marker behavior and added new tests covering restart scenarios, cross-environment/portfolio scope rules, and non-durable vs durable pending handling.

### Testing

- Ran the trading controller unit tests in `tests/test_trading_controller.py` (via `pytest tests/test_trading_controller.py`), which exercise pending/open replay and restart scenarios. 
- New and modified tests include assertions for `execution_proxy_pending_entry` markers and new skip reasons such as `pending_autonomous_order_durable_replay_suppressed` and `pending_autonomous_order_durable_symbol_replay_suppressed`. 
- All modified tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb89b07d64832a957ab2cf7e61639e)