### PR TITLE
Skip duplicate autonomous close replays for in-memory close trackers when final label lacks terminal nonfill

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1381,6 +1381,59 @@ class TradingController:
             return False
         return False
 
+    def _is_in_memory_final_close_replay_without_terminal_nonfill(
+        self,
+        *,
+        request: OrderRequest,
+        correlation_key: str,
+        existing_open_tracker: _OpportunityOpenOutcomeTracker | None,
+    ) -> bool:
+        if not correlation_key or existing_open_tracker is None:
+            return False
+        if str(request.symbol) != str(existing_open_tracker.symbol):
+            return False
+        if not self._is_closing_side(str(existing_open_tracker.side), str(request.side)):
+            return False
+        tracker_environment = str(existing_open_tracker.environment_scope or "").strip()
+        tracker_portfolio = str(existing_open_tracker.portfolio_scope or "").strip()
+        scope_environment = str(self.environment or "").strip()
+        scope_portfolio = str(self.portfolio_id or "").strip()
+        if tracker_environment and scope_environment and tracker_environment != scope_environment:
+            return False
+        if tracker_portfolio and scope_portfolio and tracker_portfolio != scope_portfolio:
+            return False
+        repository = self._opportunity_shadow_repository
+        if repository is None:
+            return False
+        try:
+            labels = repository.load_outcome_labels()
+            open_outcomes = repository.load_open_outcomes()
+        except Exception:  # pragma: no cover - diagnostics only
+            return False
+        if any(str(outcome.correlation_key) == correlation_key for outcome in open_outcomes):
+            return False
+        for row in labels:
+            if (
+                row.correlation_key != correlation_key
+                or str(row.symbol) != str(request.symbol)
+                or str(row.label_quality) != "final"
+            ):
+                continue
+            provenance = row.provenance if isinstance(row.provenance, Mapping) else {}
+            mode = str(provenance.get("autonomy_final_mode") or "").strip().lower()
+            if mode not in {"paper_autonomous", "live_autonomous"}:
+                continue
+            label_environment = str(provenance.get("environment") or "").strip()
+            label_portfolio = str(provenance.get("portfolio") or "").strip() or str(
+                provenance.get("portfolio_id") or ""
+            ).strip()
+            if label_environment and scope_environment and label_environment != scope_environment:
+                continue
+            if label_portfolio and scope_portfolio and label_portfolio != scope_portfolio:
+                continue
+            return True
+        return False
+
     def _is_final_outcome_close_replay_suppressed(
         self,
         *,
@@ -3543,6 +3596,23 @@ class TradingController:
                 status="skipped",
                 metadata={
                     "reason": "final_outcome_replay_close_suppressed",
+                    "proxy_correlation_key": correlation_key,
+                },
+            )
+            return None
+        if self._is_in_memory_final_close_replay_without_terminal_nonfill(
+            request=request,
+            correlation_key=correlation_key,
+            existing_open_tracker=existing_open_tracker,
+        ):
+            self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+            self._record_decision_event(
+                "signal_skipped",
+                signal=signal,
+                request=request,
+                status="skipped",
+                metadata={
+                    "reason": "duplicate_autonomous_close_replay_suppressed",
                     "proxy_correlation_key": correlation_key,
                 },
             )

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -52165,6 +52165,150 @@ def test_final_label_without_terminal_nonfill_restored_close_is_safely_suppresse
     assert open_outcomes == []
 
 
