### PR TITLE
Suppress final-outcome replay closes when terminal nonfill exists and add tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1381,6 +1381,111 @@ class TradingController:
             return False
         return False
 
+    def _is_final_outcome_close_replay_suppressed(
+        self,
+        *,
+        request: OrderRequest,
+        correlation_key: str,
+        existing_open_tracker: _OpportunityOpenOutcomeTracker | None,
+    ) -> bool:
+        if not correlation_key:
+            return False
+        side = str(request.side or "").upper()
+        if side not in (_BUY_SIDES | _SELL_SIDES):
+            return False
+        repository = self._opportunity_shadow_repository
+        if repository is None:
+            return False
+        request_metadata = request.metadata if isinstance(request.metadata, Mapping) else {}
+        local_mode = str(request_metadata.get("mode") or "").strip().lower()
+        is_close_intent = local_mode == "close_ranked"
+        if (
+            existing_open_tracker is not None
+            and self._is_closing_side(str(existing_open_tracker.side), side)
+        ):
+            is_close_intent = True
+        try:
+            labels = repository.load_outcome_labels()
+            shadow_records = repository.load_shadow_records()
+        except Exception:  # pragma: no cover - diagnostics only
+            _LOGGER.debug(
+                "Nie udało się zweryfikować replay close po final outcome",
+                exc_info=True,
+            )
+            return False
+        if not is_close_intent:
+            for shadow_record in shadow_records:
+                if shadow_record.record_key != correlation_key:
+                    continue
+                if str(getattr(shadow_record, "symbol", "")) != str(request.symbol):
+                    continue
+                proposed_direction = str(getattr(shadow_record, "proposed_direction", "")).strip().lower()
+                expected_open_side = (
+                    "BUY" if proposed_direction in {"long", "buy"} else ("SELL" if proposed_direction in {"short", "sell"} else "")
+                )
+                if expected_open_side and self._is_closing_side(expected_open_side, side):
+                    is_close_intent = True
+                    break
+        if not is_close_intent:
+            return False
+        scope_environment = str(self.environment or "").strip()
+        scope_portfolio = str(self.portfolio_id or "").strip()
+        terminal_nonfill_close_marker_present = False
+        for row in labels:
+            if (
+                row.correlation_key != correlation_key
+                or str(row.symbol) != str(request.symbol)
+                or str(row.label_quality).strip() != "execution_proxy_terminal_nonfill"
+            ):
+                continue
+            provenance = row.provenance if isinstance(row.provenance, Mapping) else {}
+            marker_side = str(provenance.get("side") or "").strip().upper()
+            if marker_side != side:
+                continue
+            marker_environment = str(provenance.get("environment") or "").strip()
+            marker_portfolio_raw = str(provenance.get("portfolio") or "").strip()
+            marker_portfolio_id_raw = str(provenance.get("portfolio_id") or "").strip()
+            marker_portfolio = marker_portfolio_raw or marker_portfolio_id_raw
+            if scope_environment and marker_environment and marker_environment != scope_environment:
+                continue
+            if scope_portfolio and marker_portfolio and marker_portfolio != scope_portfolio:
+                continue
+            terminal_nonfill_close_marker_present = True
+            break
+        if not terminal_nonfill_close_marker_present:
+            return False
+        for row in labels:
+            if (
+                row.correlation_key != correlation_key
+                or str(row.symbol) != str(request.symbol)
+                or str(row.label_quality).strip().lower() != "final"
+            ):
+                continue
+            final_provenance = row.provenance if isinstance(row.provenance, Mapping) else {}
+            final_mode = str(final_provenance.get("autonomy_final_mode") or "").strip().lower()
+            if final_mode not in {"paper_autonomous", "live_autonomous"}:
+                continue
+            final_environment = str(final_provenance.get("environment") or "").strip()
+            final_portfolio_raw = str(final_provenance.get("portfolio") or "").strip()
+            final_portfolio_id_raw = str(final_provenance.get("portfolio_id") or "").strip()
+            if (
+                final_portfolio_raw
+                and final_portfolio_id_raw
+                and final_portfolio_raw != final_portfolio_id_raw
+            ):
+                continue
+            final_portfolio = final_portfolio_raw or final_portfolio_id_raw
+            if scope_environment and not final_environment:
+                continue
+            if scope_portfolio and not final_portfolio:
+                continue
+            if final_environment and scope_environment and final_environment != scope_environment:
+                continue
+            if final_portfolio and scope_portfolio and final_portfolio != scope_portfolio:
+                continue
+            return True
+        return False
+
     def _is_duplicate_autonomous_open_replay_after_final_close(
         self,
         *,
@@ -3425,6 +3530,23 @@ class TradingController:
                         "restored_tracker_quantity_clamped": True,
                     },
                 )
