### PR TITLE
Zaakceptuj output `ruff format` w controllerze i testach trading_controller

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -3680,7 +3680,9 @@ class TradingController:
             stored_signature = self._pending_autonomous_open_signatures_by_key.get(correlation_key)
             if stored_signature is not None and stored_signature == pending_signature:
                 return "pending_autonomous_order_durable_replay_suppressed"
-            pending_correlation_key = self._pending_autonomous_open_signatures.get(pending_signature)
+            pending_correlation_key = self._pending_autonomous_open_signatures.get(
+                pending_signature
+            )
             if pending_correlation_key and pending_correlation_key != correlation_key:
                 return "pending_autonomous_order_durable_symbol_replay_suppressed"
         if pending_signature is None and correlation_key in self._pending_autonomous_order_replays:
@@ -3744,7 +3746,11 @@ class TradingController:
         if timestamp_raw is not None:
             try:
                 parsed = datetime.fromisoformat(str(timestamp_raw))
-                timestamp_utc = parsed.astimezone(timezone.utc) if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+                timestamp_utc = (
+                    parsed.astimezone(timezone.utc)
+                    if parsed.tzinfo
+                    else parsed.replace(tzinfo=timezone.utc)
+                )
             except ValueError:
                 pass
         marker = OpportunityOutcomeLabel(

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -51143,7 +51143,9 @@ def test_pending_open_same_correlation_after_controller_restart_blocks_with_dura
         opportunity_shadow_repository=repository,
     )
     replay = controller_b.process_signals([signal])
-    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key]
+    labels = [
+        row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key
+    ]
 
     assert replay == []
     assert execution_b.requests == []
@@ -51220,12 +51222,16 @@ def test_pending_open_same_symbol_different_correlation_after_controller_restart
         decision_timestamp=decision_timestamp,
     )
     replay = controller_b.process_signals([signal_b])
-    labels_b = [row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key_b]
+    labels_b = [
+        row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key_b
+    ]
 
     assert replay == []
     assert execution_b.requests == []
     assert labels_b == []
-    assert not any(row.correlation_key == correlation_key_b for row in repository.load_open_outcomes())
+    assert not any(
+        row.correlation_key == correlation_key_b for row in repository.load_open_outcomes()
+    )
     assert any(
         event.get("event") == "signal_skipped"
         and event.get("reason") == "pending_autonomous_order_durable_symbol_replay_suppressed"
@@ -51245,7 +51251,11 @@ def test_pending_open_rejected_after_controller_restart_allows_retry_without_dur
     )
     repository = OpportunityShadowRepository(tmp_path / "shadow")
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     execution_a = SequencedExecutionService(
         [{"status": "rejected", "order_id": "reject-A", "filled_quantity": 0.0, "avg_price": None}]
@@ -51293,7 +51303,11 @@ def test_pending_open_durable_marker_foreign_environment_same_correlation_does_n
     )
     repository = OpportunityShadowRepository(tmp_path / "shadow")
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     repository.append_outcome_labels(
         [
@@ -51318,7 +51332,9 @@ def test_pending_open_durable_marker_foreign_environment_same_correlation_does_n
             )
         ]
     )
-    execution_b = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}])
+    execution_b = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+    )
     controller_b, journal_b = _build_autonomy_controller_with_execution(
         environment="paper",
         execution_service=execution_b,
@@ -51386,7 +51402,9 @@ def test_pending_open_durable_marker_foreign_portfolio_same_symbol_different_key
             )
         ]
     )
-    execution_b = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}])
+    execution_b = SequencedExecutionService(
+        [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+    )
     controller_b, _execution_b, journal_b = _build_autonomy_controller_with_risk(
         environment="paper",
         portfolio_id="portfolio-B",
@@ -51404,7 +51422,9 @@ def test_pending_open_durable_marker_foreign_portfolio_same_symbol_different_key
     assert result == []
     assert len(execution_b.requests) == 0
     enforcement_events = [
-        event for event in journal_b.export() if event.get("event") == "opportunity_autonomy_enforcement"
+        event
+        for event in journal_b.export()
+        if event.get("event") == "opportunity_autonomy_enforcement"
     ]
     assert enforcement_events
     assert (
@@ -51501,12 +51521,21 @@ def test_pending_close_same_process_replay_keeps_non_durable_reason(tmp_path: Pa
     correlation_key = "pending-close-same-process-nondurable-reason"
     repository = OpportunityShadowRepository(tmp_path / "shadow.db")
     repository.append_shadow_records(
-        [_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)]
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
     )
     execution = SequencedExecutionService(
         [
             {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
-            {"status": "pending", "order_id": "close-pending-1", "filled_quantity": 0.0, "avg_price": None},
+            {
+                "status": "pending",
+                "order_id": "close-pending-1",
+                "filled_quantity": 0.0,
+                "avg_price": None,
+            },
             {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0},
         ]
     )
@@ -51535,7 +51564,9 @@ def test_pending_close_same_process_replay_keeps_non_durable_reason(tmp_path: Pa
     assert replay == []
     assert len(execution.requests) == 2
     skip_events = [event for event in journal.export() if event.get("event") == "signal_skipped"]
-    assert any(event.get("reason") == "pending_autonomous_order_replay_suppressed" for event in skip_events)
+    assert any(
+        event.get("reason") == "pending_autonomous_order_replay_suppressed" for event in skip_events
+    )
     assert not any(
         str(event.get("reason", "")).startswith("pending_autonomous_order_durable")
         for event in skip_events


### PR DESCRIPTION
### Motivation
- Naprawić formatter-only drift zgłoszony przez pre-commit przez zaakceptowanie zmian wygenerowanych przez `ruff format` w zakresie wskazanych plików.
- Zmiany są wyłącznie stylistyczne i nie powinny wpływać na logikę produkcyjną ani wartości oczekiwane w testach.

### Description
- Zastosowano output `ruff format` w `bot_core/runtime/controller.py` (złamania długich wyrażeń przypisań/warunków).
- Zastosowano output `ruff format` w `tests/test_trading_controller.py` (wieloliniowe list comprehensions, literal dict/list i rozbicia wywołań).
- Nie wprowadzono ręcznych zmian logiki ani modyfikacji oczekiwanych wartości testów.
- Zmiany zostały zakomitowane (`d642eb7`).

### Testing
- Uruchomiono `python -m ruff format .` i formatowanie zakończyło się sukcesem.
- Uruchomiono `git diff --check` i nie wykryto problemów związanych z białymi znakami.
- Próba uruchomienia `python -m pre_commit run --all-files --show-diff-on-failure` zakończyła się niepowodzeniem w tym środowisku z powodu braku modułu: `No module named pre_commit`.
- Uruchomiono targeted smoke: `python -m pytest -q tests/test_trading_controller.py -k "pending_open or pending_close" -xvv`, który przerwał się przy kolekcji z powodu brakującej zależności environmentowej: `ModuleNotFoundError: No module named 'numpy'`.
- Commit został wykonany i PR utworzony; walidacja pre-commit/pytest wymaga uzupełnienia zależności w środowisku CI/local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1a82f170832a8098f49375b3d471)