### PR TITLE
Harden restored-close handling for account snapshot position alias ambiguity (6G)

### DIFF
--- a/bot_core/runtime/controller.py
+++ b/bot_core/runtime/controller.py
@@ -1282,6 +1282,36 @@ class TradingController:
             return False
         return not has_valid_candidate
 
+    def _runtime_position_alias_values_for_symbol(
+        self,
+        *,
+        account: AccountSnapshot | None,
+        symbol: str,
+    ) -> list[float]:
+        if account is None:
+            return []
+        balances = getattr(account, "balances", None)
+        if not isinstance(balances, Mapping):
+            return []
+        normalized_symbol = str(symbol or "").strip()
+        if not normalized_symbol:
+            return []
+        lookup_keys = (
+            f"{normalized_symbol}_position",
+            f"{normalized_symbol.replace('/', '')}_position",
+        )
+        values: list[float] = []
+        for key in lookup_keys:
+            if key not in balances:
+                continue
+            try:
+                value = float(balances.get(key))
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(value):
+                values.append(value)
+        return values
+
     @staticmethod
     def _is_autonomous_restored_tracker_contract(
         tracker: _OpportunityOpenOutcomeTracker | None,
@@ -3567,10 +3597,31 @@ class TradingController:
                 account=account_for_runtime_truth,
                 symbol=str(request.symbol),
             )
+            runtime_alias_values = self._runtime_position_alias_values_for_symbol(
+                account=account_for_runtime_truth,
+                symbol=str(request.symbol),
+            )
             if runtime_position_notional is not None:
                 expected_runtime_sign = (
                     1.0 if str(existing_open_tracker.side).upper() in _BUY_SIDES else -1.0
                 )
