### PR TITLE
Require label.symbol match when persisting pending autonomous close marker and add durable pending-close tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -3875,8 +3875,10 @@ class TradingController:
             if str(label.label_quality).strip() != "execution_proxy_pending_close":
                 continue
             provenance = label.provenance if isinstance(label.provenance, Mapping) else {}
+            label_symbol = str(label.symbol).strip()
             if (
                 str(label.correlation_key).strip() == correlation_key
+                and label_symbol == symbol
                 and str(provenance.get("order_id") or "").strip() == order_id
                 and _normalize_execution_status(provenance.get("execution_status")) in _PENDING_EXECUTION_STATUSES
                 and str(provenance.get("side") or "").strip().upper() == side

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -51601,6 +51601,108 @@ def test_pending_close_durable_marker_foreign_environment_does_not_block_current
     assert not any(event.get("event") == "signal_skipped" and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed" for event in journal.export())
 
 
+def test_pending_close_durable_marker_foreign_portfolio_does_not_block_current_scope(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
+    correlation_key = "pending-close-foreign-portfolio"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)])
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=decision_timestamp,
+            correlation_key=correlation_key,
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            provenance={"source": "trading_controller_execution_result", "order_id": "foreign-portfolio-pending-1", "execution_status": "pending", "symbol": "BTC/USDT", "side": "SELL", "environment": "paper", "portfolio": "portfolio-A", "correlation_key": correlation_key},
+            label_quality="execution_proxy_pending_close",
+        )
+    ])
+    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}, {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0}])
+    controller, _exec, journal = _build_autonomy_controller_with_risk(
+        environment="paper", portfolio_id="portfolio-B", risk_engine=DummyRiskEngine(), execution_service=execution, opportunity_shadow_repository=repository
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    close_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=1))
+    controller.process_signals([open_signal])
+    close_result = controller.process_signals([close_signal])
+    assert [row.status for row in close_result] == ["filled"]
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed"
+        for event in journal.export()
+    )
+
+
+def test_pending_close_durable_marker_terminal_status_does_not_block_restart_retry(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
+    correlation_key = "pending-close-terminal-status"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)])
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=decision_timestamp,
+            correlation_key=correlation_key,
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            provenance={"source": "trading_controller_execution_result", "order_id": "terminal-close-1", "execution_status": "rejected", "symbol": "BTC/USDT", "side": "SELL", "environment": "paper", "portfolio": "paper-1", "correlation_key": correlation_key},
+            label_quality="execution_proxy_pending_close",
+        )
+    ])
+    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}, {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0}])
+    controller, _exec, journal = _build_autonomy_controller_with_risk(
+        environment="paper", risk_engine=DummyRiskEngine(), execution_service=execution, opportunity_shadow_repository=repository
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    close_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=1))
+    assert [row.status for row in controller.process_signals([open_signal])] == ["filled"]
+    replay = controller.process_signals([close_signal])
+    assert [row.status for row in replay] == ["filled"]
+    assert not any(event.get("event") == "signal_skipped" and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed" for event in journal.export())
+
+
+def test_pending_close_durable_marker_missing_order_id_does_not_block_restart_retry(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
+    correlation_key = "pending-close-missing-order-id"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=correlation_key, decision_timestamp=decision_timestamp)])
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=decision_timestamp,
+            correlation_key=correlation_key,
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            provenance={"source": "trading_controller_execution_result", "execution_status": "pending", "symbol": "BTC/USDT", "side": "SELL", "environment": "paper", "portfolio": "paper-1", "correlation_key": correlation_key},
+            label_quality="execution_proxy_pending_close",
+        )
+    ])
+    execution = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}, {"status": "filled", "filled_quantity": 1.0, "avg_price": 99.0}])
+    controller, _exec, journal = _build_autonomy_controller_with_risk(
+        environment="paper", risk_engine=DummyRiskEngine(), execution_service=execution, opportunity_shadow_repository=repository
+    )
+    open_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=correlation_key, decision_timestamp=decision_timestamp)
+    close_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="SELL", correlation_key=correlation_key, decision_timestamp=decision_timestamp + timedelta(minutes=1))
+    assert [row.status for row in controller.process_signals([open_signal])] == ["filled"]
+    replay = controller.process_signals([close_signal])
+    assert [row.status for row in replay] == ["filled"]
+    assert not any(event.get("event") == "signal_skipped" and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed" for event in journal.export())
+    labels = repository.load_outcome_labels()
+    assert not any(label.label_quality == "partial_exit_unconfirmed" for label in labels)
+    assert not any(
+        label.label_quality == "execution_proxy_pending_close"
+        and not str((label.provenance or {}).get("order_id") or "").strip()
+        and str(label.correlation_key).strip() == correlation_key
+        for label in labels
+    )
+
+
 def test_pending_close_same_process_replay_keeps_non_durable_reason(tmp_path: Path) -> None:
     decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
     correlation_key = "pending-close-same-process-nondurable-reason"
@@ -52116,6 +52218,7 @@ def test_opportunity_autonomous_close_unrecognized_non_fill_zero_fill_keeps_trac
     assert len(pending_close_labels) == 2
     assert any(label.label_quality == "execution_proxy_pending_exit" for label in pending_close_labels)
     assert any(label.label_quality == "execution_proxy_pending_close" for label in pending_close_labels)
+    assert len([label for label in pending_close_labels if label.label_quality == "execution_proxy_pending_close" and label.correlation_key == correlation_key]) == 1
     attach_events = [
         event for event in _journal.export() if event["event"] == "opportunity_outcome_attach"
     ]
@@ -52132,6 +52235,9 @@ def test_opportunity_autonomous_close_unrecognized_non_fill_zero_fill_keeps_trac
     assert len(labels) == 2
     assert any(label.label_quality == "execution_proxy_pending_exit" for label in labels)
     assert any(label.label_quality == "execution_proxy_pending_close" for label in labels)
+    assert len([label for label in labels if label.label_quality == "execution_proxy_pending_close" and label.correlation_key == correlation_key]) == 1
+    assert not any(label.label_quality.startswith("final") for label in labels)
+    assert not any(label.label_quality == "partial_exit_unconfirmed" for label in labels)
     open_outcomes_after_replay = shadow_repo.load_open_outcomes()
     assert len(open_outcomes_after_replay) == 1
     assert open_outcomes_after_replay[0].closed_quantity == 0.0
@@ -52142,6 +52248,11 @@ def test_opportunity_autonomous_close_unrecognized_non_fill_zero_fill_keeps_trac
         and event.get("reason") == "pending_autonomous_order_replay_suppressed"
     ]
     assert skip_events
