### PR TITLE
Harden autonomous account snapshot quantity boundaries

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -74864,7 +74864,71 @@ def test_autonomous_restored_close_blocks_when_account_snapshot_is_empty_for_sym
 def test_autonomous_restored_close_blocks_when_account_snapshot_position_quantity_is_zero(
     tmp_path: Path,
 ) -> None:
-    test_opportunity_autonomy_restored_tracker_runtime_position_absent_suppresses_close_execution_after_restart()
+    decision_timestamp = datetime(2026, 1, 9, 15, 25, tzinfo=timezone.utc)
+    correlation_key = "last-mile-restored-close-account-zero-position"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    controller_a, _execution_a, _journal_a = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+
+    risk_engine = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller_b.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"BTCUSDT_position": 0.0, "USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "ai",
+        "opportunity_shadow_record_key": correlation_key,
+    }
+
+    assert controller_b.process_signals([close_signal]) == []
+    assert risk_engine.last_checks == []
+    assert execution_b.requests == []
+    assert _order_path_events_with_shadow_key(journal_b, correlation_key) == []
+    assert _opportunity_attach_events_referencing_key(journal_b, correlation_key) == []
+    assert any(
+        event.get("event") == "signal_skipped"
+        and event.get("reason") == "restored_tracker_runtime_position_absent_suppressed"
+        and str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        for event in journal_b.export()
+    )
 
 
 def test_autonomous_restored_close_allows_when_account_snapshot_position_quantity_matches_tracker(


### PR DESCRIPTION
### Motivation
- Celem Karty 6D było domknięcie realnego seamu „zero/ambiguous exposure” bez zmian modelu snapshotu ani architektury kontrolera.
- Audyt wykazał, że istniejący test zero-position był wrapperem/aliasem do scenariusza `absent-position` i nie weryfikował literalnego `position == 0`.
- `AccountSnapshot` reprezentuje ekspozycję przez `balances` (np. `BTCUSDT_position`) więc realne `0.0` / ujemne wartości da się wyrazić bez dodawania pól.
- Nie wprowadzono zmian produkcyjnych w `controller.py` ani API snapshotu, jedynie test został zrealizowany na realnej fixture.

### Description
- Zastąpiono aliasowy test `test_autonomous_restored_close_blocks_when_account_snapshot_position_quantity_is_zero` realnym scenariuszem, który buduje shadow record, otwiera pozycję i potem podaje `AccountSnapshot(balances={"BTCUSDT_position": 0.0, ...})` przed próbą restored close.
- Nowy test oczekuje, że restored close zostanie zablokowany (brak `execution.requests`, brak wywołań `risk_engine`) i że w dzienniku pojawi się `signal_skipped` z istniejącym reasonem `restored_tracker_runtime_position_absent_suppressed`.
- Nie zmieniono logiki w `bot_core/runtime/controller.py`, ponieważ istniejąca funkcja `_runtime_position_notional_for_symbol` oraz warunki z `abs(... ) <= 1e-12`, sign-mismatch i porównań z `remaining_quantity` już pokrywa wymagane przypadki.
- Zmiana dotyczy tylko `tests/test_trading_controller.py`; brak zmian w produkcyjnych modułach i brak nowych pól w `AccountSnapshot`.

### Testing
- Uruchomiono target Karta 6D batch z `pytest` dla nowych/kluczowych testów: `python -m pytest -q tests/test_trading_controller.py::test_autonomous_restored_close_blocks_when_account_snapshot_position_quantity_is_zero tests/test_trading_controller.py::test_autonomous_restored_close_blocks_when_runtime_position_sign_mismatch tests/test_trading_controller.py::test_autonomous_open_blocks_when_account_snapshot_contains_same_symbol_exposure_with_nonzero_quantity` — wynik: `3 passed`.
- Przeprowadzono wymagane regresje i selektory; kluczowe wyniki to: `6C regression: 5 passed`, `6B regression: 4 passed`, `6A regression: 5 passed`, `5B: 5 passed`, `5A: 6 passed`, `seam 4B/4C: 8 passed`, small selector: `279 passed, 857 deselected`, repo-layer proof: `3 passed`, full selector: `1118 passed, 18 deselected`.
- Uruchomiono `pre-commit` i sprawdzenia lintera; `ruff`, `ruff format` i `mypy` zakończyły się pomyślnie po przyjęciu autoformatowania, a ostateczne uruchomienie pre-commit przeszło OK.
- Commit zawiera tylko testową modyfikację and został zapisany jako `11e320b9270acffe259599f2722e2d68a04a0121`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe10236e38832a9ac0882789f599ee)