+                finite_positive = any(value > 1e-12 for value in runtime_alias_values)
+                finite_negative = any(value < -1e-12 for value in runtime_alias_values)
+                if finite_positive and finite_negative:
+                    self._discard_open_outcome_tracker(correlation_key)
+                    existing_open_tracker = None
+                    self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
+                    self._record_decision_event(
+                        "signal_skipped",
+                        signal=signal,
+                        request=request,
+                        status="skipped",
+                        metadata={
+                            "reason": "restored_tracker_runtime_position_sign_mismatch_suppressed",
+                            "proxy_correlation_key": correlation_key,
+                        },
+                    )
+                    return None
                 sign_mismatch = (
                     abs(runtime_position_notional) > 1e-12
                     and runtime_position_notional * expected_runtime_sign < 0.0
@@ -3598,7 +3649,14 @@ class TradingController:
                 if (
                     remaining_quantity is not None
                     and remaining_quantity > 1e-12
-                    and abs(runtime_position_notional) + 1e-12 < remaining_quantity
+                    and (
+                        abs(runtime_position_notional) + 1e-12 < remaining_quantity
+                        or (
+                            len(runtime_alias_values) >= 2
+                            and min(abs(value) for value in runtime_alias_values) + 1e-12
+                            < remaining_quantity
+                        )
+                    )
                 ):
                     self._metric_signals_total.inc(labels={**metric_labels, "status": "skipped"})
                     self._record_decision_event(

--- a/tests/test_trading_controller.py
+++ b/tests/test_trading_controller.py
@@ -75029,6 +75029,339 @@ def test_autonomous_restored_close_blocks_when_account_snapshot_position_numeric
     )
 
 
+@pytest.mark.parametrize(
+    ("slash_value", "compact_value"),
+    [("not-a-number", 1.0), (1.0, "not-a-number")],
+)
+def test_autonomous_restored_close_allows_when_one_position_alias_invalid_but_other_alias_valid(
+    tmp_path: Path, slash_value: object, compact_value: object
+) -> None:
+    decision_timestamp = datetime(2026, 1, 9, 15, 28, tzinfo=timezone.utc)
+    correlation_key = f"last-mile-restored-close-account-one-alias-invalid-{abs(hash(str((slash_value, compact_value)))) % 100000}"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    controller_a, _, _ = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+
+    risk_engine = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller_b.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={
+            "BTC/USDT_position": slash_value,
+            "BTCUSDT_position": compact_value,
+            "USDT": 1000.0,
+        },
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "ai",
+        "opportunity_shadow_record_key": correlation_key,
+    }
+    results = controller_b.process_signals([close_signal])
+    assert len(results) == 1
+    assert len(execution_b.requests) == 1
+    assert risk_engine.last_checks
+    assert not any(
+        event.get("event") in {"signal_skipped", "opportunity_autonomy_enforcement"}
+        and str(event.get("reason") or "").strip()
+        == "restored_tracker_runtime_position_absent_suppressed"
+        and str(event.get("proxy_correlation_key") or "").strip() == correlation_key
+        for event in journal_b.export()
+    )
+
+
+def test_autonomous_restored_close_allows_when_account_snapshot_position_aliases_are_consistent(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 9, 15, 28, tzinfo=timezone.utc)
+    correlation_key = "last-mile-restored-close-account-aliases-consistent"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    controller_a, _, _ = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    controller_b, execution_b, _ = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller_b.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"BTC/USDT_position": 1.0, "BTCUSDT_position": 1.0, "USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "ai",
+        "opportunity_shadow_record_key": correlation_key,
+    }
+    assert [row.status for row in controller_b.process_signals([close_signal])] == ["filled"]
+    assert len(execution_b.requests) == 1
+    assert execution_b.requests[0].quantity == pytest.approx(1.0, rel=1e-6)
+
+
+def test_autonomous_restored_close_blocks_when_position_aliases_have_opposite_signs(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 9, 15, 29, tzinfo=timezone.utc)
+    correlation_key = "last-mile-restored-close-account-aliases-sign-conflict"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    controller_a, _, _ = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    risk_engine = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller_b.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"BTC/USDT_position": 1.0, "BTCUSDT_position": -1.0, "USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "ai",
+        "opportunity_shadow_record_key": correlation_key,
+    }
+    assert controller_b.process_signals([close_signal]) == []
+    assert execution_b.requests == []
+    assert risk_engine.last_checks == []
+    assert _order_path_events_with_shadow_key(journal_b, correlation_key) == []
+    assert _opportunity_attach_events_referencing_key(journal_b, correlation_key) == []
+    assert any(
+        event.get("reason") == "restored_tracker_runtime_position_sign_mismatch_suppressed"
+        for event in journal_b.export()
+    )
+
+
+def test_autonomous_restored_close_blocks_when_position_aliases_disagree_around_remaining_quantity(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 9, 15, 30, tzinfo=timezone.utc)
+    correlation_key = "last-mile-restored-close-account-aliases-quantity-conflict"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    controller_a, _e, _j = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+                {"status": "partially_filled", "filled_quantity": 0.0, "avg_price": 101.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    risk_engine = DummyRiskEngine()
+    controller_b, execution_b, journal_b = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=risk_engine,
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 101.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller_b.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"BTC/USDT_position": 0.5, "BTCUSDT_position": 1.0, "USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "ai",
+        "opportunity_shadow_record_key": correlation_key,
+    }
+    assert controller_b.process_signals([close_signal]) == []
+    assert execution_b.requests == []
+    assert risk_engine.last_checks == []
+    assert _order_path_events_with_shadow_key(journal_b, correlation_key) == []
+    assert _opportunity_attach_events_referencing_key(journal_b, correlation_key) == []
+    assert any(
+        event.get("reason") == "restored_tracker_account_quantity_mismatch_suppressed"
+        for event in journal_b.export()
+    )
+
+
+def test_autonomous_restored_close_allows_when_position_aliases_both_cover_remaining_quantity(
+    tmp_path: Path,
+) -> None:
+    decision_timestamp = datetime(2026, 1, 9, 15, 31, tzinfo=timezone.utc)
+    correlation_key = "last-mile-restored-close-account-aliases-cover-remaining"
+    repository = OpportunityShadowRepository(tmp_path / "shadow.db")
+    repository.append_shadow_records(
+        [
+            _shadow_record_for_key(
+                correlation_key=correlation_key, decision_timestamp=decision_timestamp
+            )
+        ]
+    )
+    controller_a, _ea, _ja = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [
+                {"status": "filled", "filled_quantity": 1.0, "avg_price": 100.0},
+                {"status": "partially_filled", "filled_quantity": 0.0, "avg_price": 101.0},
+            ]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    open_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="BUY",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp,
+    )
+    open_signal.metadata = {**dict(open_signal.metadata), "mode": "ai"}
+    assert [row.status for row in controller_a.process_signals([open_signal])] == ["filled"]
+    controller_b, execution_b, _jb = _build_autonomy_controller_with_risk(
+        environment="paper",
+        risk_engine=DummyRiskEngine(),
+        execution_service=SequencedExecutionService(
+            [{"status": "filled", "filled_quantity": 1.0, "avg_price": 102.0}]
+        ),
+        opportunity_shadow_repository=repository,
+    )
+    controller_b.account_snapshot_provider = lambda: AccountSnapshot(
+        balances={"BTC/USDT_position": 1.0, "BTCUSDT_position": 2.0, "USDT": 1000.0},
+        available_margin=1000.0,
+        total_equity=1000.0,
+        maintenance_margin=0.0,
+    )
+    close_signal = _autonomy_signal_with_correlation(
+        mode="paper_autonomous",
+        side="SELL",
+        correlation_key=correlation_key,
+        decision_timestamp=decision_timestamp + timedelta(minutes=1),
+    )
+    close_signal.metadata = {
+        **dict(close_signal.metadata),
+        "mode": "ai",
+        "opportunity_shadow_record_key": correlation_key,
+    }
+    assert [row.status for row in controller_b.process_signals([close_signal])] == ["filled"]
+    assert len(execution_b.requests) == 1
+    assert execution_b.requests[0].quantity == pytest.approx(1.0, rel=1e-6)
+
+
 def test_autonomous_restored_close_allows_when_account_snapshot_position_is_numeric_string_if_supported(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Zamknięcie Karty 6G: rozwiązać ambiwalencję dwóch kluczy pozycji w `AccountSnapshot.balances` (z aliasami `f"{symbol}_position"` i `f"{symbol.replace('/', '')}_position"`) przy restored-close bez cofania 6F. 
- Celem jest zachowanie istniejącej polityki fallback (invalid+valid => valid) i jednoczesne fail‑close, gdy aliasy dostarczają sprzeczne informacje znaczeniowe (przeczny sign lub sprzeczność względem remaining). 

### Description
- Dodano prywatny helper `_runtime_position_alias_values_for_symbol(...)` w `bot_core/runtime/controller.py`, który zbiera finite wartości dla obu aliasów. 
- W logice restored-close rozszerzono walidację runtime: jeśli aliasy mają jednocześnie finite dodatnie i ujemne wartości — zgłaszamy istniejący reason `restored_tracker_runtime_position_sign_mismatch_suppressed` i fail-close. 
- Jeśli istnieją co najmniej 2 finite aliasy i ich minimalna wartość (abs) nie pokrywa `remaining_quantity` — zgłaszamy `restored_tracker_account_quantity_mismatch_suppressed` i fail-close; jednocześnie zachowano dotychczasowy fallback invalid+valid. 
- Dodano zestaw testów 6G w `tests/test_trading_controller.py` (nazwy zgodne z wymaganiem): `test_autonomous_restored_close_allows_when_account_snapshot_position_aliases_are_consistent`, `test_autonomous_restored_close_allows_when_one_position_alias_invalid_but_other_alias_valid` (parametryzowany), `test_autonomous_restored_close_blocks_when_position_aliases_have_opposite_signs`, `test_autonomous_restored_close_blocks_when_position_aliases_disagree_around_remaining_quantity`, i `test_autonomous_restored_close_allows_when_position_aliases_both_cover_remaining_quantity` bez zmian publicznych API ani nowych pól snapshotu. 

### Testing
- Uruchomiono target 6G: `python -m pytest -q tests/test_trading_controller.py::test_autonomous_restored_close_allows_when_account_snapshot_position_aliases_are_consistent tests/test_trading_controller.py::test_autonomous_restored_close_allows_when_one_position_alias_invalid_but_other_alias_valid tests/test_trading_controller.py::test_autonomous_restored_close_blocks_when_position_aliases_have_opposite_signs tests/test_trading_controller.py::test_autonomous_restored_close_blocks_when_position_aliases_disagree_around_remaining_quantity tests/test_trading_controller.py::test_autonomous_restored_close_allows_when_position_aliases_both_cover_remaining_quantity -vv` — wszystkie testy targetu przeszły (PASS). 
- Uruchomiono regresje 6F/6E/6D i szerokie selektory związane z restored/close oraz repository‑layer proof: `pytest` na wskazanych selektorach (m.in. close‑selector, full autonomy selector i trzy testy w `tests/ai/test_trading_opportunity_engine.py`) — wszystkie uruchomione zestawy przeszły (PASS). 
- Uruchomiono `pre-commit` i ruff format, które dokonały jednego autoformatowania; po rerunie pre-commit zakończył się pomyślnie (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6f4e295c832a8d177bd920e91144)