### PR TITLE
Trwały pending CLOSE marker: zapis przez append i blokada replay po restarcie

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -588,6 +588,11 @@ class TradingController:
         repr=False,
         default_factory=dict,
     )
+    _pending_autonomous_close_replays: set[tuple[str, str, str]] = field(
+        init=False,
+        repr=False,
+        default_factory=set,
+    )
 
     def __post_init__(self) -> None:
         self.performance_guard_recent_final_window_size = _validate_optional_positive_int(
@@ -716,8 +721,10 @@ class TradingController:
         self._pending_autonomous_order_replays = set()
         self._pending_autonomous_open_signatures = {}
         self._pending_autonomous_open_signatures_by_key = {}
+        self._pending_autonomous_close_replays = set()
         self._restore_opportunity_open_outcomes()
         self._restore_pending_autonomous_open_guards()
+        self._restore_pending_autonomous_close_guards()
 
     def _restore_opportunity_open_outcomes(self) -> None:
         repository = self._opportunity_shadow_repository
@@ -841,6 +848,37 @@ class TradingController:
             signature = (environment, portfolio, symbol, side)
             self._pending_autonomous_open_signatures[signature] = correlation_key
             self._pending_autonomous_open_signatures_by_key[correlation_key] = signature
+
+    def _restore_pending_autonomous_close_guards(self) -> None:
+        repository = self._opportunity_shadow_repository
+        if repository is None:
+            return
+        try:
+            labels = repository.load_outcome_labels()
+        except Exception:  # pragma: no cover - diagnostics only
+            return
+        for label in labels:
+            if str(label.label_quality).strip() != "execution_proxy_pending_close":
+                continue
+            provenance = label.provenance if isinstance(label.provenance, Mapping) else {}
+            order_id = str(provenance.get("order_id") or "").strip()
+            status = _normalize_execution_status(provenance.get("execution_status"))
+            correlation_key = str(label.correlation_key).strip()
+            symbol = str(label.symbol).strip()
+            side = str(provenance.get("side") or "").strip().upper()
+            environment = str(provenance.get("environment") or "").strip()
+            portfolio = str(provenance.get("portfolio") or "").strip()
+            if (
+                not order_id
+                or status not in _PENDING_EXECUTION_STATUSES
+                or not correlation_key
+                or not symbol
+                or side not in _BUY_SIDES | _SELL_SIDES
+                or environment != self.environment
+                or portfolio != self.portfolio_id
+            ):
+                continue
+            self._pending_autonomous_close_replays.add((correlation_key, symbol, side))
 
     def _persist_open_outcome_tracker(self, tracker: _OpportunityOpenOutcomeTracker) -> None:
         repository = self._opportunity_shadow_repository
@@ -3387,6 +3425,23 @@ class TradingController:
                 },
             )
             return None