+
+
+def test_final_label_without_terminal_nonfill_in_memory_close_tracker_is_safely_suppressed_by_duplicate_guard(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 16, 10, 50, tzinfo=timezone.utc)
+    key = "final-blocks-in-memory-close-tracker-without-terminal-nonfill"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)])
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=decision_timestamp + timedelta(minutes=5),
+            correlation_key=key,
+            horizon_minutes=60,
+            realized_return_bps=11.0,
+            max_favorable_excursion_bps=11.0,
+            max_adverse_excursion_bps=-3.0,
+            provenance={"autonomy_final_mode": "paper_autonomous", "environment": "paper", "portfolio": "paper-1"},
+            label_quality="final",
+        )
+    ])
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]),
+        opportunity_shadow_repository=repository,
+    )
+    controller._opportunity_open_outcomes[key] = _OpportunityOpenOutcomeTracker(
+        correlation_key=key,
+        symbol="BTC/USDT",
+        side="BUY",
+        entry_price=100.0,
+        decision_timestamp=decision_timestamp,
+        entry_quantity=1.0,
+        closed_quantity=0.0,
+        environment_scope="paper",
+        portfolio_scope="paper-1",
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="SELL", correlation_key=key, decision_timestamp=decision_timestamp + timedelta(minutes=1)
+    )
+    result = controller.process_signals([close_signal])
+    assert result == []
+    reasons = [str(e.get("reason") or "").strip() for e in journal.export() if e.get("event") == "signal_skipped"]
+    assert reasons[-1] == "duplicate_autonomous_close_replay_suppressed"
+    assert "final_outcome_replay_close_suppressed" not in reasons
+    assert "pending_autonomous_close_durable_replay_suppressed" not in reasons
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert not any(
+        event.get("event") in {"order_submitted", "order_executed", "order_partially_executed"}
+        and event.get("opportunity_shadow_record_key") == key
+        for event in journal.export()
+    )
+    assert not any(
+        event.get("event") == "opportunity_outcome_attach"
+        and event.get("opportunity_shadow_record_key") == key
+        for event in journal.export()
+    )
+    labels_for_key = [row for row in repository.load_outcome_labels() if row.correlation_key == key]
+    assert len([row for row in labels_for_key if row.label_quality == "final"]) == 1
+    assert not any(row.label_quality == "partial_exit_unconfirmed" for row in labels_for_key)
+    assert not any(row.label_quality == "execution_proxy_pending_exit" for row in labels_for_key)
+    assert not any(row.label_quality == "execution_proxy_terminal_nonfill" for row in labels_for_key)
+    tracker = controller._opportunity_open_outcomes.get(key)
+    assert tracker is not None
+    assert tracker.closed_quantity == 0.0
+
+
+def test_final_label_without_terminal_nonfill_pending_close_marker_is_safely_suppressed_by_duplicate_guard(tmp_path: Path) -> None:
+    decision_timestamp = datetime(2026, 1, 16, 11, 0, tzinfo=timezone.utc)
+    key = "final-blocks-pending-close-without-terminal-nonfill"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records([_shadow_record_for_key(correlation_key=key, decision_timestamp=decision_timestamp)])
+    repository.upsert_open_outcome(
+        OpportunityShadowRepository.OpenOutcomeState(
+            correlation_key=key,
+            symbol="BTC/USDT",
+            side="BUY",
+            entry_price=100.0,
+            decision_timestamp=decision_timestamp,
+            entry_quantity=1.0,
+            closed_quantity=0.0,
+            provenance={"source": "test", "environment": "paper", "portfolio": "paper-1"},
+        )
+    )
+    repository.append_outcome_labels([
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=decision_timestamp + timedelta(seconds=1),
+            correlation_key=key,
+            horizon_minutes=0,
+            realized_return_bps=0.0,
+            max_favorable_excursion_bps=0.0,
+            max_adverse_excursion_bps=0.0,
+            provenance={"source": "trading_controller_execution_result", "order_id": "pending-close-1", "execution_status": "pending", "symbol": "BTC/USDT", "side": "SELL", "environment": "paper", "portfolio": "paper-1", "correlation_key": key},
+            label_quality="execution_proxy_pending_close",
+        ),
+        OpportunityOutcomeLabel(
+            symbol="BTC/USDT",
+            decision_timestamp=decision_timestamp + timedelta(minutes=5),
+            correlation_key=key,
+            horizon_minutes=60,
+            realized_return_bps=11.0,
+            max_favorable_excursion_bps=11.0,
+            max_adverse_excursion_bps=-3.0,
+            provenance={"autonomy_final_mode": "paper_autonomous", "environment": "paper", "portfolio": "paper-1"},
+            label_quality="final",
+        ),
+    ])
+    risk_engine = DummyRiskEngine()
+    controller, execution, journal = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService([{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]),
+        opportunity_shadow_repository=repository,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous", side="SELL", correlation_key=key, decision_timestamp=decision_timestamp + timedelta(minutes=1)
+    )
+    result = controller.process_signals([close_signal])
+    assert result == []
+    reasons = [str(e.get("reason") or "").strip() for e in journal.export() if e.get("event") == "signal_skipped"]
+    assert reasons[-1] == "duplicate_autonomous_close_replay_suppressed"
+    assert "final_outcome_replay_close_suppressed" not in reasons
+    assert risk_engine.last_checks == []
+    assert execution.requests == []
+    assert not any(
+        event.get("event") in {"order_submitted", "order_executed", "order_partially_executed"}
+        and event.get("opportunity_shadow_record_key") == key
+        for event in journal.export()
+    )
+    assert not any(
+        event.get("event") == "opportunity_outcome_attach"
+        and event.get("opportunity_shadow_record_key") == key
+        for event in journal.export()
+    )
+    labels_for_key = [row for row in repository.load_outcome_labels() if row.correlation_key == key]
+    assert len([row for row in labels_for_key if row.label_quality == "final"]) == 1
+    assert len([row for row in labels_for_key if row.label_quality == "execution_proxy_pending_close"]) == 1
+    assert not any(row.label_quality == "execution_proxy_terminal_nonfill" for row in labels_for_key)
+    assert not any(row.label_quality == "partial_exit_unconfirmed" for row in labels_for_key)
+    assert not any(row.label_quality == "execution_proxy_pending_exit" for row in labels_for_key)
+
 def test_same_process_terminal_nonfill_then_final_clears_pending_guards_for_correlation(tmp_path: Path) -> None:
     decision_timestamp = datetime(2026, 1, 15, 10, 30, tzinfo=timezone.utc)
     key = "same-process-terminal-nonfill-final-cleanup"