+        if self._is_final_outcome_close_replay_suppressed(
+            request=request,
+            correlation_key=correlation_key,
+            existing_open_tracker=existing_open_tracker,
+        ):
+            self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+            self._record_decision_event(
+                "signal_skipped",
+                signal=signal,
+                request=request,
+                status="skipped",
+                metadata={
+                    "reason": "final_outcome_replay_close_suppressed",
+                    "proxy_correlation_key": correlation_key,
+                },
+            )
+            return None
         if self._is_duplicate_autonomous_close_replay(
             request=request,
             correlation_key=correlation_key,

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -51944,6 +51944,182 @@ def test_pending_close_durable_marker_terminal_status_does_not_block_restart_ret
     assert not any(event.get("event") == "signal_skipped" and event.get("reason") == "pending_autonomous_close_durable_replay_suppressed" for event in journal.export())
 
 
+
+
+def test_terminal_nonfill_marker_ignored_when_final_label_exists_for_same_correlation_after_restart(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 15, 10, 0, tzinfo=timezone.utc)
+    key = "terminal-nonfill-final-open-restart"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)])
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(symbol="BTC/USDT", decision_timestamp=decision_timestamp + timedelta(seconds=1), correlation_key=key, horizon_minutes=0, realized_return_bps=0.0, max_favorable_excursion_bps=0.0, max_adverse_excursion_bps=0.0, provenance={"source": "trading_controller_execution_result", "order_id": "open-rejected-1", "execution_status": "rejected", "symbol": "BTC/USDT", "side": "BUY", "environment": "paper", "portfolio": "paper-1", "correlation_key": key}, label_quality="execution_proxy_terminal_nonfill"),
+        OpportunityOutcomeLabel(symbol="BTC/USDT", decision_timestamp=decision_timestamp + timedelta(minutes=5), correlation_key=key, horizon_minutes=60, realized_return_bps=10.0, max_favorable_excursion_bps=12.0, max_adverse_excursion_bps=-5.0, provenance={"autonomy_final_mode": "paper_autonomous", "environment": "paper", "portfolio": "paper-1"}, label_quality="final"),
+    ])
+    controller, execution, journal = _build_autonomy_controller_with_risk(environment="paper", risk_engine=DummyRiskEngine(), opportunity_shadow_repository=repository)
+    signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=key, decision_timestamp=decision_timestamp)
+    assert controller.process_signals([signal]) == []
+    reasons = [str(e.get("reason") or "").strip() for e in journal.export() if e.get("event")=="signal_skipped"]
+    assert "final_outcome_replay_open_suppressed" in reasons
+    assert "pending_autonomous_order_durable_replay_suppressed" not in reasons
+    assert "pending_autonomous_order_durable_symbol_replay_suppressed" not in reasons
+    assert execution.requests == []
+    labels = [row for row in repository.load_outcome_labels() if row.correlation_key == key]
+    assert len([row for row in labels if row.label_quality == "final"]) == 1
+    assert not any(row.label_quality in {"partial_exit_unconfirmed", "execution_proxy_pending_entry"} for row in labels)
+
+
+def test_terminal_nonfill_marker_does_not_block_new_symbol_key_after_original_key_finalized(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 15, 10, 10, tzinfo=timezone.utc)
+    key_a = "terminal-nonfill-final-key-a"
+    key_b = "terminal-nonfill-final-key-b"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([
+        _shadow_record_for_key(correlation_key=key_a, decision_timestamp=decision_timestamp),
+        _shadow_record_for_key(correlation_key=key_b, decision_timestamp=decision_timestamp + timedelta(minutes=1)),
+    ])
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(symbol="BTC/USDT", decision_timestamp=decision_timestamp + timedelta(seconds=1), correlation_key=key_a, horizon_minutes=0, realized_return_bps=0.0, max_favorable_excursion_bps=0.0, max_adverse_excursion_bps=0.0, provenance={"source": "trading_controller_execution_result", "order_id": "open-rejected-1", "execution_status": "rejected", "symbol": "BTC/USDT", "side": "BUY", "environment": "paper", "portfolio": "paper-1", "correlation_key": key_a}, label_quality="execution_proxy_terminal_nonfill"),
+        OpportunityOutcomeLabel(symbol="BTC/USDT", decision_timestamp=decision_timestamp + timedelta(minutes=5), correlation_key=key_a, horizon_minutes=60, realized_return_bps=8.0, max_favorable_excursion_bps=8.0, max_adverse_excursion_bps=-4.0, provenance={"autonomy_final_mode": "paper_autonomous", "environment": "paper", "portfolio": "paper-1"}, label_quality="final"),
+    ])
+    controller, execution, journal = _build_autonomy_controller_with_risk(environment="paper", risk_engine=DummyRiskEngine(), execution_service=SequencedExecutionService([{"status":"filled","filled_quantity":1.0,"avg_price":100.0}]), opportunity_shadow_repository=repository)
+    signal_b = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=key_b, decision_timestamp=decision_timestamp + timedelta(minutes=1))
+    results = controller.process_signals([signal_b])
+    assert [row.status for row in results] == ["filled"]
+    assert [req.side for req in execution.requests] == ["BUY"]
+    assert not any(e.get("event")=="signal_skipped" and str(e.get("reason") or "").strip() in {"pending_autonomous_order_durable_symbol_replay_suppressed", "pending_autonomous_order_durable_replay_suppressed"} for e in journal.export())
+
+
+def test_terminal_nonfill_close_marker_ignored_when_final_label_exists_for_same_correlation_after_restart(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 15, 10, 20, tzinfo=timezone.utc)
+    key = "terminal-nonfill-final-close-restart"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)])
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(symbol="BTC/USDT", decision_timestamp=decision_timestamp + timedelta(seconds=1), correlation_key=key, horizon_minutes=0, realized_return_bps=0.0, max_favorable_excursion_bps=0.0, max_adverse_excursion_bps=0.0, provenance={"source": "trading_controller_execution_result", "order_id": "close-rejected-1", "execution_status": "rejected", "symbol": "BTC/USDT", "side": "SELL", "environment": "paper", "portfolio": "paper-1", "correlation_key": key}, label_quality="execution_proxy_terminal_nonfill"),
+        OpportunityOutcomeLabel(symbol="BTC/USDT", decision_timestamp=decision_timestamp + timedelta(minutes=5), correlation_key=key, horizon_minutes=60, realized_return_bps=11.0, max_favorable_excursion_bps=11.0, max_adverse_excursion_bps=-3.0, provenance={"autonomy_final_mode": "paper_autonomous", "environment": "paper", "portfolio": "paper-1"}, label_quality="final"),
+    ])
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(environment="paper", risk_engine=risk_engine, opportunity_shadow_repository=repository)
+    controller._opportunity_open_outcomes[key] = _OpportunityOpenOutcomeTracker(
+        correlation_key=key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=decision_timestamp,
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        environment_scope="paper",
+        portfolio_scope="paper-1",
+    )
+    close_signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="SELL", correlation_key=key, decision_timestamp=decision_timestamp + timedelta(minutes=1))
+    results = controller.process_signals([close_signal])
+    assert results == []
+    reasons = [str(e.get("reason") or "").strip() for e in journal.export() if e.get("event")=="signal_skipped"]
+    assert reasons[-1] == "final_outcome_replay_close_suppressed"
+    assert "pending_autonomous_close_durable_replay_suppressed" not in reasons
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert key in controller._opportunity_open_outcomes
+    assert controller._opportunity_open_outcomes[key].closed_quantity == pytest.approx(0.0)
+    assert not any(
+        event.get("event") in {"order_submitted", "order_executed", "order_partially_executed"}
+        and event.get("opportunity_shadow_record_key") == key
+        for event in journal.export()
+    )
+    assert not any(
+        event.get("event") == "opportunity_outcome_attach"
+        and event.get("opportunity_shadow_record_key") == key
+        for event in journal.export()
+    )
+    labels_for_key = [row for row in repository.load_outcome_labels() if row.correlation_key == key]
+    assert len([row for row in labels_for_key if row.label_quality == "final"]) == 1
+    assert not any(
+        row.label_quality in {"partial_exit_unconfirmed", "execution_proxy_pending_exit"}
+        and row.correlation_key == key
+        for row in repository.load_outcome_labels()
+    )
+
+
+def test_final_label_blocks_restored_close_even_when_terminal_nonfill_marker_exists(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 15, 10, 40, tzinfo=timezone.utc)
+    key = "final-blocks-restored-close-with-terminal-nonfill"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)])
+    execution_a = SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}])
+    controller_a, _exec_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=execution_a,
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="BUY", correlation_key=key, decision_timestamp=decision_timestamp
+    )
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(symbol="BTC/USDT", decision_timestamp=decision_timestamp + timedelta(seconds=1), correlation_key=key, horizon_minutes=0, realized_return_bps=0.0, max_favorable_excursion_bps=0.0, max_adverse_excursion_bps=0.0, provenance={"source": "trading_controller_execution_result", "order_id": "close-rejected-1", "execution_status": "rejected", "symbol": "BTC/USDT", "side": "SELL", "environment": "paper", "portfolio": "paper-1", "correlation_key": key}, label_quality="execution_proxy_terminal_nonfill"),
+        OpportunityOutcomeLabel(symbol="BTC/USDT", decision_timestamp=decision_timestamp + timedelta(minutes=5), correlation_key=key, horizon_minutes=60, realized_return_bps=11.0, max_favorable_excursion_bps=11.0, max_adverse_excursion_bps=-3.0, provenance={"autonomy_final_mode": "paper_autonomous", "environment": "paper", "portfolio": "paper-1"}, label_quality="final"),
+    ])
+    risk_engine = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]),
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="SELL", correlation_key=key, decision_timestamp=decision_timestamp + timedelta(minutes=1)
+    )
+    labels_before_replay = [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in repository.load_outcome_labels()
+        if row.correlation_key == key
+    ]
+    assert controller_b.process_signals([close_signal]) == []
+    reasons = [str(e.get("reason") or "").strip() for e in journal_b.export() if e.get("event") == "signal_skipped"]
+    assert reasons[-1] == "final_outcome_replay_close_suppressed"
+    assert risk_engine.last_checks == []
+    assert execution_b.requests == []
+    assert not any(
+        event.get("event") in {"order_submitted", "order_executed", "order_partially_executed"}
+        and event.get("opportunity_shadow_record_key") == key
+        for event in journal_b.export()
+    )
+    assert not any(
+        event.get("event") == "opportunity_outcome_attach"
+        and event.get("opportunity_shadow_record_key") == key
+        for event in journal_b.export()
+    )
+    labels_for_key = [row for row in repository.load_outcome_labels() if row.correlation_key == key]
+    assert len([row for row in labels_for_key if row.label_quality == "final"]) == 1
+    assert [
+        (row.correlation_key, row.label_quality, dict(row.provenance))
+        for row in labels_for_key
+    ] == labels_before_replay
+
+
+def test_same_process_terminal_nonfill_then_final_clears_pending_guards_for_correlation(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 15, 10, 30, tzinfo=timezone.utc)
+    key = "same-process-terminal-nonfill-final-cleanup"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)])
+    controller, _execution, _journal = _build_autonomy_controller_with_risk(environment="paper", risk_engine=DummyRiskEngine(), opportunity_shadow_repository=repository)
+    signal = _autonomy_signal_with_correlation(mode="paper_autonomous", side="BUY", correlation_key=key, decision_timestamp=decision_timestamp)
+    controller._update_pending_autonomous_order_replay_state(
+        request=signal,
+        normalized_status="submitted",
+        result=OrderResult(order_id="pending-open-1", status="submitted", filled_quantity=0.0, avg_price=None, raw_response={}),
+    )
+    controller._update_pending_autonomous_order_replay_state(
+        request=signal,
+        normalized_status="rejected",
+        result=OrderResult(order_id="pending-open-1", status="rejected", filled_quantity=0.0, avg_price=None, raw_response={}),
+    )
+    controller._clear_pending_autonomous_guards_for_correlation_key(key)
+    assert key not in controller._pending_autonomous_order_replays
+    assert key not in controller._pending_autonomous_open_signatures_by_key
+    assert not any(tracked_key == key for tracked_key in controller._pending_autonomous_open_signatures.values())
+    assert not any(replay[0] == key for replay in controller._pending_autonomous_close_replays)
 def test_terminal_nonfill_marker_written_for_rejected_autonomous_open_result(tmp_path: Path) -> None:
     decision_timestamp = datetime(2026, 1, 8, 12, 0, tzinfo=timezone.utc)
     correlation_key = "terminal-nonfill-open-rejected"