+        pending_close_durable_reason = self._pending_autonomous_close_replay_reason(
+            request=request,
+            correlation_key=correlation_key,
+        )
+        if pending_close_durable_reason is not None:
+            self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+            self._record_decision_event(
+                "signal_skipped",
+                signal=signal,
+                request=request,
+                status="skipped",
+                metadata={
+                    "reason": pending_close_durable_reason,
+                    "proxy_correlation_key": correlation_key,
+                },
+            )
+            return None
         account = self.account_snapshot_provider()
         risk_result = self.risk_engine.apply_pre_trade_checks(
             request,
@@ -3771,6 +3826,84 @@ class TradingController:
             repository.attach_outcome_labels_idempotent([marker])
         except Exception:  # pragma: no cover - diagnostics only
             _LOGGER.debug("Nie udało się zapisać pending OPEN marker", exc_info=True)
+
+    def _pending_autonomous_close_replay_reason(
+        self,
+        *,
+        request: OrderRequest,
+        correlation_key: str,
+    ) -> str | None:
+        if not self._is_autonomous_order_request(request):
+            return None
+        if not correlation_key:
+            return None
+        symbol = str(request.symbol or "").strip()
+        side = str(request.side or "").strip().upper()
+        if not symbol or side not in _BUY_SIDES | _SELL_SIDES:
+            return None
+        if (correlation_key, symbol, side) in self._pending_autonomous_close_replays:
+            return "pending_autonomous_close_durable_replay_suppressed"
+        return None
+
+    def _persist_pending_autonomous_close_marker(
+        self,
+        *,
+        request: OrderRequest,
+        correlation_key: str,
+        normalized_status: str,
+        order_id: str,
+    ) -> None:
+        repository = self._opportunity_shadow_repository
+        if repository is None or not self._is_autonomous_order_request(request):
+            return
+        symbol = str(request.symbol or "").strip()
+        side = str(request.side or "").strip().upper()
+        if not correlation_key or not symbol or side not in _BUY_SIDES | _SELL_SIDES:
+            return
+        try:
+            labels = repository.load_outcome_labels()
+        except Exception:  # pragma: no cover - diagnostics only
+            _LOGGER.debug("Nie udało się odczytać outcome labels dla pending CLOSE marker", exc_info=True)
+            labels = []
+        for label in labels:
+            if str(label.label_quality).strip() != "execution_proxy_pending_close":
+                continue
+            provenance = label.provenance if isinstance(label.provenance, Mapping) else {}
+            if (
+                str(label.correlation_key).strip() == correlation_key
+                and str(provenance.get("order_id") or "").strip() == order_id
+                and _normalize_execution_status(provenance.get("execution_status")) in _PENDING_EXECUTION_STATUSES
+                and str(provenance.get("side") or "").strip().upper() == side
+                and str(provenance.get("environment") or "").strip() == self.environment
+                and str(provenance.get("portfolio") or "").strip() == self.portfolio_id
+            ):
+                self._pending_autonomous_close_replays.add((correlation_key, symbol, side))
+                return
+        marker = OpportunityOutcomeLabel(
+            symbol=symbol,
+            decision_timestamp=self._clock().astimezone(timezone.utc),
+            correlation_key=correlation_key,
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            provenance={
+                "source": "trading_controller_execution_result",
+                "order_id": order_id,
+                "execution_status": normalized_status,
+                "symbol": symbol,
+                "side": side,
+                "environment": self.environment,
+                "portfolio": self.portfolio_id,
+                "correlation_key": correlation_key,
+            },
+            label_quality="execution_proxy_pending_close",
+        )
+        try:
+            repository.append_outcome_labels([marker])
+            self._pending_autonomous_close_replays.add((correlation_key, symbol, side))
+        except Exception:  # pragma: no cover - diagnostics only
+            _LOGGER.debug("Nie udało się zapisać pending CLOSE marker", exc_info=True)
 
     def _is_autonomous_order_request(self, request: OrderRequest) -> bool:
         request_metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
@@ -5797,6 +5930,24 @@ class TradingController:
                 },
                 label_quality="execution_proxy_pending_exit",
             )
+        pending_close_tracker = (
+            self._opportunity_open_outcomes.get(correlation_key) if correlation_key else None
+        )
+        if (
+            correlation_key
+            and pending_close_tracker is not None
+            and self._is_autonomous_order_request(request)
+            and self._is_closing_side(str(pending_close_tracker.side), str(request.side))
+            and normalized_status in _PENDING_EXECUTION_STATUSES
+        ):
+            pending_order_id = str(result.order_id or "").strip()
+            if pending_order_id:
+                self._persist_pending_autonomous_close_marker(
+                    request=request,
+                    correlation_key=correlation_key,
+                    normalized_status=normalized_status,
+                    order_id=pending_order_id,
+                )
 
         labels_to_attach: list[OpportunityOutcomeLabel] = []
         if proxy_label is not None:

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -51423,7 +51423,7 @@ def test_pending_open_durable_marker_foreign_portfolio_same_symbol_different_key
     )
 
 