+    assert not any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed"
+        for event in _journal.export()
+    )
 
 
 def test_controller_final_close_after_partial_upgrades_and_removes_tracker(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Prevent false-positive durable pending-close detection by ensuring the stored outcome label's `symbol` matches the incoming order request symbol when deciding to suppress autonomous close replays.
- Add coverage for edge cases around durable pending-close markers including cross-portfolio scope, terminal statuses, and missing `order_id` provenance to guard against incorrect suppression or leftover labels.

### Description

- In `TradingController._persist_pending_autonomous_close_marker` require that `label.symbol` matches the request `symbol` before treating a label as a durable pending-close marker by introducing `label_symbol = str(label.symbol).strip()` and checking `label_symbol == symbol` in the matching condition.
- Added tests to `tests/test_trading_controller.py` covering durable pending-close behavior: `test_pending_close_durable_marker_foreign_portfolio_does_not_block_current_scope`, `test_pending_close_durable_marker_terminal_status_does_not_block_restart_retry`, and `test_pending_close_durable_marker_missing_order_id_does_not_block_restart_retry`.
- Tightened assertions in existing tests to ensure only one durable `execution_proxy_pending_close` label is created for the correlation key and to assert that no spurious `pending_autonomous_close_durable_replay_suppressed` skip events are emitted.

### Testing

- Ran the unit test suite portions affected by these changes including the newly added tests in `tests/test_trading_controller.py`, and updated assertions in related tests; all tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2fb281b4832a854fda51baaa2b57)