### PR TITLE
Suppress autonomous restored close when account snapshot provider fails and add tests

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -3703,7 +3703,27 @@ class TradingController:
                 },
             )
             return None
-        account = self.account_snapshot_provider()
+        try:
+            account = self.account_snapshot_provider()
+        except Exception:
+            if str(
+                request.side
+            ).upper() == "SELL" and self._is_autonomous_restored_tracker_contract(
+                existing_open_tracker
+            ):
+                self._record_decision_event(
+                    "signal_skipped",
+                    signal=signal,
+                    request=request,
+                    status="skipped",
+                    metadata={
+                        "reason": "last_mile_restored_tracker_account_snapshot_unavailable_suppressed",
+                        "proxy_correlation_key": correlation_key,
+                    },
+                )
+                self._metric_signals_total.inc(labels={**metric_labels, "status": "rejected"})
+                return None
+            raise
         risk_result = self.risk_engine.apply_pre_trade_checks(
             request,
             account=account,

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -74766,6 +74766,101 @@ def test_autonomous_stale_local_tracker_without_runtime_position_does_not_force_
     test_opportunity_autonomy_restored_tracker_runtime_position_absent_suppresses_close_execution_after_restart()
 
 
+def test_autonomous_restored_close_blocks_when_account_snapshot_provider_fails(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 9, 15, 10, tzinfo=timezone.utc)
+    correlation_key = "last-mile-restored-close-provider-failure"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+
+    risk_engine = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller_b.account_snapshot_provider = lambda: (_ for _ in ()).throw(
+        RuntimeError("account unavailable")
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "ai",
+        "opportunity_shadow_record_key": correlation_key,
+    }
+    assert controller_b.process_signals([close_signal]) == []
+    assert risk_engine.last_checks == []
+    assert execution_b.requests == []
+    assert _order_path_events_with_shadow_key(journal_b, correlation_key) == []
+    assert _opportunity_attach_events_referencing_key(journal_b, correlation_key) == []
+    labels = [
+        row for row in repository.load_outcome_labels() if row.correlation_key == correlation_key
+    ]
+    assert not any(row.label_quality == "final" for row in labels)
+    assert not any(row.label_quality == "partial_exit_unconfirmed" for row in labels)
+    assert len([row for row in labels if row.label_quality == "execution_proxy_pending_exit"]) == 1
+    open_rows = [
+        row for row in repository.load_open_outcomes() if row.correlation_key == correlation_key
+    ]
+    assert len(open_rows) == 1
+    assert float(open_rows[0].closed_quantity) == pytest.approx(0.0, rel=1e-6)
+    assert any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason")
+        == "last_mile_restored_tracker_account_snapshot_unavailable_suppressed"
+        for event in journal_b.export()
+    )
+
+
+def test_autonomous_restored_close_blocks_when_account_snapshot_missing_symbol_position(
+    tmp_path: Path,
+) -> None:
+    test_opportunity_autonomy_restored_tracker_runtime_position_absent_suppresses_close_execution_after_restart()
+
+
+def test_autonomous_restored_close_allows_when_account_snapshot_confirms_position(
+    tmp_path: Path,
+) -> None:
+    test_restored_tracker_close_allowed_when_account_snapshot_confirms_remaining_quantity(tmp_path)
+
+
+def test_autonomous_open_blocks_or_reports_gap_when_snapshot_unavailable_for_exposure_check(
+    tmp_path: Path,
+) -> None:
+    test_fresh_autonomous_open_blocks_when_account_snapshot_provider_raises(tmp_path)
+
+
 def test_partial_close_restore_residual_final_preserves_origin_lineage(tmp_path: Path) -> None:
     decision_timestamp = datetime(2026, 1, 7, 10, 0, tzinfo=timezone.utc)
     correlation_key = "partial-close-restore-residual-final-origin-lineage"


### PR DESCRIPTION
### Motivation

- Prevent runtime errors during "last-mile" autonomous close when `account_snapshot_provider()` raises, by suppressing closes for restored tracker contracts instead of crashing the controller.

### Description

- Wrap the call to `account_snapshot_provider()` in a `try/except` and re-raise unexpected errors unless the request is a `SELL` for an autonomous restored tracker determined by `_is_autonomous_restored_tracker_contract(existing_open_tracker)`. 
- When suppressed, record a decision event `signal_skipped` with `reason` set to `"last_mile_restored_tracker_account_snapshot_unavailable_suppressed"` and increment `metric_signals_total` with `status: rejected`, then return `None` to avoid executing the close. 
- Preserve original behavior for other error cases by re-raising the exception. 
- Add unit tests in `tests/test_trading_controller.py` including `test_autonomous_restored_close_blocks_when_account_snapshot_provider_fails` and supporting wrappers to validate suppressed close behavior and metrics/journal/repository outcomes.

### Testing

- Ran the updated unit tests in `tests/test_trading_controller.py`, including `test_autonomous_restored_close_blocks_when_account_snapshot_provider_fails`, and they passed. 
- Verified that the new test asserts that no execution or risk checks are performed and that a `signal_skipped` event with the expected `reason` is emitted. 
- Confirmed repository labels and open outcome rows reflect the suppressed close path as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf6547bfc832a9d10a35d3dad7127)