-def test_pending_close_after_controller_restart_current_contract_duplicates_despite_proxy_label(
+def test_pending_close_after_controller_restart_blocks_with_proxy_label(
     tmp_path: Path,
 ) -> None:
     decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
@@ -51475,11 +51475,21 @@ def test_pending_close_after_controller_restart_current_contract_duplicates_desp
 
     assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
     assert [row.status for row in controller_a.process_signals([close_signal])] == ["pending"]
-    assert any(
-        row.label_quality == "execution_proxy_pending_exit"
-        and row.correlation_key == correlation_key
-        for row in repository.load_outcome_labels()
-    )
+    labels_after_a = repository.load_outcome_labels()
+    pending_close_labels = [
+        row
+        for row in labels_after_a
+        if row.label_quality == "execution_proxy_pending_close" and row.correlation_key == correlation_key
+    ]
+    assert len(pending_close_labels) == 1
+    assert pending_close_labels[0].provenance.get("execution_status") in {"pending", "open", "accepted", "submitted", "new"}
+    assert pending_close_labels[0].provenance.get("side") == "SELL"
+    assert pending_close_labels[0].provenance.get("order_id") == "close-pending-1"
+    assert not any(row.label_quality.startswith("final") for row in labels_after_a)
+    assert not any(row.label_quality == "partial_exit_unconfirmed" for row in labels_after_a)
+    open_after_a = repository.load_open_outcomes()
+    assert len(open_after_a) == 1
+    assert open_after_a[0].closed_quantity == 0.0
 
     execution_b = SequencedExecutionService(
         [{"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0}]
@@ -51492,8 +51502,83 @@ def test_pending_close_after_controller_restart_current_contract_duplicates_desp
     )
 
     replay = controller_b.process_signals([close_signal])
+    assert replay == []
+    assert len(execution_b.requests) == 0
+    assert len(controller_b.risk_engine.last_checks) == 0
+    labels_after_b = repository.load_outcome_labels()
+    assert len([row for row in labels_after_b if row.label_quality == "execution_proxy_pending_close" and row.correlation_key == correlation_key]) == 1
+    pending_exit_count_after_a = len([row for row in labels_after_a if row.label_quality == "execution_proxy_pending_exit" and row.correlation_key == correlation_key])
+    pending_exit_count_after_b = len([row for row in labels_after_b if row.label_quality == "execution_proxy_pending_exit" and row.correlation_key == correlation_key])
+    assert not any(row.label_quality.startswith("final") for row in labels_after_b)
+    assert not any(row.label_quality == "partial_exit_unconfirmed" for row in labels_after_b)
+    assert pending_exit_count_after_b == pending_exit_count_after_a
+    open_after_b = repository.load_open_outcomes()
+    assert len(open_after_b) == 1
+    assert open_after_b[0].closed_quantity == 0.0
+    assert any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed"
+        for event in _journal_b.export()
+    )
+
+
+def test_pending_close_after_controller_restart_rejected_close_allows_retry_without_durable_close_marker(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
+    correlation_key = "pending-close-rejected-retry"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)])
+    execution_a = SequencedExecutionService([
+        {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+        {"status": "rejected", "order_id": "close-rejected-1", "filled_quantity": 0.0, "avg_price": None},
+    ])
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper", risk_engine=DummyRiskEngine(), execution_service=execution_a, opportunity_shadow_repository=repository
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    close_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=1))
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    assert [row.status for row in controller_a.process_signals([close_signal])] == ["rejected"]
+    assert not any(row.label_quality == "execution_proxy_pending_close" for row in repository.load_outcome_labels())
+    execution_b = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0}])
+    controller_b, _execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper", risk_engine=DummyRiskEngine(), execution_service=execution_b, opportunity_shadow_repository=repository
+    )
+    replay = controller_b.process_signals([close_signal])
     assert [row.status for row in replay] == ["filled"]
     assert len(execution_b.requests) == 1
+    assert not any(event.get("event") == "signal_skipped" and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed" for event in journal_b.export())
+
+
+def test_pending_close_durable_marker_foreign_environment_does_not_block_current_scope(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
+    correlation_key = "pending-close-foreign-env"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)])
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=decision_timestamp,
+            correlation_key=correlation_key,
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            provenance={"source": "trading_controller_execution_result", "order_id": "foreign-pending-1", "execution_status": "pending", "symbol": "BTC/USDT", "side": "SELL", "environment": "live", "portfolio": "paper-1", "correlation_key": correlation_key},
+            label_quality="execution_proxy_pending_close",
+        )
+    ])
+    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}, {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0}])
+    controller, _exec, journal = _build_autonomy_controller_with_risk(
+        environment="paper", risk_engine=DummyRiskEngine(), execution_service=execution, opportunity_shadow_repository=repository
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    close_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=1))
+    assert [row.status for row in controller.process_signals([open_signal])] == ["filled"]
+    replay = controller.process_signals([close_signal])
+    assert [row.status for row in replay] == ["filled"]
+    assert not any(event.get("event") == "signal_skipped" and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed" for event in journal.export())
 
 
 def test_pending_close_same_process_replay_keeps_non_durable_reason(tmp_path: Path) -> None:
@@ -51997,9 +52082,9 @@ def test_opportunity_autonomous_close_unrecognized_non_fill_zero_fill_keeps_trac
     assert len(open_outcomes_after_pending_close) == 1
     assert open_outcomes_after_pending_close[0].closed_quantity == 0.0
     pending_close_labels = shadow_repo.load_outcome_labels()
-    assert len(pending_close_labels) == 1
-    assert pending_close_labels[0].label_quality == "execution_proxy_pending_exit"
-    assert pending_close_labels[0].provenance.get("execution_status") == "filled"
+    assert len(pending_close_labels) == 2
+    assert any(label.label_quality == "execution_proxy_pending_exit" for label in pending_close_labels)
+    assert any(label.label_quality == "execution_proxy_pending_close" for label in pending_close_labels)
     attach_events = [
         event for event in _journal.export() if event["event"] == "opportunity_outcome_attach"
     ]
@@ -52013,9 +52098,9 @@ def test_opportunity_autonomous_close_unrecognized_non_fill_zero_fill_keeps_trac
     ]
     assert len(attach_events_after) == len(attach_events)
     labels = shadow_repo.load_outcome_labels()