### PR DESCRIPTION
### Motivation
- Prevent replayed close signals from reopening or altering opportunities when a later `final` outcome label already authoritatively closed the opportunity despite an earlier terminal nonfill marker.
- Ensure replay suppression logic accounts for environment/portfolio scoping and existing open trackers to avoid duplicate or conflicting order submissions.

### Description
- Added a new method ` _is_final_outcome_close_replay_suppressed` on `TradingController` that inspects outcome labels and shadow records to determine whether a replayed close should be suppressed when a `final` outcome exists for the same correlation and scope. 
- Integrated the new suppression check into the signal processing path to skip the signal, increment metrics, and emit a `signal_skipped` decision event with reason `final_outcome_replay_close_suppressed` when applicable. 
- The suppression check validates sides, request metadata (including `mode`), existing open trackers, and ensures correct scoping by `environment` and `portfolio` before deciding to suppress. 
- Added multiple unit tests in `tests/test_trading_controller.py` to cover scenarios with `execution_proxy_terminal_nonfill` markers followed by `final` labels, cross-key behavior, and cleanup of pending guards.

### Testing
- Ran the new unit tests in `tests/test_trading_controller.py` including `test_terminal_nonfill_marker_ignored_when_final_label_exists_for_same_correlation_after_restart`, `test_terminal_nonfill_marker_does_not_block_new_symbol_key_after_original_key_finalized`, `test_terminal_nonfill_close_marker_ignored_when_final_label_exists_for_same_correlation_after_restart`, `test_final_label_blocks_restored_close_even_when_terminal_nonfill_marker_exists`, and `test_same_process_terminal_nonfill_then_final_clears_pending_guards_for_correlation`, and they all succeeded. 
- Existing tests exercised the updated signal processing path and also succeeded during the run. 
- No automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc60bab5cc832a8fbbb2b46527922a)