### PR DESCRIPTION
### Motivation

- Prevent generating redundant close orders when a final autonomous label exists for a correlation and the same close is already represented in-memory (no terminal nonfill recorded), avoiding duplicate executions.

### Description

- Added `_is_in_memory_final_close_replay_without_terminal_nonfill` to `TradingController` to detect in-memory open trackers that match a close replay and are associated with a final outcome label whose provenance indicates an autonomous final mode and matching environment/portfolio and where no terminal nonfill was recorded in the repository.
- Integrated the new guard into the signal handling flow to skip processing and record a `signal_skipped` event with reason `duplicate_autonomous_close_replay_suppressed` when the guard fires, incrementing the metrics counter accordingly.
- Added tests in `tests/test_trading_controller.py` to cover: in-memory open tracker suppression (`test_final_label_without_terminal_nonfill_in_memory_close_tracker_is_safely_suppressed_by_duplicate_guard`) and suppression when a pending-close marker exists plus a final label (`test_final_label_without_terminal_nonfill_pending_close_marker_is_safely_suppressed_by_duplicate_guard`), and adjusted surrounding test expectations.

### Testing

- Ran `pytest tests/test_trading_controller.py` including the two new tests and the related final-label tests, and the new tests passed. 
- Verified that the controller emits `signal_skipped` with reason `duplicate_autonomous_close_replay_suppressed` and that no execution requests or pending/terminal nonfill labels were created by these scenarios. 
- Confirmed existing final-outcome suppression tests still pass after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdd7cb6f4832a8901d7c44203cade)