### PR TITLE
Harden restored close account quantity boundaries (tests)

### DIFF
--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -74759,6 +74759,28 @@ def test_autonomous_restored_close_allows_when_runtime_position_matches(
     test_restored_tracker_close_allowed_when_account_snapshot_confirms_remaining_quantity(tmp_path)
 
 
+def test_autonomous_restored_close_blocks_when_account_snapshot_position_less_than_remaining_quantity(
+    tmp_path: Path,
+) -> None:
+    test_restored_tracker_close_blocks_when_account_snapshot_quantity_less_than_tracker_remaining(
+        tmp_path
+    )
+
+
+def test_autonomous_restored_close_allows_when_account_snapshot_position_equals_remaining_quantity(
+    tmp_path: Path,
+) -> None:
+    test_restored_tracker_close_allowed_when_account_snapshot_confirms_remaining_quantity(tmp_path)
+
+
+def test_autonomous_restored_close_behavior_when_account_snapshot_position_exceeds_remaining_quantity(
+    tmp_path: Path,
+) -> None:
+    test_restored_tracker_close_uses_tracker_remaining_when_account_snapshot_quantity_greater(
+        tmp_path
+    )
+
+
 def test_autonomous_stale_local_tracker_without_runtime_position_does_not_force_close_execution(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Domknąć seam Karty 6E: zapewnić, że restored-close jest blokowany gdy snapshot runtime pokazuje mniejszą pozycję niż restored remaining, dozwolony gdy równe, a przy większej pozycji zachować obecny kontrakt bez oversell i bez zmian produkcyjnych.

### Description
- Dodano trzy autonomiczne entrypointy testowe w `tests/test_trading_controller.py` sprawdzające przypadki: snapshot < remaining (blokada), snapshot == remaining (allow), snapshot > remaining (zachowanie istniejącego kontraktu i użycie tracker remaining); brak zmian w kodzie produkcyjnym ani w API.

### Testing
- Uruchomiono i przeszły automatycznie: target 6E (3 tests, all passed), regresje 6D/6C/6B/6A/5B/5A, seam 4B/4C, smoke reason taxonomy, small selector, repo-layer proof, full selector oraz pre-commit (ruff/ruff-format/mypy); repo po commicie czysty.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1c6e0b40832aabea2ee744a904af)