-    assert len(labels) == 1
-    assert labels[0].label_quality == "execution_proxy_pending_exit"
-    assert labels[0].provenance.get("execution_status") == "filled"
+    assert len(labels) == 2
+    assert any(label.label_quality == "execution_proxy_pending_exit" for label in labels)
+    assert any(label.label_quality == "execution_proxy_pending_close" for label in labels)
     open_outcomes_after_replay = shadow_repo.load_open_outcomes()
     assert len(open_outcomes_after_replay) == 1
     assert open_outcomes_after_replay[0].closed_quantity == 0.0


### PR DESCRIPTION
### Motivation
- Root cause: marker CLOSE był zapisywany przez ścieżkę attach/ranking (`attach_outcome_labels_idempotent`) i nie materializował się jako niezależny durable guard, więc replay po restarcie nie był blokowany poprawnie.
- Cel zmiany: wprowadzić oddzielny, trwały marker `execution_proxy_pending_close` zapisywany idempotentnie po stronie kontrolera bez udziału ranking/attach semantyki repozytorium.
- Oczekiwany efekt: test `test_pending_close_after_controller_restart_blocks_with_proxy_label` przechodzi i restartowane CLOSE są blokowane powodem `pending_autonomous_close_durable_replay_suppressed` bez tworzenia fake final/partial labels ani zmiany closed_quantity.

### Description
- Dodano stan kontrolera `_pending_autonomous_close_replays` oraz funkcję odtworzeniową `_restore_pending_autonomous_close_guards()` która ładuje z repo tylko etykiety `execution_proxy_pending_close` spełniające scope (environment/portfolio/symbol/side/order pending-like) i uzupełnia lokalny guard.
- Wprowadzono `_persist_pending_autonomous_close_marker(...)` który przed zapisem czyta istniejące etykiety (`load_outcome_labels()`), decyduje idempotentnie czy zapisać i używa `repository.append_outcome_labels(...)` zamiast `attach_outcome_labels_idempotent(...)`, a następnie aktualizuje lokalny guard.
- Dodano kontroler-side sprawdzenie replay: `_pending_autonomous_close_replay_reason(...)` zwracające `pending_autonomous_close_durable_replay_suppressed` jeśli guard istnieje, i wpięto tę logikę w flow przetwarzania sygnałów (sygnał zostaje pominięty z odpowiednim eventem w journalu).
- Podpięto wywołanie persist przy wykryciu autonomous CLOSE z istniejącym open trackerem i pending-like status + order_id; nie modyfikowano API repozytorium ani istniejącej logiki ranking/attach dla innych labeli.
- Zaktualizowano testy w `tests/test_trading_controller.py`: zmieniono test restartowy na nowy kontrakt blokowania, dodano test o retry po rejected CLOSE oraz test sprawdzający, że foreign-environment durable marker nie blokuje lokalnego scope; poprawiono kilka asercji, aby uwzględnić równoległą obecność proxy pending_exit i nowego durable pending_close markeru.

### Testing
- Środowisko: brak `3.11.14`, użyto `3.11.15`; przed testami wykonano `PYENV_VERSION=3.11.15 python -m pip install -e '.[test]'` i potwierdzono `numpy` (2.4.4).
- Uruchamiane komendy przykładów i wyniki: `PYENV_VERSION=3.11.15 python -m pytest -q tests/test_trading_controller.py::test_pending_close_after_controller_restart_blocks_with_proxy_label ...` — zestaw docelowych node’ów testowych przeszedł (17 testów) i zakończył się: 17 passed.
- Repo-layer proof: `PYENV_VERSION=3.11.15 python -m pytest -q tests/ai/test_trading_opportunity_engine.py::test_opportunity_shadow_repository_persists_pending_entry_marker_with_provenance tests/ai/test_trading_opportunity_engine.py::test_opportunity_shadow_repository_distinguishes_pending_entry_from_pending_exit_marker` — 2 passed.
- Pełny selector dla krytycznych scenariuszy: `PYENV_VERSION=3.11.15 python -m pytest -q tests/test_trading_controller.py -k "opportunity_autonomy or autonomy or pending or ... or label"` — 1047 passed, 28 deselected.
- Połączenie sanity: wszystkie założone testy dotyczące durable pending CLOSE przechodzą, brak regresji w repo-layer testach i brak zmian w API repozytorium.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1a72eb28832a8aa4b98eb64366ed)